### PR TITLE
Print a per-run score summary at the end of a run

### DIFF
--- a/src/tutorsim/cli.py
+++ b/src/tutorsim/cli.py
@@ -693,6 +693,12 @@ def run_cell(
             os.path.join(results_root, run_id),
         )
 
+        # Echo the per-run score summary to stdout. The metrics are already in
+        # summary.json; this surfaces them without a separate `report` step
+        # (which stays the cross-run leaderboard). Printed, not logged, so it
+        # shows regardless of --log-level.
+        print(report.format_run_summary(metrics, tutor_model=tutor, mode=mode, run_id=run_id))
+
         return run_id
 
 

--- a/src/tutorsim/report.py
+++ b/src/tutorsim/report.py
@@ -294,6 +294,83 @@ def leaderboard(runs: list) -> tuple:
     return markdown, csv_str
 
 
+def format_run_summary(
+    metrics: dict,
+    *,
+    tutor_model: str = "",
+    mode: str = "",
+    run_id: str = "",
+) -> str:
+    """Render a compact, human-readable summary of a single run's metrics.
+
+    Accepts either a single-trial aggregate dict (as written to summary.json
+    when trials==1) or the trials>1 {trials, mean, spread} shape. Uses the same
+    reader-facing metric derivations as the leaderboard (appropriate
+    scaffolding/rigor, avoids-over-scaffolding = 1 - rate), so the end-of-run
+    terminal summary matches what `report` later tabulates. For trials>1 each
+    score is shown as ``mean ± std``.
+    """
+    trials = metrics.get("trials", 1)
+    core = metrics.get("mean", metrics)      # trials>1 nests the aggregate under "mean"
+    spread = metrics.get("spread") or {}
+
+    row = _extract_row({
+        **core,
+        "latency": metrics.get("latency"),
+        "tokens": metrics.get("tokens"),
+        "tutor_model": tutor_model,
+        "mode": mode,
+    })
+
+    def _sub(spread_dict, subkey, field):
+        sub = spread_dict.get(subkey) if isinstance(spread_dict, dict) else None
+        return sub.get(field) if isinstance(sub, dict) else None
+
+    def _fmt_metric(value, std):
+        if value is None:
+            return "-"
+        text = f"{value:.3f}"
+        if trials > 1 and isinstance(std, (int, float)):
+            text += f" ± {std:.3f}"
+        return text
+
+    n = row.get("n") or 0
+    if isinstance(n, float) and n.is_integer():
+        n = int(n)
+    counts = metrics.get("run_counts") or {}
+
+    lines = ["Run summary" + (f": {run_id}" if run_id else "")]
+    ident = f"  tutor={tutor_model or '-'}  mode={mode or '-'}  moments={n}"
+    if trials > 1:
+        ident += f"  trials={trials}"
+    lines.append(ident)
+    lines.append("  " + "-" * 44)
+
+    metric_rows = [
+        ("Appropriate Scaffolding", row.get("appropriate_scaffolding"), _sub(spread, "scaffold_calibrated", "score")),
+        ("Appropriate Rigor",       row.get("appropriate_rigor"),       _sub(spread, "rigor_calibrated", "score")),
+        ("Avoids Over-Scaffolding", row.get("avoids_overscaffold"),     _sub(spread, "overscaffold", "rate")),
+    ]
+    for label, value, std in metric_rows:
+        lines.append(f"  {label:<26} {_fmt_metric(value, std)}")
+
+    if counts:
+        lines.append(
+            f"  {'Moments succeeded':<26} "
+            f"{counts.get('succeeded', 0)}/{counts.get('attempted', 0)} "
+            f"(failed {counts.get('failed', 0)}, resumed {counts.get('resumed', 0)})"
+        )
+    if row.get("tutor_lat_p50") is not None or row.get("tutor_lat_p95") is not None:
+        lines.append(
+            f"  {'Tutor latency p50/p95 (s)':<26} "
+            f"{_fmt_md(row.get('tutor_lat_p50'))} / {_fmt_md(row.get('tutor_lat_p95'))}"
+        )
+    if row.get("tokens_total") is not None:
+        lines.append(f"  {'Total tokens':<26} {_fmt_md(row.get('tokens_total'))}")
+
+    return "\n".join(lines)
+
+
 # ---------------------------------------------------------------------------
 # HTML viewer
 # ---------------------------------------------------------------------------

--- a/tests/tutorsim/test_report.py
+++ b/tests/tutorsim/test_report.py
@@ -434,3 +434,66 @@ def test_leaderboard_latency_and_tokens_non_dash():
     # None values -> '-' in markdown
     assert "| - |" in none_lines[0] or none_lines[0].count("| - ") >= 2, \
         f"Expected '-' for None lat/tokens in: {none_lines[0]}"
+
+
+# ---------------------------------------------------------------------------
+# format_run_summary() -- the end-of-run terminal summary
+# ---------------------------------------------------------------------------
+
+from tutorsim.report import format_run_summary
+
+
+def test_format_run_summary_single_trial():
+    """Single-trial metrics render the paper's three reader metrics + counts."""
+    metrics = dict(SUMMARY_A)
+    metrics["run_counts"] = {"attempted": 100, "succeeded": 98, "failed": 2, "resumed": 1}
+    out = format_run_summary(metrics, tutor_model="model-alpha", mode="scaffolding_rigor",
+                             run_id="model-alpha_scaffolding_rigor_x")
+
+    assert "Run summary: model-alpha_scaffolding_rigor_x" in out
+    assert "tutor=model-alpha" in out and "mode=scaffolding_rigor" in out
+    assert "moments=100" in out
+    # Reader-facing metrics, 3dp, same derivation as the leaderboard.
+    assert "Appropriate Scaffolding    0.750" in out
+    assert "Appropriate Rigor          0.600" in out
+    assert "Avoids Over-Scaffolding    0.900" in out   # 1 - 0.10
+    assert "98/100" in out and "failed 2" in out and "resumed 1" in out
+    assert "500000" in out
+    # No spread markers for a single trial.
+    assert "±" not in out
+    assert "trials=" not in out
+
+
+def test_format_run_summary_trials_shows_mean_and_spread():
+    """trials>1 uses the mean/spread shape and renders mean ± std."""
+    metrics = {
+        "trials": 3,
+        "mean": {
+            "n_scenarios": 100,
+            "scaffold_calibrated": {"score": 0.75, "n_clean_yes": 0, "n_total": 100, "n_overscaffold": 0},
+            "rigor_calibrated":    {"score": 0.60, "n_clean_yes": 0, "n_total": 100},
+            "overscaffold":        {"rate": 0.10, "n_yes": 0, "n_total": 100, "available": True},
+        },
+        "spread": {
+            "scaffold_calibrated": {"score": 0.02},
+            "rigor_calibrated":    {"score": 0.03},
+            "overscaffold":        {"rate": 0.01},
+        },
+        "latency": {"tutor": {"p50_seconds": 1.2, "p95_seconds": 3.4}},
+        "tokens":  {"total": {"total_tokens": 500000}},
+        "run_counts": {"attempted": 300, "succeeded": 300, "failed": 0, "resumed": 0},
+    }
+    out = format_run_summary(metrics, tutor_model="model-alpha", mode="scaffolding_rigor")
+
+    assert "trials=3" in out
+    assert "0.750 ± 0.020" in out
+    assert "0.600 ± 0.030" in out
+    assert "0.900 ± 0.010" in out   # avoids = 1 - mean rate; std carries through
+
+
+def test_format_run_summary_none_metrics_render_dash():
+    """None scores/latency/tokens render as '-' rather than crashing."""
+    out = format_run_summary(SUMMARY_NONE, tutor_model="model-gamma", mode="scaffolding_only")
+    assert "Appropriate Scaffolding    -" in out
+    assert "Appropriate Rigor          -" in out
+    assert "Avoids Over-Scaffolding    -" in out


### PR DESCRIPTION
## What

`tutorsim run` now prints a compact score summary to stdout when a run finishes:

```
Run summary: <run_id>
  tutor=claude-sonnet-5  mode=plain  moments=122
  --------------------------------------------
  Appropriate Scaffolding    0.672
  Appropriate Rigor          0.541
  Avoids Over-Scaffolding    0.885
  Moments succeeded          122/122 (failed 0, resumed 0)
  Tutor latency p50/p95 (s)  2.110 / 6.830
  Total tokens               418923
```

## Why

The metrics were already computed and written to `summary.json`, but a run only logged succeed/fail *counts* — so a single run surfaced no scores at the terminal, and you had to run `report` (the cross-run leaderboard) to see anything.

That split is out of step with peer eval frameworks: [lm-evaluation-harness](https://lm-evaluation-harness.readthedocs.io/getting_started/quickstart/) and [inspect-ai](https://inspect.aisi.org.uk/log-viewer.html) both print a per-run summary inline, and only cross-run aggregation is a separate step (as in [HELM's `helm-summarize`](https://crfm-helm.readthedocs.io/en/latest/tutorial/)). We already had the separate-aggregation part right (`report`); we were an outlier only in not printing the per-run summary.

## How

- `report.format_run_summary(metrics, *, tutor_model, mode, run_id)` — a pure, testable renderer that reuses the leaderboard's reader-facing derivations (`_extract_row` / `_fmt_md`), so the terminal numbers match exactly what `report` later tabulates. Handles both the single-trial and trials>1 (`mean ± std`) summary shapes, and renders `-` for `None` fields.
- `run_cell` `print()`s it (not via the logger, so it shows regardless of `--log-level`) right after `summary.json` is written. No existing output changes — this only adds the block.
- `report` is unchanged and remains the cross-run leaderboard.

## Tests

`pytest tests/tutorsim -q` → 317 passed, 12 skipped. Adds three `format_run_summary` tests: single-trial rendering, trials>1 mean±std, and None-safe fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)