### PR TITLE
Fix batch-path benchmark fidelity: forward thinking/effort to run_batch; correct Haiku 4.5 thinking shape and vision gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "anthropic",
+    # >=0.72 exposes output_config as a top-level message param; the batch path
+    # (client._run_batch_anthropic) sets params["output_config"] directly, so an
+    # older SDK would strip effort and silently diverge from the sync path.
+    "anthropic>=0.72",
     "openai",
     "google-genai",
     "pyyaml",

--- a/src/tutorsim/client.py
+++ b/src/tutorsim/client.py
@@ -31,7 +31,7 @@ PROVIDER_PREFIXES = [
 
 
 VISION_CAPABLE_PREFIXES = (
-    "claude-opus-4", "claude-sonnet-4",
+    "claude-opus-4", "claude-sonnet-4", "claude-sonnet-5", "claude-fable-5",
     "gemini-2", "gemini-3",
     "gpt-4o", "gpt-4.1", "gpt-5", "o4",
 )
@@ -83,14 +83,17 @@ TOGETHER_BASE_URL = "https://api.together.xyz/v1"
 
 
 # Adaptive thinking ({"type": "adaptive"}) is the modern default and the shape
-# every current Anthropic model uses. The legacy enabled+budget_tokens shape is
-# needed only by a *closed, frozen set* of pre-adaptive models -- no new model
-# is ever added here. So we default to adaptive and enumerate only the legacy
-# models; a brand-new Anthropic model works with no code change (see README
-# "Running new tutor models"). Adaptive is rejected on nothing current; legacy
-# enabled+budget is rejected on Opus 4.7+/Sonnet 5/Fable 5.
+# every current Opus/Sonnet-tier Anthropic model uses. The legacy
+# enabled+budget_tokens shape is needed only by a *closed, frozen set* of
+# pre-adaptive models -- no new model is ever added here. So we default to
+# adaptive and enumerate only the legacy models; a brand-new Anthropic model
+# works with no code change (see README "Running new tutor models"). Legacy
+# enabled+budget is rejected on Opus 4.7+/Sonnet 5/Fable 5. Haiku 4.5 is the
+# one current model still on the legacy shape (extended thinking only, no
+# adaptive support per the Anthropic models overview).
 _ANTHROPIC_LEGACY_THINKING_MODELS = (
     "claude-3-7-sonnet",
+    "claude-haiku-4-5",
     "claude-opus-4-0", "claude-opus-4-20250514",
     "claude-opus-4-1",
     "claude-opus-4-5",
@@ -750,6 +753,7 @@ def run_batch(client: 'ModelClient', entries: list[dict],
               poll_interval: int = 60,
               thinking: bool = False, thinking_budget: int = 0,
               reasoning_effort: str = "",
+              effort: str = "",
               enable_cache: bool = False,
               existing_batch_id: str | None = None,
               on_batch_created=None) -> dict:
@@ -783,6 +787,7 @@ def run_batch(client: 'ModelClient', entries: list[dict],
     elif provider == "anthropic":
         return _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval,
                                     thinking, thinking_budget, reasoning_effort,
+                                    effort=effort,
                                     enable_cache=enable_cache,
                                     existing_batch_id=existing_batch_id,
                                     on_batch_created=on_batch_created)
@@ -1072,6 +1077,7 @@ def _run_batch_openai(client, entries, json_mode, display_name, poll_interval,
 
 def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval,
                          thinking=False, thinking_budget=0, reasoning_effort="",
+                         effort="",
                          enable_cache=False,
                          existing_batch_id=None, on_batch_created=None):
     """Anthropic batch: create message batch, poll, stream results.
@@ -1152,6 +1158,10 @@ def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval
                 )
             if thinking_param is not None:
                 params["thinking"] = thinking_param
+            # effort goes inside output_config, mirroring the sync path
+            # (_generate_anthropic). Haiku 4.5 rejects effort -- skip there.
+            if effort and client.model and not client.model.startswith("claude-haiku-4-5"):
+                params["output_config"] = {"effort": effort}
 
             requests.append(Request(
                 custom_id=f"r{i}",

--- a/src/tutorsim/conversation.py
+++ b/src/tutorsim/conversation.py
@@ -383,6 +383,22 @@ def run_conversation(
     return transcript
 
 
+def _batch_gen_kwargs(roster_kwargs: dict) -> dict:
+    """Map roster generation kwargs to the subset run_batch understands.
+
+    run_conversation forwards the full roster kwargs to client.generate();
+    run_batch exposes the same generation knobs as explicit parameters, so
+    pick them out here. Keeping the mapping explicit (rather than **splat)
+    means an unknown roster key fails loudly in sync mode first.
+    """
+    return {
+        "thinking": roster_kwargs.get("thinking", False),
+        "thinking_budget": roster_kwargs.get("thinking_budget", 0),
+        "reasoning_effort": roster_kwargs.get("reasoning_effort", ""),
+        "effort": roster_kwargs.get("effort", ""),
+    }
+
+
 def run_conversations_batch(
     scenarios: list[Moment],
     *,
@@ -450,6 +466,13 @@ def run_conversations_batch(
         )
     student_client = student_res["client"]
 
+    # Generation kwargs from the model roster (thinking/effort/etc.) must be
+    # forwarded to run_batch, mirroring run_conversation's **kwargs merge --
+    # otherwise batch runs silently diverge from sync benchmark runs (e.g.
+    # tutors losing thinking/effort).
+    tutor_gen_kwargs = _batch_gen_kwargs(tutor_res["kwargs"])
+    student_gen_kwargs = _batch_gen_kwargs(student_res["kwargs"])
+
     # Per-scenario state
     transcript_map: dict[str, Transcript] = {}
     transcript_prefix_map: dict[str, str] = {}
@@ -516,6 +539,7 @@ def run_conversations_batch(
             tutor_client, tutor_entries, json_mode=False,
             display_name=f"tutor_round_{round_num + 1}",
             poll_interval=poll_interval,
+            **tutor_gen_kwargs,
         )
 
         failed = []
@@ -595,6 +619,7 @@ def run_conversations_batch(
             student_client, student_entries, json_mode=False,
             display_name=f"student_round_{round_num + 1}",
             poll_interval=poll_interval,
+            **student_gen_kwargs,
         )
 
         failed = []

--- a/tests/tutorsim/test_client.py
+++ b/tests/tutorsim/test_client.py
@@ -30,8 +30,19 @@ def test_infer_provider_unknown_raises():
 
 class TestAnthropicThinkingParam:
     def test_adaptive_models_get_adaptive_shape(self):
-        for m in ("claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-haiku-4-5", "claude-sonnet-4-6", "claude-sonnet-5", "claude-fable-5"):
+        for m in ("claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-sonnet-5", "claude-fable-5"):
             assert _anthropic_thinking_param(m, 0) == {"type": "adaptive"}
+
+    def test_haiku_4_5_gets_legacy_enabled_shape(self):
+        # Haiku 4.5 is the one current model without adaptive-thinking support
+        # (extended thinking only, per the Anthropic models overview) --
+        # sending {"type": "adaptive"} there would 400.
+        assert _anthropic_thinking_param("claude-haiku-4-5", 4096) == {
+            "type": "enabled", "budget_tokens": 4096,
+        }
+        assert _anthropic_thinking_param("claude-haiku-4-5-20251001", 0) == {
+            "type": "enabled", "budget_tokens": 16384,
+        }
 
     def test_unknown_or_future_model_defaults_to_adaptive(self):
         # A brand-new Anthropic model must work with no code change (README
@@ -223,6 +234,11 @@ from tutorsim.client import (
 
 
 class TestVisionSupport:
+    def test_vision_capable_prefixes_covers_current_anthropic_tutors(self):
+        # Every Anthropic model in the tutor roster must pass the vision gate.
+        validate_vision_support("claude-sonnet-5")
+        validate_vision_support("claude-fable-5")
+
     def test_vision_capable_prefixes_contains_known_models(self):
         # Spot-check a few entries from the source list.
         assert "claude-opus-4" in VISION_CAPABLE_PREFIXES
@@ -438,6 +454,30 @@ def test_run_batch_anthropic_remaps_custom_ids(monkeypatch):
         )
     assert out["kA"]["text"] == "A"
     assert out["kB"]["text"] == "B"
+
+
+def test_run_batch_anthropic_sends_thinking_and_effort(monkeypatch):
+    """Batch requests must carry the same thinking/effort params as sync calls
+    (benchmark fidelity: batch mode may not silently diverge from run_conversation)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    with patch("anthropic.Anthropic") as MockAnthropic, \
+         patch("tutorsim.client.time.sleep"):
+        client_obj = MagicMock()
+        batch = MagicMock()
+        batch.id = "b1"
+        batch.processing_status = "ended"
+        client_obj.messages.batches.create.return_value = batch
+        client_obj.messages.batches.retrieve.return_value = batch
+        client_obj.messages.batches.results.return_value = []
+        MockAnthropic.return_value = client_obj
+        c = ModelClient("claude-opus-4-8")
+        run_batch(
+            c, [build_batch_entry("kA", "pA")],
+            poll_interval=0, thinking=True, effort="xhigh",
+        )
+        (submitted,) = client_obj.messages.batches.create.call_args.kwargs["requests"]
+    assert submitted["params"]["thinking"] == {"type": "adaptive"}
+    assert submitted["params"]["output_config"] == {"effort": "xhigh"}
 
 
 def test_run_batch_anthropic_resume_rebuilds_id_map(monkeypatch):

--- a/tests/tutorsim/test_conversation.py
+++ b/tests/tutorsim/test_conversation.py
@@ -688,11 +688,14 @@ def _make_scenario_id(sid: str, cut_turn: int = 5) -> "Scenario":
     )
 
 
-def _patch_batch(monkeypatch, tutor_batch_results: list[dict], student_batch_results: list[dict]):
+def _patch_batch(monkeypatch, tutor_batch_results: list[dict], student_batch_results: list[dict],
+                 tutor_kwargs: dict | None = None, student_kwargs: dict | None = None):
     """Patch resolve_tutor, resolve_student, system prompts, trait, and tutorsim.client.run_batch.
 
     tutor_batch_results: list of {sid: {"text": ...}} dicts, one per round.
     student_batch_results: list of {sid: {"text": ...}} dicts, one per round.
+    tutor_kwargs/student_kwargs: roster generation kwargs returned by the
+    patched resolve_* (defaults to {}).
 
     run_batch is called alternately: tutor round 1, student round 1, tutor round 2, ...
     We interleave them in the call sequence.
@@ -704,11 +707,11 @@ def _patch_batch(monkeypatch, tutor_batch_results: list[dict], student_batch_res
 
     monkeypatch.setattr(
         "tutorsim.conversation.resolve_tutor",
-        lambda id: {"kind": "hosted", "client": tutor_client, "kwargs": {}},
+        lambda id: {"kind": "hosted", "client": tutor_client, "kwargs": tutor_kwargs or {}},
     )
     monkeypatch.setattr(
         "tutorsim.conversation.resolve_student",
-        lambda id=None: {"kind": "hosted", "client": student_client, "kwargs": {}},
+        lambda id=None: {"kind": "hosted", "client": student_client, "kwargs": student_kwargs or {}},
     )
     monkeypatch.setattr(
         "tutorsim.conversation.build_tutor_system_prompt",
@@ -771,6 +774,32 @@ def test_batch_two_scenarios_returns_two_transcripts(monkeypatch):
     assert results[0].scenario_id == "sid-1"
     assert results[1].scenario_id == "sid-2"
     assert all(r.completed for r in results)
+
+
+def test_batch_forwards_roster_thinking_and_effort_to_run_batch(monkeypatch):
+    """Benchmark fidelity: batch mode must forward the roster's generation
+    kwargs (thinking/effort/...) to run_batch, exactly as run_conversation
+    merges them into client.generate(). Regression test for the bug where
+    batch tutors silently ran without thinking/effort."""
+    from tutorsim.conversation import run_conversations_batch
+
+    s1 = _make_scenario_id("sid-1", cut_turn=3)
+    tutor_round1 = {"sid-1": {"text": "Hello from tutor"}}
+    student_round1 = {"sid-1": {"text": "Student reply"}}
+
+    run_batch_mock = _patch_batch(
+        monkeypatch, [tutor_round1], [student_round1],
+        tutor_kwargs={"thinking": True, "effort": "xhigh"},
+        student_kwargs={"thinking": False},
+    )
+
+    run_conversations_batch([s1], tutor_id="fake-tutor", max_turns=2, poll_interval=0)
+
+    tutor_call, student_call = run_batch_mock.call_args_list
+    assert tutor_call.kwargs["thinking"] is True
+    assert tutor_call.kwargs["effort"] == "xhigh"
+    assert student_call.kwargs["thinking"] is False
+    assert student_call.kwargs["effort"] == ""
 
 
 def test_batch_ended_via_tracked_per_scenario(monkeypatch):


### PR DESCRIPTION
## What happened

While reviewing #24 (Sonnet 5 tutor) we audited how `thinking`/`effort` flow from the model roster into actual API calls, and found three pre-existing problems plus one omission from #24. This PR fixes all of them.

**Benchmark impact: none.** The real leaderboard runs go through the sync path (`run_cell` → `conversation.run_conversation`), which merges the roster kwargs into every tutor call (`**{**kwargs, **(tutor_kwargs or {})}`) — so all published runs had adaptive thinking + their configured `effort` correctly applied. Scoring goes through the batch API but passes `thinking=` explicitly (`scoring.py`), so the scorer was also correct. The bugs below live in code paths with **zero production callers today**; this PR fixes them before anyone steps on them.

## What was wrong

1. **`run_conversations_batch` silently dropped the roster's `thinking`/`effort` kwargs.** It called `run_batch(...)` with none of the generation kwargs, so a batch-mode conversation run would have executed every tutor without thinking or effort — silently diverging from sync benchmark behavior. Worse, the divergence would have been *asymmetric*: Sonnet 5 thinks by default when the `thinking` param is omitted, while Opus 4.8 / Sonnet 4.6 do not, so a batch leaderboard run would have compared a thinking Sonnet 5 against non-thinking competitors.
   **Fix:** `run_conversations_batch` now maps the roster kwargs through a new `_batch_gen_kwargs()` helper into both `run_batch` calls, and `run_batch`/`_run_batch_anthropic` gained an `effort` parameter that lands in `output_config` exactly like the sync path (with the same Haiku 4.5 skip).

2. **Haiku 4.5 was classified as an adaptive-thinking model.** Per the [Anthropic models overview](https://platform.claude.com/docs/en/about-claude/models/overview), Haiku 4.5 supports extended thinking (`enabled` + `budget_tokens`) but **not** adaptive — sending `{"type": "adaptive"}` there 400s. This predates #24 (the old allowlist had the same entry), and nothing in production uses Haiku, but the "frozen legacy set" from #24 is the right place to record it correctly.
   **Fix:** `claude-haiku-4-5` moved into `_ANTHROPIC_LEGACY_THINKING_MODELS`; comment corrected; tests updated.

3. **`VISION_CAPABLE_PREFIXES` didn't match `claude-sonnet-5` (or `claude-fable-5`).** #24 added Sonnet 5 to the roster without updating the vision gate. `validate_vision_support` isn't called inside this repo's pipeline, but external callers using it would wrongly reject Sonnet 5 on image scenarios even though it supports vision.
   **Fix:** both prefixes added.

## What happened in the benchmark runs (verification summary)

- Tutor conversations: sync path → roster `thinking`/`effort` applied on every turn ✅ (unchanged before/after #24 for all roster models)
- Student: `thinking: false` intentionally, applied ✅
- Scorer: batch path with `thinking=use_thinking` passed explicitly ✅ (scorer sets no `effort`, so the missing batch `effort` plumbing never mattered)
- `run_conversations_batch`: no production callers — the bug was latent, no run was affected ✅

## Tests

- New: `test_run_batch_anthropic_sends_thinking_and_effort` — asserts submitted batch requests carry `thinking={"type": "adaptive"}` and `output_config={"effort": "xhigh"}`.
- New: `test_batch_forwards_roster_thinking_and_effort_to_run_batch` — asserts `run_conversations_batch` forwards tutor/student roster kwargs to `run_batch`.
- New: `test_haiku_4_5_gets_legacy_enabled_shape`; Haiku removed from the adaptive-shape test.
- New: vision-gate coverage for `claude-sonnet-5` / `claude-fable-5`.
- `pytest tests/tutorsim -q`: 317 passed, 12 skipped, 1 failed — the failure is `test_load_moments_data_path_reads_in_file_order`, a pre-existing Windows path-separator issue that fails identically on clean main (verified via `git stash`); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
