### PR TITLE
chore(deps): batch dependabot updates, weekly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,23 @@
 version: 2
 updates:
-- package-ecosystem: "pip"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      pip-patch-and-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Pip and GitHub Actions ecosystems now run **weekly** instead of daily.
- Pip: all `patch` and `minor` bumps batch into a single grouped PR. Majors stay individual so they get explicit review.
- GitHub Actions: all action bumps batch into a single grouped PR.

Context: closed 6 stale dependabot PRs (#3, #7, #9, #10, #13, #14) — they all targeted files/deps that had been removed from `main`. This config change keeps future dependabot output low-noise so it's easier to triage on a regular cadence without per-bump PR sprawl.

## Test plan
- [ ] After merge, confirm dependabot's next run produces grouped PRs (one per ecosystem) rather than per-bump PRs.
- [ ] Confirm the weekly schedule is reflected in the dependabot dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)