### PR TITLE
Add GitHub Actions CI (ruff lint + tests)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # GitHub Actions: bundle all bumps into a single PR (both routine version
+  # updates and security fixes), since action bumps are low-risk.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns: ["*"]
+      github-actions-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  # Python dependencies: group minor/patch bumps into one PR. MAJOR version
+  # bumps are intentionally left ungrouped so each lands as its own PR and gets
+  # isolated review -- a major SDK bump (e.g. anthropic) can change model/batch
+  # behavior, which per AGENTS.md must not change without deliberate review.
+  # Security fixes are grouped separately so CVE patches arrive as one batch.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      python-security:
+        applies-to: security-updates
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -26,8 +26,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. force-pushes to a PR branch).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      # Full suite: runtime + build + analysis. No API keys — the suite runs
+      # without real API calls, so this is safe for pull requests from forks.
+      - run: pip install -e ".[dev,build-dev,analysis]"
+      - run: pytest tests -q

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv
 __pycache__/
 *.pyc
 .pytest_cache/
+.ruff_cache/
 .DS_Store
 *.egg-info/
 

--- a/analysis/split_ground_truth.py
+++ b/analysis/split_ground_truth.py
@@ -20,6 +20,7 @@ Usage:
     python analysis/split_ground_truth.py --ground-truth-dir data/ground_truth_hybrid
     python analysis/split_ground_truth.py --output analysis/my_split.json
 """
+
 import argparse
 import json
 import random
@@ -39,16 +40,32 @@ DEFAULT_SEED = 42
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ground-truth-dir", default=str(DEFAULT_GT_DIR),
-                        help=f"Ground truth directory (default: {DEFAULT_GT_DIR})")
-    parser.add_argument("--original-split", default=str(DEFAULT_ORIG_SPLIT),
-                        help=f"Original train/test split JSON (default: {DEFAULT_ORIG_SPLIT})")
-    parser.add_argument("--transcripts", default=str(DEFAULT_TRANSCRIPTS),
-                        help=f"Transcripts JSONL file (default: {DEFAULT_TRANSCRIPTS})")
-    parser.add_argument("--seed", type=int, default=DEFAULT_SEED,
-                        help=f"Random seed for shuffling new IDs (default: {DEFAULT_SEED})")
-    parser.add_argument("--output", default=str(DEFAULT_OUTPUT),
-                        help=f"Output JSON file (default: {DEFAULT_OUTPUT})")
+    parser.add_argument(
+        "--ground-truth-dir",
+        default=str(DEFAULT_GT_DIR),
+        help=f"Ground truth directory (default: {DEFAULT_GT_DIR})",
+    )
+    parser.add_argument(
+        "--original-split",
+        default=str(DEFAULT_ORIG_SPLIT),
+        help=f"Original train/test split JSON (default: {DEFAULT_ORIG_SPLIT})",
+    )
+    parser.add_argument(
+        "--transcripts",
+        default=str(DEFAULT_TRANSCRIPTS),
+        help=f"Transcripts JSONL file (default: {DEFAULT_TRANSCRIPTS})",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help=f"Random seed for shuffling new IDs (default: {DEFAULT_SEED})",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help=f"Output JSON file (default: {DEFAULT_OUTPUT})",
+    )
     args = parser.parse_args()
 
     gt_dir = Path(args.ground_truth_dir)
@@ -84,7 +101,9 @@ def main():
     # Exclude original IDs that have no ground truth file
     orig_no_gt = orig_all - gt_ids
     if orig_no_gt:
-        print(f"Excluding {len(orig_no_gt)} original ID(s) with no ground truth: {sorted(orig_no_gt)}")
+        print(
+            f"Excluding {len(orig_no_gt)} original ID(s) with no ground truth: {sorted(orig_no_gt)}"
+        )
         orig_train = [x for x in orig_train if x in gt_ids]
         orig_test = [x for x in orig_test if x in gt_ids]
         orig_all = set(orig_train) | set(orig_test)
@@ -112,7 +131,9 @@ def main():
 
     # New IDs: in transcripts + ground truth, but not in original split
     new_ids = sorted(gt_ids & transcript_ids - orig_all)
-    print(f"New IDs (in transcripts & ground truth, not in original split): {len(new_ids)}")
+    print(
+        f"New IDs (in transcripts & ground truth, not in original split): {len(new_ids)}"
+    )
 
     # Shuffle new IDs and split equally between train and test
     rng = random.Random(args.seed)
@@ -136,7 +157,9 @@ def main():
         json.dump(out, f, indent=2, ensure_ascii=False)
 
     print(f"\nSplit {len(train_ids) + len(test_ids)} conversations (seed={args.seed})")
-    print(f"  train: {len(train_ids)} ({len(orig_train)} original + {len(new_train)} new)")
+    print(
+        f"  train: {len(train_ids)} ({len(orig_train)} original + {len(new_train)} new)"
+    )
     print(f"  test:  {len(test_ids)} ({len(orig_test)} original + {len(new_test)} new)")
     print(f"Written to {output_path}")
 

--- a/analysis/working-paper-20260630/benchmark_perf_cost.py
+++ b/analysis/working-paper-20260630/benchmark_perf_cost.py
@@ -96,8 +96,12 @@ def summarize_exchanges(exchanges: list[dict], id_set: set[str] | None = None) -
             out_per_turn.append(usage["output_tokens"] / len(lats))
     return {
         "n_scenarios": len(seen),
-        "tutor_latency_mean_s": statistics.mean(turn_latencies) if turn_latencies else None,
-        "tutor_output_tokens_per_turn": statistics.mean(out_per_turn) if out_per_turn else None,
+        "tutor_latency_mean_s": statistics.mean(turn_latencies)
+        if turn_latencies
+        else None,
+        "tutor_output_tokens_per_turn": statistics.mean(out_per_turn)
+        if out_per_turn
+        else None,
     }
 
 
@@ -105,11 +109,18 @@ def summarize_exchanges(exchanges: list[dict], id_set: set[str] | None = None) -
 # Loaders                                                                     #
 # --------------------------------------------------------------------------- #
 def _perf(model: str, prompt: str) -> dict:
-    d = json.loads((BENCH / "_full_combined" / f"{model}__{prompt}" / "scores.json").read_text("utf-8"))
+    d = json.loads(
+        (BENCH / "_full_combined" / f"{model}__{prompt}" / "scores.json").read_text(
+            "utf-8"
+        )
+    )
     scaf, rig = d["scaffold_calibrated"]["score"], d["rigor_calibrated"]["score"]
     return {
-        "n": d["n_scenarios"], "scaffold_cal": scaf, "rigor_cal": rig,
-        "avoid_over": 1.0 - d["overscaffold"]["rate"], "composite": (scaf + rig) / 2.0,
+        "n": d["n_scenarios"],
+        "scaffold_cal": scaf,
+        "rigor_cal": rig,
+        "avoid_over": 1.0 - d["overscaffold"]["rate"],
+        "composite": (scaf + rig) / 2.0,
     }
 
 
@@ -128,12 +139,21 @@ def _cost(model: str, prompt: str, ids: set[str]) -> dict:
 
 
 def load_table() -> pd.DataFrame:
-    ids = set(json.loads((BENCH / "_balanced_520_scenario_ids.json").read_text("utf-8")))
+    ids = set(
+        json.loads((BENCH / "_balanced_520_scenario_ids.json").read_text("utf-8"))
+    )
     rows = []
     for model, label in MODELS:
         for prompt in PROMPTS:
-            rows.append({"model": model, "label": label, "prompt": prompt,
-                         **_perf(model, prompt), **_cost(model, prompt, ids)})
+            rows.append(
+                {
+                    "model": model,
+                    "label": label,
+                    "prompt": prompt,
+                    **_perf(model, prompt),
+                    **_cost(model, prompt, ids),
+                }
+            )
     return pd.DataFrame(rows)
 
 
@@ -146,7 +166,9 @@ def paper_latex(df: pd.DataFrame) -> str:
         return f"{v:.3f}"
 
     lines = [
-        r"\begin{table}[H]", r"    \centering", r"    \begin{tabular}{lccc ccc}",
+        r"\begin{table}[H]",
+        r"    \centering",
+        r"    \begin{tabular}{lccc ccc}",
         r"        \toprule",
         r"        & \multicolumn{3}{c}{\textbf{Plain prompt}} & \multicolumn{3}{c}{\textbf{Evaluation-aware prompt}} \\",
         r"        \cmidrule(lr){2-4} \cmidrule(lr){5-7}",
@@ -154,8 +176,14 @@ def paper_latex(df: pd.DataFrame) -> str:
         r"        \midrule",
     ]
     for model, label in MODELS:
-        c = [cell(model, "plain", "scaffold_cal"), cell(model, "plain", "rigor_cal"), cell(model, "plain", "avoid_over"),
-             cell(model, "scaffolding_rigor", "scaffold_cal"), cell(model, "scaffolding_rigor", "rigor_cal"), cell(model, "scaffolding_rigor", "avoid_over")]
+        c = [
+            cell(model, "plain", "scaffold_cal"),
+            cell(model, "plain", "rigor_cal"),
+            cell(model, "plain", "avoid_over"),
+            cell(model, "scaffolding_rigor", "scaffold_cal"),
+            cell(model, "scaffolding_rigor", "rigor_cal"),
+            cell(model, "scaffolding_rigor", "avoid_over"),
+        ]
         lines.append(f"        {label:<18} & " + " & ".join(c) + r" \\")
     lines += [r"        \bottomrule", r"    \end{tabular}", r"\end{table}"]
     return "\n".join(lines) + "\n"
@@ -173,9 +201,17 @@ def figures(df: pd.DataFrame) -> None:
         r = sub[sub.model == model]
         if not len(r):
             continue
-        ax.scatter(r["tutor_latency_mean_s"], r["composite"], s=80,
-                   color=MODEL_COLORS[model], marker=MODEL_MARKERS[model],
-                   edgecolor="white", linewidth=0.6, zorder=4, label=label)
+        ax.scatter(
+            r["tutor_latency_mean_s"],
+            r["composite"],
+            s=80,
+            color=MODEL_COLORS[model],
+            marker=MODEL_MARKERS[model],
+            edgecolor="white",
+            linewidth=0.6,
+            zorder=4,
+            label=label,
+        )
     ax.set_xlabel("Mean tutor latency per turn (s)", fontsize=11)
     ax.set_ylabel("Mean of Appropriate Scaffolding & Appropriate Rigor", fontsize=11)
     ax.grid(axis="both", ls=":", alpha=0.4)
@@ -191,9 +227,20 @@ def main() -> None:
     df = load_table()
     tex = paper_latex(df)
     (FIGDIR / "results_table.tex").write_text(tex, encoding="utf-8")
-    cols = ["label", "prompt", "n", "scaffold_cal", "rigor_cal", "avoid_over",
-            "composite", "tutor_latency_mean_s", "tutor_output_tokens_per_turn"]
-    (FIGDIR / "results_table.md").write_text(df[cols].round(3).to_markdown(index=False), encoding="utf-8")
+    cols = [
+        "label",
+        "prompt",
+        "n",
+        "scaffold_cal",
+        "rigor_cal",
+        "avoid_over",
+        "composite",
+        "tutor_latency_mean_s",
+        "tutor_output_tokens_per_turn",
+    ]
+    (FIGDIR / "results_table.md").write_text(
+        df[cols].round(3).to_markdown(index=False), encoding="utf-8"
+    )
     figures(df)
     print(tex)
     print("wrote: results_table.tex, results_table.md, latency_vs_perf.{pdf,png}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ build = ["boto3", "jsonschema"]
 # for the notebooks + benchmark_perf_cost.py (was misnamed "taxonomy")
 analysis = ["pandas", "matplotlib", "seaborn"]
 # dev alone runs the runtime tests; add build-dev (+analysis) for the full suite
-dev = ["pytest"]
+dev = ["pytest", "ruff"]
 build-dev = ["tutorsim[build]", "moto[s3]"]
 
 [project.scripts]
@@ -68,3 +68,20 @@ tutorsim_build = [
 [tool.pytest.ini_options]
 pythonpath = ["src", "."]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+# Research notebooks are exploratory artifacts; don't lint/format them. Markdown
+# is docs prose (ruff would otherwise reformat Python code fences in README.md).
+extend-exclude = ["*.ipynb", "*.md"]
+
+[tool.ruff.lint]
+# Ruff's default E subset (E4 imports, E7 statements, E9 syntax) + pyflakes (F)
+# + import sorting (I). Whitespace/line-length rules (E1/E2/E3, E501) are left to
+# `ruff format`, so long lines don't fail `ruff check`.
+select = ["E4", "E7", "E9", "F", "I"]
+# E402: cli.py intentionally re-exports imports after a function definition so
+# tests can monkeypatch them. E741: `l` is used as a throwaway in a few tests.
+# Both are stylistic here, so we don't gate on them.
+ignore = ["E402", "E741"]

--- a/src/tutorsim/__init__.py
+++ b/src/tutorsim/__init__.py
@@ -1,5 +1,5 @@
 """Tutorsim - a benchmark for measuring how well language models tutor."""
 
-from tutorsim.config import register_tutor, register_student
+from tutorsim.config import register_student, register_tutor
 
 __all__ = ["register_tutor", "register_student"]

--- a/src/tutorsim/cli.py
+++ b/src/tutorsim/cli.py
@@ -24,6 +24,7 @@ No module-level SDK imports.
 ASCII console output only (no Unicode / em-dash / box-drawing).
 All file I/O is UTF-8.
 """
+
 import argparse
 import datetime
 import hashlib
@@ -46,6 +47,7 @@ logger = logging.getLogger("tutorsim.cli")
 # ---------------------------------------------------------------------------
 # Cell expansion + lane scheduling
 # ---------------------------------------------------------------------------
+
 
 def expand_cells(tutors: list[str], modes: list[str]) -> list[dict]:
     """Expand (tutors x modes) into one cell dict per combination.
@@ -116,7 +118,9 @@ def run_sweep(
         lane_run_ids = []
         for idx, cell in enumerate(lane_cells, 1):
             with log_context(f"{cell['tutor']}/{cell['mode']}"):
-                logger.info("Starting cell %d/%d on lane %s", idx, len(lane_cells), lane)
+                logger.info(
+                    "Starting cell %d/%d on lane %s", idx, len(lane_cells), lane
+                )
                 rid = _run_cell_fn(
                     cell["tutor"],
                     cell["mode"],
@@ -144,11 +148,13 @@ def run_sweep(
 # Lazy module imports (no module-level SDK imports)
 # ---------------------------------------------------------------------------
 
+
 def _import_modules():
     """Import heavy modules lazily to avoid SDK import at module level."""
-    from tutorsim import conversation, scoring, results, report
+    from tutorsim import conversation, report, results, scoring
     from tutorsim.config import build_run_config
     from tutorsim.moments import load_moments
+
     return conversation, scoring, results, report, build_run_config, load_moments
 
 
@@ -156,9 +162,9 @@ def _import_modules():
 # These are imported at function call time, not at module load time,
 # but we re-export references so patch targets resolve correctly.
 import tutorsim.conversation as conversation
-import tutorsim.scoring as scoring
-import tutorsim.results as results
 import tutorsim.report as report
+import tutorsim.results as results
+import tutorsim.scoring as scoring
 from tutorsim.config import build_run_config
 from tutorsim.logging_setup import (
     bind_worker_logging,
@@ -231,6 +237,7 @@ def _resource_hashes(root: str) -> dict[str, str]:
 # Trials aggregation helpers
 # ---------------------------------------------------------------------------
 
+
 def _mean_spread(values: list) -> tuple[float | None, float | None]:
     """Return (mean, std) for a list of numeric values; None for empty/all-None."""
     nums = [v for v in values if v is not None]
@@ -258,6 +265,7 @@ def _aggregate_trials(trial_metrics: list[dict], n_trials: int) -> dict:
       scaffold_calibrated.{n_clean_yes, n_overscaffold, n_total, score},
       rigor_calibrated.{n_clean_yes, n_total, score}.
     """
+
     def _field(dicts, *keys):
         """Extract a nested field from each dict in dicts."""
         vals = []
@@ -283,20 +291,26 @@ def _aggregate_trials(trial_metrics: list[dict], n_trials: int) -> dict:
     m_nscen, s_nscen = _mean_spread(_field(trial_metrics, "n_scenarios"))
 
     # sub-dicts
-    m_over, s_over = _sub_mean_spread(trial_metrics, "overscaffold", ["n_yes", "n_total", "rate"])
+    m_over, s_over = _sub_mean_spread(
+        trial_metrics, "overscaffold", ["n_yes", "n_total", "rate"]
+    )
 
     # scaffold_calibrated has an extra field
     m_sc, s_sc = _sub_mean_spread(
-        trial_metrics, "scaffold_calibrated",
+        trial_metrics,
+        "scaffold_calibrated",
         ["n_clean_yes", "n_overscaffold", "n_total", "score"],
     )
     m_rc, s_rc = _sub_mean_spread(
-        trial_metrics, "rigor_calibrated",
+        trial_metrics,
+        "rigor_calibrated",
         ["n_clean_yes", "n_total", "score"],
     )
 
     # "available" is boolean -- take first trial's value (invariant across trials)
-    over_available = (trial_metrics[0].get("overscaffold") or {}).get("available", False)
+    over_available = (trial_metrics[0].get("overscaffold") or {}).get(
+        "available", False
+    )
 
     mean_dict = {
         "n_scenarios": m_nscen,
@@ -322,6 +336,7 @@ def _aggregate_trials(trial_metrics: list[dict], n_trials: int) -> dict:
 # Public API: run_cell
 # ---------------------------------------------------------------------------
 
+
 def _classify_run_taxonomy(run_dir, annotations, scenarios, *, tutor, mode):
     """Run the always-on action-taxonomy classification for a completed cell.
 
@@ -331,15 +346,18 @@ def _classify_run_taxonomy(run_dir, annotations, scenarios, *, tutor, mode):
     classifier model comes from the `taxonomy` config block.
     """
     from tutorsim import taxonomy
+
     out_dir = os.path.join(run_dir, "taxonomy")
     try:
         return taxonomy.classify_run(
-            annotations, scenarios, out_dir, model=tutor, mode=mode,
+            annotations,
+            scenarios,
+            out_dir,
+            model=tutor,
+            mode=mode,
         )
     except Exception as e:  # best-effort: never fail the run on taxonomy
-        logger.warning(
-            "Taxonomy classification failed (run metrics unaffected): %s", e
-        )
+        logger.warning("Taxonomy classification failed (run metrics unaffected): %s", e)
         return {"error": str(e)}
 
 
@@ -433,16 +451,18 @@ def run_cell(
             "reproducibility": {
                 "tutorsim_version": _package_version(),
                 "git_commit": _git_commit(),
-                "config_hash": _json_sha256({
-                    "student": cfg.student,
-                    "scorer": cfg.scorer,
-                    "resolved_tutors": cfg.resolved_tutors,
-                    "defaults": {
-                        "sample": cfg.sample,
-                        "max_turns": cfg.max_turns,
-                        "trials": cfg.trials,
-                    },
-                }),
+                "config_hash": _json_sha256(
+                    {
+                        "student": cfg.student,
+                        "scorer": cfg.scorer,
+                        "resolved_tutors": cfg.resolved_tutors,
+                        "defaults": {
+                            "sample": cfg.sample,
+                            "max_turns": cfg.max_turns,
+                            "trials": cfg.trials,
+                        },
+                    }
+                ),
                 "prompt_hashes": _resource_hashes("prompts"),
                 "dataset_manifest": dataset_manifest,
             },
@@ -460,8 +480,18 @@ def run_cell(
 
         _EMPTY_METRICS = {
             "n_scenarios": 0,
-            "overscaffold": {"n_yes": 0, "n_total": 0, "rate": None, "available": False},
-            "scaffold_calibrated": {"n_clean_yes": 0, "n_overscaffold": 0, "n_total": 0, "score": None},
+            "overscaffold": {
+                "n_yes": 0,
+                "n_total": 0,
+                "rate": None,
+                "available": False,
+            },
+            "scaffold_calibrated": {
+                "n_clean_yes": 0,
+                "n_overscaffold": 0,
+                "n_total": 0,
+                "score": None,
+            },
             "rigor_calibrated": {"n_clean_yes": 0, "n_total": 0, "score": None},
         }
 
@@ -530,10 +560,13 @@ def run_cell(
             #      to_score is byte-identical regardless of completion order.
             logger.info(
                 "Starting Replay (trial %d/%d): %d moments, student=%s (%s), max_turns=%s, concurrency=%d",
-                trial_idx, n_trials, n_total,
+                trial_idx,
+                n_trials,
+                n_total,
                 (cfg.student or {}).get("model"),
                 (cfg.student or {}).get("mode", "oracle"),
-                cfg.max_turns, replay_concurrency,
+                cfg.max_turns,
+                replay_concurrency,
             )
 
             # ---- Stage 1: sequential planning pass (resume decisions) ----
@@ -549,10 +582,19 @@ def run_cell(
 
                 # Resume: skip if both transcript and score already exist
                 if results.is_done(run_id, resume_sid, results_root=results_root):
-                    logger.info("[trial %d][%d/%d] SKIP (already done): %s", trial_idx, i, n_total, sid)
-                    score_dict = results.read_score(run_id, resume_sid, results_root=results_root)
+                    logger.info(
+                        "[trial %d][%d/%d] SKIP (already done): %s",
+                        trial_idx,
+                        i,
+                        n_total,
+                        sid,
+                    )
+                    score_dict = results.read_score(
+                        run_id, resume_sid, results_root=results_root
+                    )
                     if score_dict is not None:
                         from tutorsim.scoring import Annotation
+
                         try:
                             ann = Annotation(**score_dict)
                             completed_scenarios.append(scenario)
@@ -562,22 +604,39 @@ def run_cell(
                             # No transcript object on resume -- latencies not available
                         except Exception as e:
                             counts["failed"] += 1
-                            failed_scenarios.append({"id": sid, "error": str(e), "phase": "resume"})
+                            failed_scenarios.append(
+                                {"id": sid, "error": str(e), "phase": "resume"}
+                            )
                             logger.warning(
                                 "[trial %d][%d/%d] Could not reload score for %s: %s",
-                                trial_idx, i, n_total, sid, e,
+                                trial_idx,
+                                i,
+                                n_total,
+                                sid,
+                                e,
                             )
                     continue
 
                 # Interrupted-run resume: transcript on disk but no score yet --
                 # skip the conversation and pool the moment for scoring.
-                transcript_dict = results.read_transcript(run_id, resume_sid, results_root=results_root)
+                transcript_dict = results.read_transcript(
+                    run_id, resume_sid, results_root=results_root
+                )
                 if transcript_dict is not None:
                     logger.info(
                         "[trial %d][%d/%d] RESUME replay (classification pending): %s",
-                        trial_idx, i, n_total, sid,
+                        trial_idx,
+                        i,
+                        n_total,
+                        sid,
                     )
-                    to_score.append((scenario, conversation.Transcript.from_dict(transcript_dict), resume_sid))
+                    to_score.append(
+                        (
+                            scenario,
+                            conversation.Transcript.from_dict(transcript_dict),
+                            resume_sid,
+                        )
+                    )
                     continue
 
                 pending.append((i, scenario, resume_sid))
@@ -625,11 +684,24 @@ def run_cell(
                         # conversation that already finished (resume durability).
                         # Written before scoring so a score failure doesn't lose it.
                         transcript_dict = (
-                            transcript.to_dict() if hasattr(transcript, "to_dict") else dict(transcript)
+                            transcript.to_dict()
+                            if hasattr(transcript, "to_dict")
+                            else dict(transcript)
                         )
-                        results.write_transcript(run_id, resume_sid, transcript_dict, results_root=results_root)
+                        results.write_transcript(
+                            run_id,
+                            resume_sid,
+                            transcript_dict,
+                            results_root=results_root,
+                        )
                         outcome[idx] = ("ok", transcript)
-                        logger.info("[trial %d][%d/%d] replay OK: %s", trial_idx, idx, n_total, sid)
+                        logger.info(
+                            "[trial %d][%d/%d] replay OK: %s",
+                            trial_idx,
+                            idx,
+                            n_total,
+                            sid,
+                        )
 
             # ---- Stage 3: deterministic, single-threaded collection ----
             for i, scenario, resume_sid in pending:
@@ -637,8 +709,17 @@ def run_cell(
                 status, payload = outcome[i]
                 if status == "err":
                     counts["failed"] += 1
-                    failed_scenarios.append({"id": sid, "error": str(payload), "phase": "run"})
-                    logger.error("[trial %d][%d/%d] SKIP %s: %s", trial_idx, i, n_total, sid, payload)
+                    failed_scenarios.append(
+                        {"id": sid, "error": str(payload), "phase": "run"}
+                    )
+                    logger.error(
+                        "[trial %d][%d/%d] SKIP %s: %s",
+                        trial_idx,
+                        i,
+                        n_total,
+                        sid,
+                        payload,
+                    )
                     continue
 
                 to_score.append((scenario, payload, resume_sid))
@@ -647,7 +728,9 @@ def run_cell(
             if to_score:
                 logger.info(
                     "Starting Classification (trial %d/%d): %d replays, 3 pooled batch passes",
-                    trial_idx, n_trials, len(to_score),
+                    trial_idx,
+                    n_trials,
+                    len(to_score),
                 )
                 try:
                     annotations_by_sid = scoring.score_batch(
@@ -658,8 +741,14 @@ def run_cell(
                     annotations_by_sid = {}
                     for s, _, _ in to_score:
                         counts["failed"] += 1
-                        failed_scenarios.append({"id": s.id, "error": str(e), "phase": "score"})
-                    logger.error("[trial %d] Classification failed for all pooled replays: %s", trial_idx, e)
+                        failed_scenarios.append(
+                            {"id": s.id, "error": str(e), "phase": "score"}
+                        )
+                    logger.error(
+                        "[trial %d] Classification failed for all pooled replays: %s",
+                        trial_idx,
+                        e,
+                    )
 
                 for scenario, transcript, resume_sid in to_score:
                     annotation = annotations_by_sid.get(scenario.id)
@@ -667,17 +756,23 @@ def run_cell(
                         if not annotations_by_sid:
                             continue  # whole-batch failure already recorded above
                         counts["failed"] += 1
-                        failed_scenarios.append({
-                            "id": scenario.id,
-                            "error": "no annotation returned by score_batch",
-                            "phase": "score",
-                        })
+                        failed_scenarios.append(
+                            {
+                                "id": scenario.id,
+                                "error": "no annotation returned by score_batch",
+                                "phase": "score",
+                            }
+                        )
                         continue
 
                     annotation_dict = (
-                        annotation.to_dict() if hasattr(annotation, "to_dict") else dict(annotation)
+                        annotation.to_dict()
+                        if hasattr(annotation, "to_dict")
+                        else dict(annotation)
                     )
-                    results.write_score(run_id, resume_sid, annotation_dict, results_root=results_root)
+                    results.write_score(
+                        run_id, resume_sid, annotation_dict, results_root=results_root
+                    )
 
                     completed_scenarios.append(scenario)
                     completed_annotations.append(annotation)
@@ -695,8 +790,13 @@ def run_cell(
             metrics["run_counts"] = counts
             if failed_scenarios:
                 metrics["failed_scenarios"] = failed_scenarios
-            return (metrics, completed_transcripts, counts,
-                    completed_scenarios, completed_annotations)
+            return (
+                metrics,
+                completed_transcripts,
+                counts,
+                completed_scenarios,
+                completed_annotations,
+            )
 
         # Run all trials
         trial_results = [_run_trial(t) for t in range(1, n_trials + 1)]
@@ -773,7 +873,11 @@ def run_cell(
         # key, classifier error) must never discard the run's primary metrics.
         run_dir = os.path.join(results_root, run_id)
         tax = _classify_run_taxonomy(
-            run_dir, all_trial_annotations, all_trial_scenarios, tutor=tutor, mode=mode,
+            run_dir,
+            all_trial_annotations,
+            all_trial_scenarios,
+            tutor=tutor,
+            mode=mode,
         )
         metrics["taxonomy"] = tax
         tax_usage = (tax or {}).get("usage") or {}
@@ -788,8 +892,11 @@ def run_cell(
         logger.info(
             "Run complete: %d/%d moments succeeded (%d failed, %d resumed, "
             "%d trial(s)) -> %s",
-            run_counts["succeeded"], run_counts["attempted"],
-            run_counts["failed"], run_counts["resumed"], n_trials,
+            run_counts["succeeded"],
+            run_counts["attempted"],
+            run_counts["failed"],
+            run_counts["resumed"],
+            n_trials,
             os.path.join(results_root, run_id),
         )
 
@@ -797,7 +904,11 @@ def run_cell(
         # summary.json; this surfaces them without a separate `report` step
         # (which stays the cross-run leaderboard). Printed, not logged, so it
         # shows regardless of --log-level.
-        print(report.format_run_summary(metrics, tutor_model=tutor, mode=mode, run_id=run_id))
+        print(
+            report.format_run_summary(
+                metrics, tutor_model=tutor, mode=mode, run_id=run_id
+            )
+        )
 
         return run_id
 
@@ -805,6 +916,7 @@ def run_cell(
 # ---------------------------------------------------------------------------
 # CLI: argparse
 # ---------------------------------------------------------------------------
+
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser."""
@@ -846,7 +958,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="HF_ID",
         help="Hugging Face dataset id for the released benchmark "
-             "(default: dataset.id from config)",
+        "(default: dataset.id from config)",
     )
     run_p.add_argument(
         "--data_path",
@@ -854,7 +966,7 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="data_path",
         metavar="DIR",
         help="Local release directory containing moments.jsonl "
-             "(developer override; wins over --dataset)",
+        "(developer override; wins over --dataset)",
     )
     run_p.add_argument(
         "--dataset-revision",
@@ -892,8 +1004,8 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="replay_concurrency",
         metavar="N",
         help="Concurrent per-moment replays within a cell (default: from config, "
-             "typically 4). Result-preserving; lower it on smaller API tiers that "
-             "hit rate limits.",
+        "typically 4). Result-preserving; lower it on smaller API tiers that "
+        "hit rate limits.",
     )
     # -- report subcommand ----------------------------------------------------
     report_p = subs.add_parser(
@@ -951,7 +1063,6 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _cmd_report(args) -> None:
     """Implement the 'report' subcommand: read all run summaries -> leaderboard md+csv."""
-    import os
     from pathlib import Path
 
     run_ids = results.list_runs(args.results_root)
@@ -1005,7 +1116,9 @@ def _cmd_view(args) -> None:
             continue
         summary = dict(summary)
         summary.setdefault("tutor_model", run_id.split("_")[0] if run_id else "")
-        summary.setdefault("mode", run_id.split("_")[1] if len(run_id.split("_")) > 1 else "")
+        summary.setdefault(
+            "mode", run_id.split("_")[1] if len(run_id.split("_")) > 1 else ""
+        )
         summaries.append(summary)
 
     html = report.view(summaries)
@@ -1030,10 +1143,13 @@ def main(argv=None) -> None:
     # no shared --log-level/--log-file args, so handle it before setup_logging.
     if args.command == "taxonomy":
         from tutorsim import taxonomy
+
         sys.exit(taxonomy.cli_dispatch(args.args))
 
     setup_logging(level=args.log_level, log_file=args.log_file)
-    logger.info("Command: tutorsim %s", " ".join(argv if argv is not None else sys.argv[1:]))
+    logger.info(
+        "Command: tutorsim %s", " ".join(argv if argv is not None else sys.argv[1:])
+    )
 
     if args.command == "run":
         if args.config:

--- a/src/tutorsim/client.py
+++ b/src/tutorsim/client.py
@@ -1,4 +1,5 @@
 """Model provider routing and calling (sync + batch), shared by tutor/student/scorer."""
+
 import base64
 import json
 import logging
@@ -6,6 +7,7 @@ import os
 import re
 import time
 from dataclasses import dataclass, field
+
 from dotenv import load_dotenv
 from google.genai import types
 
@@ -31,9 +33,16 @@ PROVIDER_PREFIXES = [
 
 
 VISION_CAPABLE_PREFIXES = (
-    "claude-opus-4", "claude-sonnet-4", "claude-sonnet-5", "claude-fable-5",
-    "gemini-2", "gemini-3",
-    "gpt-4o", "gpt-4.1", "gpt-5", "o4",
+    "claude-opus-4",
+    "claude-sonnet-4",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "gemini-2",
+    "gemini-3",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-5",
+    "o4",
 )
 
 
@@ -69,10 +78,15 @@ def infer_provider(model: str) -> str:
 @dataclass
 class ModelResponse:
     """Unified response from any provider."""
+
     text: str
-    usage: dict = field(default_factory=lambda: {
-        "input_tokens": 0, "output_tokens": 0, "total_tokens": 0
-    })
+    usage: dict = field(
+        default_factory=lambda: {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        }
+    )
     # Wall-clock seconds from the start of the successful generate() attempt
     # to the response landing. Stamped by ModelClient.generate(). Retries
     # are not included (they're bookkeeping, not model reasoning time).
@@ -94,10 +108,12 @@ TOGETHER_BASE_URL = "https://api.together.xyz/v1"
 _ANTHROPIC_LEGACY_THINKING_MODELS = (
     "claude-3-7-sonnet",
     "claude-haiku-4-5",
-    "claude-opus-4-0", "claude-opus-4-20250514",
+    "claude-opus-4-0",
+    "claude-opus-4-20250514",
     "claude-opus-4-1",
     "claude-opus-4-5",
-    "claude-sonnet-4-0", "claude-sonnet-4-20250514",
+    "claude-sonnet-4-0",
+    "claude-sonnet-4-20250514",
     "claude-sonnet-4-5",
 )
 
@@ -109,7 +125,9 @@ def _anthropic_thinking_param(model: str, thinking_budget: int) -> dict:
     model requires. Only the frozen pre-adaptive models in
     _ANTHROPIC_LEGACY_THINKING_MODELS get the enabled+budget_tokens form.
     """
-    if model and any(model.startswith(prefix) for prefix in _ANTHROPIC_LEGACY_THINKING_MODELS):
+    if model and any(
+        model.startswith(prefix) for prefix in _ANTHROPIC_LEGACY_THINKING_MODELS
+    ):
         budget = thinking_budget if thinking_budget > 0 else 16384
         return {"type": "enabled", "budget_tokens": budget}
     return {"type": "adaptive"}
@@ -131,6 +149,7 @@ class ModelClient:
         """Initialize the SDK client for the inferred provider."""
         if self.provider == "gemini":
             from google import genai
+
             api_key = os.getenv("GEMINI_API_KEY")
             if not api_key:
                 raise RuntimeError("GEMINI_API_KEY not found in environment")
@@ -138,6 +157,7 @@ class ModelClient:
 
         elif self.provider == "openai":
             from openai import OpenAI
+
             api_key = os.getenv("OPENAI_API_KEY")
             if not api_key:
                 raise RuntimeError("OPENAI_API_KEY not found in environment")
@@ -145,6 +165,7 @@ class ModelClient:
 
         elif self.provider == "anthropic":
             import anthropic
+
             api_key = os.getenv("ANTHROPIC_API_KEY")
             if not api_key:
                 raise RuntimeError("ANTHROPIC_API_KEY not found in environment")
@@ -153,6 +174,7 @@ class ModelClient:
         elif self.provider == "together":
             # Together is OpenAI-compatible -- same SDK, different base_url + key.
             from openai import OpenAI
+
             api_key = os.getenv("TOGETHER_API_KEY")
             if not api_key:
                 raise RuntimeError("TOGETHER_API_KEY not found in environment")
@@ -161,18 +183,22 @@ class ModelClient:
         else:
             raise ValueError(f"Unsupported provider: {self.provider}")
 
-    def generate(self, prompt: str,
-                 images: list[str] | None = None,
-                 json_mode: bool = True,
-                 max_tokens: int = 0, timeout: int = 120,
-                 thinking: bool = False,
-                 thinking_budget: int = 0,
-                 reasoning_effort: str = "",
-                 effort: str = "",
-                 enable_cache: bool = False,
-                 *,
-                 output_schema: dict | None = None,
-                 cacheable_prefix: str | None = None) -> "ModelResponse":
+    def generate(
+        self,
+        prompt: str,
+        images: list[str] | None = None,
+        json_mode: bool = True,
+        max_tokens: int = 0,
+        timeout: int = 120,
+        thinking: bool = False,
+        thinking_budget: int = 0,
+        reasoning_effort: str = "",
+        effort: str = "",
+        enable_cache: bool = False,
+        *,
+        output_schema: dict | None = None,
+        cacheable_prefix: str | None = None,
+    ) -> "ModelResponse":
         """Generate a response from the model with retry logic.
 
         output_schema: optional JSON Schema for structured output. When set,
@@ -182,7 +208,9 @@ class ModelClient:
         from tutorsim.config import get_retry_config
 
         if output_schema is not None and self.provider != "anthropic":
-            raise ValueError("output_schema is only supported on the anthropic provider")
+            raise ValueError(
+                "output_schema is only supported on the anthropic provider"
+            )
 
         if max_tokens <= 0:
             max_tokens = MAX_OUTPUT_TOKENS.get(self.provider, 8192)
@@ -196,27 +224,51 @@ class ModelClient:
         for attempt in range(max_retries):
             try:
                 if self.provider == "gemini":
-                    resp = self._generate_gemini(prompt, json_mode, max_tokens, timeout,
-                                                 thinking, thinking_budget, images,
-                                                 cacheable_prefix=cacheable_prefix)
+                    resp = self._generate_gemini(
+                        prompt,
+                        json_mode,
+                        max_tokens,
+                        timeout,
+                        thinking,
+                        thinking_budget,
+                        images,
+                        cacheable_prefix=cacheable_prefix,
+                    )
                 elif self.provider == "openai":
-                    resp = self._generate_openai(prompt, json_mode, max_tokens, timeout,
-                                                  thinking, thinking_budget,
-                                                  reasoning_effort=reasoning_effort,
-                                                  images=images,
-                                                  cacheable_prefix=cacheable_prefix)
+                    resp = self._generate_openai(
+                        prompt,
+                        json_mode,
+                        max_tokens,
+                        timeout,
+                        thinking,
+                        thinking_budget,
+                        reasoning_effort=reasoning_effort,
+                        images=images,
+                        cacheable_prefix=cacheable_prefix,
+                    )
                 elif self.provider == "anthropic":
-                    resp = self._generate_anthropic(prompt, json_mode, max_tokens, timeout,
-                                                     thinking, thinking_budget,
-                                                     reasoning_effort=reasoning_effort,
-                                                     effort=effort,
-                                                     images=images,
-                                                     enable_cache=enable_cache,
-                                                     output_schema=output_schema,
-                                                     cacheable_prefix=cacheable_prefix)
+                    resp = self._generate_anthropic(
+                        prompt,
+                        json_mode,
+                        max_tokens,
+                        timeout,
+                        thinking,
+                        thinking_budget,
+                        reasoning_effort=reasoning_effort,
+                        effort=effort,
+                        images=images,
+                        enable_cache=enable_cache,
+                        output_schema=output_schema,
+                        cacheable_prefix=cacheable_prefix,
+                    )
                 elif self.provider == "together":
-                    resp = self._generate_together(prompt, json_mode, max_tokens, timeout,
-                                                    cacheable_prefix=cacheable_prefix)
+                    resp = self._generate_together(
+                        prompt,
+                        json_mode,
+                        max_tokens,
+                        timeout,
+                        cacheable_prefix=cacheable_prefix,
+                    )
                 else:
                     raise RuntimeError(f"unknown provider {self.provider}")
                 # Stamp wall-clock latency for the successful attempt only
@@ -225,10 +277,15 @@ class ModelClient:
                 return resp
             except Exception as e:
                 last_error = e
-                delay = base_delay * (2 ** attempt)
+                delay = base_delay * (2**attempt)
                 if attempt < max_retries - 1:
-                    logger.warning("API error (attempt %d/%d): %s. Retrying in %ds...",
-                                   attempt + 1, max_retries, e, delay)
+                    logger.warning(
+                        "API error (attempt %d/%d): %s. Retrying in %ds...",
+                        attempt + 1,
+                        max_retries,
+                        e,
+                        delay,
+                    )
                     time.sleep(delay)
                 else:
                     logger.error("API failed after %d attempts: %s", max_retries, e)
@@ -237,9 +294,17 @@ class ModelClient:
             f"API call failed after {max_retries} attempts: {last_error}"
         )
 
-    def _generate_gemini(self, prompt, json_mode, max_tokens, timeout,
-                         thinking=False, thinking_budget=0, images=None,
-                         cacheable_prefix: str | None = None):
+    def _generate_gemini(
+        self,
+        prompt,
+        json_mode,
+        max_tokens,
+        timeout,
+        thinking=False,
+        thinking_budget=0,
+        images=None,
+        cacheable_prefix: str | None = None,
+    ):
         """Gemini API call via google-genai SDK."""
         config = {
             "max_output_tokens": max_tokens,
@@ -254,7 +319,10 @@ class ModelClient:
                 budget = 16384
             else:
                 budget = thinking_budget  # may be -1 (dynamic) or positive
-            config["thinking_config"] = {"include_thoughts": True, "thinking_budget": budget}
+            config["thinking_config"] = {
+                "include_thoughts": True,
+                "thinking_budget": budget,
+            }
 
         # Gemini has no server-side prompt cache wired here; the cacheable
         # head is concatenated into the prompt, which is semantically
@@ -263,7 +331,9 @@ class ModelClient:
         if images:
             image_blocks = _build_image_blocks_gemini(images)
             parts = _interleave_text_and_images(
-                effective_prompt, image_blocks, lambda s: {"text": s},
+                effective_prompt,
+                image_blocks,
+                lambda s: {"text": s},
             )
             contents = [{"role": "user", "parts": parts}]
         else:
@@ -284,19 +354,30 @@ class ModelClient:
         }
         return ModelResponse(text=text, usage=usage)
 
-    def _generate_openai(self, prompt, json_mode, max_tokens, timeout,
-                         thinking=False, thinking_budget=0,
-                         reasoning_effort: str = "", images=None,
-                         cacheable_prefix: str | None = None):
+    def _generate_openai(
+        self,
+        prompt,
+        json_mode,
+        max_tokens,
+        timeout,
+        thinking=False,
+        thinking_budget=0,
+        reasoning_effort: str = "",
+        images=None,
+        cacheable_prefix: str | None = None,
+    ):
         """OpenAI API call via openai SDK."""
         if images:
             image_blocks = _build_image_blocks_openai(
-                images, use_url=_should_use_presigned_url(),
+                images,
+                use_url=_should_use_presigned_url(),
             )
             # Prepend cacheable head so auto-cache sees the same prefix on repeats.
             head_text = cacheable_prefix or ""
             content = _interleave_text_and_images(
-                head_text + prompt, image_blocks, lambda s: {"type": "text", "text": s},
+                head_text + prompt,
+                image_blocks,
+                lambda s: {"type": "text", "text": s},
             )
         else:
             content = (cacheable_prefix or "") + prompt
@@ -327,8 +408,14 @@ class ModelClient:
         }
         return ModelResponse(text=text, usage=usage)
 
-    def _generate_together(self, prompt, json_mode, max_tokens, timeout,
-                           cacheable_prefix: str | None = None):
+    def _generate_together(
+        self,
+        prompt,
+        json_mode,
+        max_tokens,
+        timeout,
+        cacheable_prefix: str | None = None,
+    ):
         """Together (open-weight) call via OpenAI-compatible chat completions.
 
         Together uses `max_tokens` (not `max_completion_tokens`) and does not
@@ -360,12 +447,21 @@ class ModelClient:
         }
         return ModelResponse(text=text, usage=usage)
 
-    def _generate_anthropic(self, prompt, json_mode, max_tokens, timeout,
-                            thinking=False, thinking_budget=0,
-                            reasoning_effort="", effort="",
-                            images=None, enable_cache=False,
-                            output_schema: dict | None = None,
-                            cacheable_prefix: str | None = None):
+    def _generate_anthropic(
+        self,
+        prompt,
+        json_mode,
+        max_tokens,
+        timeout,
+        thinking=False,
+        thinking_budget=0,
+        reasoning_effort="",
+        effort="",
+        images=None,
+        enable_cache=False,
+        output_schema: dict | None = None,
+        cacheable_prefix: str | None = None,
+    ):
         """Anthropic API call via anthropic SDK."""
         system_parts = []
         if json_mode:
@@ -377,21 +473,31 @@ class ModelClient:
 
         if images:
             image_blocks = _build_image_blocks_anthropic(
-                images, use_url=_should_use_presigned_url(), enable_cache=enable_cache,
+                images,
+                use_url=_should_use_presigned_url(),
+                enable_cache=enable_cache,
             )
             content = _interleave_text_and_images(
-                prompt, image_blocks, lambda s: {"type": "text", "text": s},
+                prompt,
+                image_blocks,
+                lambda s: {"type": "text", "text": s},
             )
             if cacheable_prefix is not None:
                 # Prepend the cacheable head as its own text block.
                 content = [
-                    {"type": "text", "text": cacheable_prefix,
-                     "cache_control": {"type": "ephemeral"}},
+                    {
+                        "type": "text",
+                        "text": cacheable_prefix,
+                        "cache_control": {"type": "ephemeral"},
+                    },
                 ] + content
         elif cacheable_prefix is not None:
             content = [
-                {"type": "text", "text": cacheable_prefix,
-                 "cache_control": {"type": "ephemeral"}},
+                {
+                    "type": "text",
+                    "text": cacheable_prefix,
+                    "cache_control": {"type": "ephemeral"},
+                },
                 {"type": "text", "text": prompt},
             ]
         else:
@@ -445,9 +551,16 @@ class ModelClient:
         usage = {
             "input_tokens": response.usage.input_tokens or 0,
             "output_tokens": response.usage.output_tokens or 0,
-            "total_tokens": (response.usage.input_tokens or 0) + (response.usage.output_tokens or 0),
-            "cache_creation_input_tokens": getattr(response.usage, "cache_creation_input_tokens", 0) or 0,
-            "cache_read_input_tokens": getattr(response.usage, "cache_read_input_tokens", 0) or 0,
+            "total_tokens": (response.usage.input_tokens or 0)
+            + (response.usage.output_tokens or 0),
+            "cache_creation_input_tokens": getattr(
+                response.usage, "cache_creation_input_tokens", 0
+            )
+            or 0,
+            "cache_read_input_tokens": getattr(
+                response.usage, "cache_read_input_tokens", 0
+            )
+            or 0,
         }
         return ModelResponse(text=text, usage=usage)
 
@@ -533,7 +646,7 @@ def _interleave_text_and_images(
     used: set[int] = set()
 
     for m in _SCREEN_MARKER_RE.finditer(prompt):
-        chunk = prompt[cursor:m.end()]
+        chunk = prompt[cursor : m.end()]
         if chunk:
             parts.append(text_block(chunk))
         cursor = m.end()
@@ -558,6 +671,7 @@ def _interleave_text_and_images(
 # ===================================================================
 # Storage backend stub (Phase 1: local-only)
 # ===================================================================
+
 
 class _LocalBackend:
     """Minimal local-file storage backend for Phase 1.
@@ -618,7 +732,9 @@ def _presigned_url(rel_path: str, expires_seconds: int = 172800) -> str:
 
 
 def _build_image_blocks_anthropic(
-    image_paths: list[str], use_url: bool, enable_cache: bool,
+    image_paths: list[str],
+    use_url: bool,
+    enable_cache: bool,
 ) -> list[dict]:
     """Build Anthropic image content blocks."""
     blocks = []
@@ -640,7 +756,8 @@ def _build_image_blocks_anthropic(
 
 
 def _build_image_blocks_openai(
-    image_paths: list[str], use_url: bool,
+    image_paths: list[str],
+    use_url: bool,
 ) -> list[dict]:
     """Build OpenAI image content blocks."""
     blocks = []
@@ -661,12 +778,14 @@ def _build_image_blocks_gemini(image_paths: list[str]) -> list[dict]:
     """
     blocks = []
     for path in image_paths:
-        blocks.append({
-            "inline_data": {
-                "mime_type": _mime_from_path(path),
-                "data": _base64_bytes(path),
+        blocks.append(
+            {
+                "inline_data": {
+                    "mime_type": _mime_from_path(path),
+                    "data": _base64_bytes(path),
+                }
             }
-        })
+        )
     return blocks
 
 
@@ -682,11 +801,14 @@ def _extract_entry(entry: dict) -> tuple[str, str, bool, int, list[str]]:
     return key, prompt_text, json_mode, max_tokens, images
 
 
-def build_batch_entry(key: str, prompt_text: str,
-                      images: list[str] | None = None,
-                      json_mode: bool = True,
-                      max_tokens: int = 65536,
-                      cacheable_prefix: str | None = None) -> dict:
+def build_batch_entry(
+    key: str,
+    prompt_text: str,
+    images: list[str] | None = None,
+    json_mode: bool = True,
+    max_tokens: int = 65536,
+    cacheable_prefix: str | None = None,
+) -> dict:
     """Build a single batch entry from a key and prompt text.
 
     Uses a provider-neutral internal format. run_batch() and run_sync_entries()
@@ -701,10 +823,7 @@ def build_batch_entry(key: str, prompt_text: str,
     if json_mode:
         gen_config["response_mime_type"] = "application/json"
     request = {
-        "contents": [{
-            "parts": [{"text": prompt_text}],
-            "role": "user"
-        }],
+        "contents": [{"parts": [{"text": prompt_text}], "role": "user"}],
         "generation_config": gen_config,
     }
     if images:
@@ -726,8 +845,12 @@ def write_jsonl(entries: list[dict], jsonl_path: str) -> int:
     return len(entries)
 
 
-def run_sync_entries(client: 'ModelClient', entries: list[dict],
-                     json_mode: bool = True, max_tokens: int = 0) -> dict:
+def run_sync_entries(
+    client: "ModelClient",
+    entries: list[dict],
+    json_mode: bool = True,
+    max_tokens: int = 0,
+) -> dict:
     """Run entries synchronously one at a time.
 
     Returns {key: {text, usage}} dict (same shape as run_batch).
@@ -735,7 +858,9 @@ def run_sync_entries(client: 'ModelClient', entries: list[dict],
     raw_entries = {}
     total = len(entries)
     for i, entry in enumerate(entries):
-        key, prompt_text, entry_json_mode, entry_max_tokens, images = _extract_entry(entry)
+        key, prompt_text, entry_json_mode, entry_max_tokens, images = _extract_entry(
+            entry
+        )
         if not entry_max_tokens:
             entry_max_tokens = max_tokens
 
@@ -765,15 +890,21 @@ def run_sync_entries(client: 'ModelClient', entries: list[dict],
 # Unified batch API
 # ===================================================================
 
-def run_batch(client: 'ModelClient', entries: list[dict],
-              json_mode: bool = True, display_name: str = "batch",
-              poll_interval: int = 60,
-              thinking: bool = False, thinking_budget: int = 0,
-              reasoning_effort: str = "",
-              effort: str = "",
-              enable_cache: bool = False,
-              existing_batch_id: str | None = None,
-              on_batch_created=None) -> dict:
+
+def run_batch(
+    client: "ModelClient",
+    entries: list[dict],
+    json_mode: bool = True,
+    display_name: str = "batch",
+    poll_interval: int = 60,
+    thinking: bool = False,
+    thinking_budget: int = 0,
+    reasoning_effort: str = "",
+    effort: str = "",
+    enable_cache: bool = False,
+    existing_batch_id: str | None = None,
+    on_batch_created=None,
+) -> dict:
     """Run entries as a batch job via the provider's batch API.
 
     Resume support: if `existing_batch_id` is set, skip submission and resume
@@ -785,29 +916,60 @@ def run_batch(client: 'ModelClient', entries: list[dict],
     """
     provider = client.provider
     if existing_batch_id:
-        logger.info("Resuming in-flight %s batch %s (%d entries)",
-                    provider, existing_batch_id, len(entries))
+        logger.info(
+            "Resuming in-flight %s batch %s (%d entries)",
+            provider,
+            existing_batch_id,
+            len(entries),
+        )
     else:
-        logger.info("Running batch (%s): %d entries, display_name=%s",
-                    provider, len(entries), display_name)
+        logger.info(
+            "Running batch (%s): %d entries, display_name=%s",
+            provider,
+            len(entries),
+            display_name,
+        )
 
     if provider == "gemini":
-        return _run_batch_gemini(client, entries, json_mode, display_name, poll_interval,
-                                 thinking, thinking_budget,
-                                 existing_batch_id=existing_batch_id,
-                                 on_batch_created=on_batch_created)
+        return _run_batch_gemini(
+            client,
+            entries,
+            json_mode,
+            display_name,
+            poll_interval,
+            thinking,
+            thinking_budget,
+            existing_batch_id=existing_batch_id,
+            on_batch_created=on_batch_created,
+        )
     elif provider == "openai":
-        return _run_batch_openai(client, entries, json_mode, display_name, poll_interval,
-                                 thinking, thinking_budget, reasoning_effort,
-                                 existing_batch_id=existing_batch_id,
-                                 on_batch_created=on_batch_created)
+        return _run_batch_openai(
+            client,
+            entries,
+            json_mode,
+            display_name,
+            poll_interval,
+            thinking,
+            thinking_budget,
+            reasoning_effort,
+            existing_batch_id=existing_batch_id,
+            on_batch_created=on_batch_created,
+        )
     elif provider == "anthropic":
-        return _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval,
-                                    thinking, thinking_budget, reasoning_effort,
-                                    effort=effort,
-                                    enable_cache=enable_cache,
-                                    existing_batch_id=existing_batch_id,
-                                    on_batch_created=on_batch_created)
+        return _run_batch_anthropic(
+            client,
+            entries,
+            json_mode,
+            display_name,
+            poll_interval,
+            thinking,
+            thinking_budget,
+            reasoning_effort,
+            effort=effort,
+            enable_cache=enable_cache,
+            existing_batch_id=existing_batch_id,
+            on_batch_created=on_batch_created,
+        )
     else:
         raise ValueError(f"Batch API not supported for provider: {provider}")
 
@@ -816,15 +978,26 @@ def run_batch(client: 'ModelClient', entries: list[dict],
 # Gemini Batch API
 # ===================================================================
 
-def _run_batch_gemini(client, entries, json_mode, display_name, poll_interval,
-                      thinking=False, thinking_budget=0,
-                      existing_batch_id=None, on_batch_created=None):
+
+def _run_batch_gemini(
+    client,
+    entries,
+    json_mode,
+    display_name,
+    poll_interval,
+    thinking=False,
+    thinking_budget=0,
+    existing_batch_id=None,
+    on_batch_created=None,
+):
     """Gemini batch: upload JSONL, submit, poll, download.
 
     If existing_batch_id is set, skip upload+submit and retrieve that job.
     """
     import tempfile
+
     from tutorsim.config import get_batch_timeout
+
     gemini_client = client._client
     jsonl_path = None
 
@@ -832,17 +1005,22 @@ def _run_batch_gemini(client, entries, json_mode, display_name, poll_interval,
         batch_job = gemini_client.batches.get(name=existing_batch_id)
     else:
         # Write Gemini-format JSONL to temp file
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False,
-                                          encoding="utf-8") as f:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+        ) as f:
             for entry in entries:
-                key, prompt_text, entry_json_mode, entry_max_tokens, images = _extract_entry(entry)
+                key, prompt_text, entry_json_mode, entry_max_tokens, images = (
+                    _extract_entry(entry)
+                )
                 # Gemini has no explicit batch cache API; concatenate prefix (auto-cache).
                 cacheable_prefix = entry.get("cacheable_prefix")
                 effective_prompt = (cacheable_prefix or "") + prompt_text
                 if images:
                     image_blocks = _build_image_blocks_gemini(images)
                     parts = _interleave_text_and_images(
-                        effective_prompt, image_blocks, lambda s: {"text": s},
+                        effective_prompt,
+                        image_blocks,
+                        lambda s: {"text": s},
                     )
                 else:
                     parts = [{"text": effective_prompt}]
@@ -850,7 +1028,9 @@ def _run_batch_gemini(client, entries, json_mode, display_name, poll_interval,
                     "key": key,
                     "request": {
                         "contents": [{"parts": parts, "role": "user"}],
-                        "generation_config": entry["request"].get("generation_config", {}),
+                        "generation_config": entry["request"].get(
+                            "generation_config", {}
+                        ),
                     },
                 }
                 f.write(json.dumps(gem_entry, ensure_ascii=False) + "\n")
@@ -859,10 +1039,7 @@ def _run_batch_gemini(client, entries, json_mode, display_name, poll_interval,
         logger.info("Uploading batch request file...")
         uploaded_file = gemini_client.files.upload(
             file=jsonl_path,
-            config=types.UploadFileConfig(
-                display_name=display_name,
-                mime_type="jsonl"
-            )
+            config=types.UploadFileConfig(display_name=display_name, mime_type="jsonl"),
         )
         logger.info("Uploaded file: %s", uploaded_file.name)
 
@@ -880,8 +1057,10 @@ def _run_batch_gemini(client, entries, json_mode, display_name, poll_interval,
         poll_start = time.monotonic()
         batch_timeout = get_batch_timeout()
         completed_states = {
-            "JOB_STATE_SUCCEEDED", "JOB_STATE_FAILED",
-            "JOB_STATE_CANCELLED", "JOB_STATE_EXPIRED",
+            "JOB_STATE_SUCCEEDED",
+            "JOB_STATE_FAILED",
+            "JOB_STATE_CANCELLED",
+            "JOB_STATE_EXPIRED",
         }
         while batch_job.state.name not in completed_states:
             if time.monotonic() - poll_start > batch_timeout:
@@ -892,7 +1071,8 @@ def _run_batch_gemini(client, entries, json_mode, display_name, poll_interval,
             logger.info(
                 "Batch in progress: %s (%dm elapsed, next poll in %ds)",
                 batch_job.state.name,
-                int(time.monotonic() - poll_start) // 60, poll_interval,
+                int(time.monotonic() - poll_start) // 60,
+                poll_interval,
             )
             time.sleep(poll_interval)
             batch_job = gemini_client.batches.get(name=batch_job.name)
@@ -949,15 +1129,27 @@ def _run_batch_gemini(client, entries, json_mode, display_name, poll_interval,
 # OpenAI Batch API
 # ===================================================================
 
-def _run_batch_openai(client, entries, json_mode, display_name, poll_interval,
-                      thinking=False, thinking_budget=0, reasoning_effort="",
-                      existing_batch_id=None, on_batch_created=None):
+
+def _run_batch_openai(
+    client,
+    entries,
+    json_mode,
+    display_name,
+    poll_interval,
+    thinking=False,
+    thinking_budget=0,
+    reasoning_effort="",
+    existing_batch_id=None,
+    on_batch_created=None,
+):
     """OpenAI batch: upload JSONL, create batch, poll, download results.
 
     If existing_batch_id is set, skip upload+create and retrieve that batch.
     """
     import tempfile
+
     from tutorsim.config import get_batch_timeout
+
     openai_client = client._client
     max_tokens = MAX_OUTPUT_TOKENS["openai"]
     jsonl_path = None
@@ -966,10 +1158,13 @@ def _run_batch_openai(client, entries, json_mode, display_name, poll_interval,
         batch_job = openai_client.batches.retrieve(existing_batch_id)
     else:
         # Write OpenAI-format JSONL
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False,
-                                          encoding="utf-8") as f:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+        ) as f:
             for entry in entries:
-                key, prompt_text, entry_json_mode, entry_max_tokens, images = _extract_entry(entry)
+                key, prompt_text, entry_json_mode, entry_max_tokens, images = (
+                    _extract_entry(entry)
+                )
                 if not entry_max_tokens or entry_max_tokens > max_tokens:
                     entry_max_tokens = max_tokens
 
@@ -980,10 +1175,13 @@ def _run_batch_openai(client, entries, json_mode, display_name, poll_interval,
 
                 if images:
                     image_blocks = _build_image_blocks_openai(
-                        images, use_url=_should_use_presigned_url(),
+                        images,
+                        use_url=_should_use_presigned_url(),
                     )
                     content = _interleave_text_and_images(
-                        effective_prompt, image_blocks, lambda s: {"type": "text", "text": s},
+                        effective_prompt,
+                        image_blocks,
+                        lambda s: {"type": "text", "text": s},
                     )
                 else:
                     content = effective_prompt
@@ -1035,7 +1233,8 @@ def _run_batch_openai(client, entries, json_mode, display_name, poll_interval,
             logger.info(
                 "Batch in progress: %s (%dm elapsed, next poll in %ds)",
                 batch_job.status,
-                int(time.monotonic() - poll_start) // 60, poll_interval,
+                int(time.monotonic() - poll_start) // 60,
+                poll_interval,
             )
             time.sleep(poll_interval)
             batch_job = openai_client.batches.retrieve(batch_job.id)
@@ -1092,11 +1291,21 @@ def _run_batch_openai(client, entries, json_mode, display_name, poll_interval,
 # Anthropic Batch API
 # ===================================================================
 
-def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval,
-                         thinking=False, thinking_budget=0, reasoning_effort="",
-                         effort="",
-                         enable_cache=False,
-                         existing_batch_id=None, on_batch_created=None):
+
+def _run_batch_anthropic(
+    client,
+    entries,
+    json_mode,
+    display_name,
+    poll_interval,
+    thinking=False,
+    thinking_budget=0,
+    reasoning_effort="",
+    effort="",
+    enable_cache=False,
+    existing_batch_id=None,
+    on_batch_created=None,
+):
     """Anthropic batch: create message batch, poll, stream results.
 
     If existing_batch_id is set, skip submission and retrieve that batch.
@@ -1105,7 +1314,8 @@ def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval
     """
     from anthropic.types.message_create_params import MessageCreateParamsNonStreaming
     from anthropic.types.messages.batch_create_params import Request
-    from tutorsim.config import get_retry_config, get_batch_timeout
+
+    from tutorsim.config import get_batch_timeout, get_retry_config
 
     anthropic_client = client._client
     max_tokens = MAX_OUTPUT_TOKENS["anthropic"]
@@ -1124,7 +1334,9 @@ def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval
         message_batch = anthropic_client.messages.batches.retrieve(existing_batch_id)
     else:
         thinking_param = (
-            _anthropic_thinking_param(client.model, thinking_budget) if thinking else None
+            _anthropic_thinking_param(client.model, thinking_budget)
+            if thinking
+            else None
         )
         thinking_min = 0
         if thinking_param is not None and thinking_param.get("type") == "enabled":
@@ -1133,7 +1345,9 @@ def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval
 
         requests = []
         for i, entry in enumerate(entries):
-            key, prompt_text, entry_json_mode, entry_max_tokens, images = _extract_entry(entry)
+            key, prompt_text, entry_json_mode, entry_max_tokens, images = (
+                _extract_entry(entry)
+            )
             if not entry_max_tokens or entry_max_tokens > max_tokens:
                 entry_max_tokens = max_tokens
             if thinking_min and entry_max_tokens < thinking_min:
@@ -1143,20 +1357,30 @@ def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval
 
             if images:
                 image_blocks = _build_image_blocks_anthropic(
-                    images, use_url=_should_use_presigned_url(), enable_cache=enable_cache,
+                    images,
+                    use_url=_should_use_presigned_url(),
+                    enable_cache=enable_cache,
                 )
                 content = _interleave_text_and_images(
-                    prompt_text, image_blocks, lambda s: {"type": "text", "text": s},
+                    prompt_text,
+                    image_blocks,
+                    lambda s: {"type": "text", "text": s},
                 )
                 if cacheable_prefix is not None:
                     content = [
-                        {"type": "text", "text": cacheable_prefix,
-                         "cache_control": {"type": "ephemeral"}},
+                        {
+                            "type": "text",
+                            "text": cacheable_prefix,
+                            "cache_control": {"type": "ephemeral"},
+                        },
                     ] + content
             elif cacheable_prefix is not None:
                 content = [
-                    {"type": "text", "text": cacheable_prefix,
-                     "cache_control": {"type": "ephemeral"}},
+                    {
+                        "type": "text",
+                        "text": cacheable_prefix,
+                        "cache_control": {"type": "ephemeral"},
+                    },
                     {"type": "text", "text": prompt_text},
                 ]
             else:
@@ -1177,13 +1401,19 @@ def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval
                 params["thinking"] = thinking_param
             # effort goes inside output_config, mirroring the sync path
             # (_generate_anthropic). Haiku 4.5 rejects effort -- skip there.
-            if effort and client.model and not client.model.startswith("claude-haiku-4-5"):
+            if (
+                effort
+                and client.model
+                and not client.model.startswith("claude-haiku-4-5")
+            ):
                 params["output_config"] = {"effort": effort}
 
-            requests.append(Request(
-                custom_id=f"r{i}",
-                params=MessageCreateParamsNonStreaming(**params),
-            ))
+            requests.append(
+                Request(
+                    custom_id=f"r{i}",
+                    params=MessageCreateParamsNonStreaming(**params),
+                )
+            )
 
         logger.info("Submitting batch (%d requests)...", len(requests))
         retry_cfg = get_retry_config()
@@ -1191,13 +1421,20 @@ def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval
         base_delay = retry_cfg.get("base_delay", 5)
         for attempt in range(max_retries):
             try:
-                message_batch = anthropic_client.messages.batches.create(requests=requests)
+                message_batch = anthropic_client.messages.batches.create(
+                    requests=requests
+                )
                 break
             except Exception as e:
                 if attempt < max_retries - 1:
-                    delay = base_delay * (2 ** attempt)
-                    logger.warning("Batch submit error (attempt %d/%d): %s. Retrying in %ds...",
-                                   attempt + 1, max_retries, e, delay)
+                    delay = base_delay * (2**attempt)
+                    logger.warning(
+                        "Batch submit error (attempt %d/%d): %s. Retrying in %ds...",
+                        attempt + 1,
+                        max_retries,
+                        e,
+                        delay,
+                    )
                     time.sleep(delay)
                 else:
                     raise
@@ -1215,8 +1452,10 @@ def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval
             )
         logger.info(
             "Batch in progress: %s, %s (%dm elapsed, next poll in %ds)",
-            message_batch.processing_status, message_batch.request_counts,
-            int(time.monotonic() - poll_start) // 60, poll_interval,
+            message_batch.processing_status,
+            message_batch.request_counts,
+            int(time.monotonic() - poll_start) // 60,
+            poll_interval,
         )
         time.sleep(poll_interval)
         message_batch = anthropic_client.messages.batches.retrieve(message_batch.id)
@@ -1238,7 +1477,8 @@ def _run_batch_anthropic(client, entries, json_mode, display_name, poll_interval
             usage = {
                 "input_tokens": message.usage.input_tokens or 0,
                 "output_tokens": message.usage.output_tokens or 0,
-                "total_tokens": (message.usage.input_tokens or 0) + (message.usage.output_tokens or 0),
+                "total_tokens": (message.usage.input_tokens or 0)
+                + (message.usage.output_tokens or 0),
             }
             raw_entries[key] = {"text": text, "usage": usage}
         else:

--- a/src/tutorsim/config.py
+++ b/src/tutorsim/config.py
@@ -1,7 +1,7 @@
 """Config loading and tutor/student registries for tutorsim."""
 
-from dataclasses import dataclass
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -9,7 +9,6 @@ import yaml
 
 from tutorsim.client import infer_provider
 from tutorsim.resources import resource_text
-
 
 _CONFIG_CACHE = {}
 _TUTOR_REGISTRY: dict[str, callable] = {}
@@ -167,8 +166,7 @@ def resolve_model(model_id: str, config_path: str | os.PathLike | None = None) -
     if model_id not in cfg["models"]:
         valid_ids = list(cfg["models"].keys())
         raise ValueError(
-            f"Model '{model_id}' not in roster. "
-            f"Valid models: {', '.join(valid_ids)}"
+            f"Model '{model_id}' not in roster. Valid models: {', '.join(valid_ids)}"
         )
     provider = infer_provider(model_id)
     env = cfg["providers"][provider]["env"]
@@ -247,6 +245,7 @@ class RunConfig:
         resolved_tutors: Dict[model_id -> kwargs dict] for resolved tutors.
         config_source: Where the config was loaded from.
     """
+
     tutors: list[str]
     modes: list[str]
     dataset: str | None

--- a/src/tutorsim/conversation.py
+++ b/src/tutorsim/conversation.py
@@ -2,14 +2,15 @@
 
 Provides a synchronous per-scenario loop and a round-based batch loop.
 """
+
 import logging
 import math
-from dataclasses import dataclass, field, fields, asdict
+from dataclasses import asdict, dataclass, field, fields
 from types import SimpleNamespace
 
-from tutorsim.tutor import build_tutor_system_prompt, resolve_tutor
-from tutorsim.student import build_student_system_prompt, resolve_student
 from tutorsim.moments import Moment, _build_reference_transcript
+from tutorsim.student import build_student_system_prompt, resolve_student
+from tutorsim.tutor import build_tutor_system_prompt, resolve_tutor
 
 logger = logging.getLogger(__name__)
 
@@ -28,16 +29,25 @@ NEXT_PROBLEM_TOKEN = "[NEXT_PROBLEM]"  # legacy alias (v5 and earlier prompts)
 # Transcript dataclass (renamed from Exchange)
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class Transcript:
     scenario_id: str
     tutor_model: str
     generated_turns: list[dict] = field(default_factory=list)
     tutor_usage: dict = field(
-        default_factory=lambda: {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        default_factory=lambda: {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        }
     )
     student_usage: dict = field(
-        default_factory=lambda: {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        default_factory=lambda: {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        }
     )
     tutor_latencies: list[float] = field(default_factory=list)
     student_latencies: list[float] = field(default_factory=list)
@@ -62,6 +72,7 @@ class Transcript:
 # Private helpers
 # ---------------------------------------------------------------------------
 
+
 def _parse_tutor_tokens(text: str) -> tuple[str, bool, bool]:
     """Strip tutor control tokens and report which were present.
 
@@ -72,8 +83,7 @@ def _parse_tutor_tokens(text: str) -> tuple[str, bool, bool]:
     has_end = END_TOKEN in text
     has_change = (PROBLEM_CHANGE_TOKEN in text) or (NEXT_PROBLEM_TOKEN in text)
     cleaned = (
-        text
-        .replace(END_TOKEN, "")
+        text.replace(END_TOKEN, "")
         .replace(PROBLEM_CHANGE_TOKEN, "")
         .replace(NEXT_PROBLEM_TOKEN, "")
         .rstrip()
@@ -124,6 +134,7 @@ def _append_turns_to_extra(
 # Transcript prefix formatter
 # ---------------------------------------------------------------------------
 
+
 def _format_transcript_prefix(context: list[dict]) -> str:
     """Format scenario.context turns into 'Turn N. ROLE: text' string.
 
@@ -143,6 +154,7 @@ def _format_transcript_prefix(context: list[dict]) -> str:
 # ---------------------------------------------------------------------------
 # Role prompt builder
 # ---------------------------------------------------------------------------
+
 
 def _build_role_prompt(
     role: str,
@@ -194,6 +206,7 @@ def _build_role_prompt(
 # the runtime consumes them and never generates its own)
 # ---------------------------------------------------------------------------
 
+
 def _frozen_persona(scenario: Moment) -> str:
     """Return the moment's frozen student persona, or raise.
 
@@ -215,6 +228,7 @@ def _frozen_persona(scenario: Moment) -> str:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def run_conversation(
     scenario: Moment,
@@ -530,13 +544,19 @@ def run_conversations_batch(
             scenario_images = (images_by_scenario or {}).get(sid)
             tutor_entries.append(
                 build_batch_entry(
-                    sid, tail, json_mode=False, max_tokens=tutor_max_tokens,
-                    images=scenario_images, cacheable_prefix=head,
+                    sid,
+                    tail,
+                    json_mode=False,
+                    max_tokens=tutor_max_tokens,
+                    images=scenario_images,
+                    cacheable_prefix=head,
                 )
             )
 
         tutor_raw = run_batch(
-            tutor_client, tutor_entries, json_mode=False,
+            tutor_client,
+            tutor_entries,
+            json_mode=False,
             display_name=f"tutor_round_{round_num + 1}",
             poll_interval=poll_interval,
             **tutor_gen_kwargs,
@@ -562,7 +582,11 @@ def run_conversations_batch(
                 messages = ["..."]
             if messages:
                 extras[sid], next_turns[sid] = _append_turns_to_extra(
-                    transcript, messages, "TUTOR", extras[sid], next_turns[sid],
+                    transcript,
+                    messages,
+                    "TUTOR",
+                    extras[sid],
+                    next_turns[sid],
                 )
 
             if ended:
@@ -610,13 +634,19 @@ def run_conversations_batch(
             scenario_images = (images_by_scenario or {}).get(sid)
             student_entries.append(
                 build_batch_entry(
-                    sid, tail, json_mode=False, max_tokens=student_max_tokens,
-                    images=scenario_images, cacheable_prefix=head,
+                    sid,
+                    tail,
+                    json_mode=False,
+                    max_tokens=student_max_tokens,
+                    images=scenario_images,
+                    cacheable_prefix=head,
                 )
             )
 
         student_raw = run_batch(
-            student_client, student_entries, json_mode=False,
+            student_client,
+            student_entries,
+            json_mode=False,
             display_name=f"student_round_{round_num + 1}",
             poll_interval=poll_interval,
             **student_gen_kwargs,
@@ -638,7 +668,11 @@ def run_conversations_batch(
 
             messages = _split_messages(result["text"]) or ["..."]
             extras[sid], next_turns[sid] = _append_turns_to_extra(
-                transcript, messages, "STUDENT", extras[sid], next_turns[sid],
+                transcript,
+                messages,
+                "STUDENT",
+                extras[sid],
+                next_turns[sid],
             )
 
             # After the student batch in round_num, each active scenario has

--- a/src/tutorsim/logging_setup.py
+++ b/src/tutorsim/logging_setup.py
@@ -11,6 +11,7 @@ urllib3, botocore, ...) do not flood the output at INFO/DEBUG.
 
 The file handler appends, so a resumed run accumulates into the same file.
 """
+
 import argparse
 import contextvars
 import logging
@@ -69,7 +70,7 @@ def logging_args_parent() -> argparse.ArgumentParser:
         dest="log_level",
         metavar="LEVEL",
         help="Log level: DEBUG, INFO, WARNING, or ERROR "
-             f"(default: INFO, or ${LOG_LEVEL_ENV})",
+        f"(default: INFO, or ${LOG_LEVEL_ENV})",
     )
     parent.add_argument(
         "--log-file",
@@ -77,7 +78,7 @@ def logging_args_parent() -> argparse.ArgumentParser:
         dest="log_file",
         metavar="FILE",
         help="Also append logs to FILE; recommended for reproducibility "
-             f"(default: ${LOG_FILE_ENV} if set)",
+        f"(default: ${LOG_FILE_ENV} if set)",
     )
     return parent
 

--- a/src/tutorsim/logging_setup.py
+++ b/src/tutorsim/logging_setup.py
@@ -210,6 +210,9 @@ def per_run_log_file(
     handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
     handler.setFormatter(logging.Formatter(_FILE_FORMAT, datefmt=_DATE_FORMAT))
     handler.addFilter(_CellTagFilter())
+    # Registered ids assume the threads outlive the block: a recycled id from a
+    # dead registered thread would wrongly pass this filter. The opening thread
+    # and worker-pool threads are long-lived, so that holds in practice.
     thread_ids = {threading.get_ident()}
     if current_thread_only:
         handler.addFilter(lambda record: record.thread in thread_ids)

--- a/src/tutorsim/moments.py
+++ b/src/tutorsim/moments.py
@@ -11,7 +11,7 @@ and are never constructed at runtime (see ``tutorsim_build/`` for that).
 import hashlib
 import json
 import logging
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +47,7 @@ def _missing_dataset_message(path: Path) -> str:
 # Hashing
 # ---------------------------------------------------------------------------
 
+
 def file_sha256(path: str | Path) -> str:
     """Return the SHA-256 hex digest for a file."""
     digest = hashlib.sha256()
@@ -64,7 +65,9 @@ def records_content_hash(records: list[dict]) -> str:
     """
     digest = hashlib.sha256()
     for rec in records:
-        digest.update(json.dumps(rec, sort_keys=True, ensure_ascii=False).encode("utf-8"))
+        digest.update(
+            json.dumps(rec, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        )
         digest.update(b"\n")
     return digest.hexdigest()
 
@@ -72,6 +75,7 @@ def records_content_hash(records: list[dict]) -> str:
 # ---------------------------------------------------------------------------
 # Moment
 # ---------------------------------------------------------------------------
+
 
 def _normalize_cut_votes(value: Any) -> dict:
     """Normalize provenance.cut_votes to its internal dict form.
@@ -126,6 +130,7 @@ class Moment:
 # ---------------------------------------------------------------------------
 # Loading
 # ---------------------------------------------------------------------------
+
 
 def _read_moments_jsonl(path: str | Path) -> list[Moment]:
     """Read a moments.jsonl file into Moment objects, in file order."""
@@ -255,7 +260,9 @@ def validate_dataset(release_dir: str | Path) -> dict:
         )
 
     # Schema v2: every record must carry the frozen student persona.
-    traitless = [m.id for m in moments if not (m.student.get("trait") or {}).get("persona")]
+    traitless = [
+        m.id for m in moments if not (m.student.get("trait") or {}).get("persona")
+    ]
     if traitless:
         raise ValueError(
             f"{len(traitless)} moment(s) have no student.trait persona "
@@ -276,6 +283,7 @@ def validate_dataset(release_dir: str | Path) -> dict:
 # ---------------------------------------------------------------------------
 # Reference transcript (runtime fallback for batch mode; reused by build)
 # ---------------------------------------------------------------------------
+
 
 def _build_reference_transcript(conversation: dict, cut_turn: int) -> str:
     """Format the post-cut real human turns from a full conversation.

--- a/src/tutorsim/report.py
+++ b/src/tutorsim/report.py
@@ -28,10 +28,10 @@ No module-level SDK imports.
 # ---------------------------------------------------------------------------
 
 _ACTION_LABEL_TO_DIMENSIONS = {
-    "both":        ("yes", "yes"),
+    "both": ("yes", "yes"),
     "scaffolding": ("yes", "no"),
-    "rigor":       ("no",  "yes"),
-    "neither":     ("no",  "no"),
+    "rigor": ("no", "yes"),
+    "neither": ("no", "no"),
 }
 
 
@@ -42,6 +42,7 @@ def _to_dims(label):
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def aggregate(scenarios: list, annotations: list) -> dict:
     """Compute the paper's three metrics from scored annotations.
@@ -95,9 +96,9 @@ def aggregate(scenarios: list, annotations: list) -> dict:
     # already excluded from n_clean_yes (clean requires no over-scaffold), so
     # subtracting it again counted it twice. The subtraction was removed;
     # scaf_over_yes is kept as a reported component only (not in the score).
-    scaf_clean_yes = 0    # scaffold-gold + action right + no over-scaffold
-    scaf_over_yes = 0     # scaffold-gold + over-scaffold emitted (reported, not scored)
-    rig_clean_yes = 0     # rigor-gold + action right + no over-scaffold
+    scaf_clean_yes = 0  # scaffold-gold + action right + no over-scaffold
+    scaf_over_yes = 0  # scaffold-gold + over-scaffold emitted (reported, not scored)
+    rig_clean_yes = 0  # rigor-gold + action right + no over-scaffold
 
     for scenario, annotation in zip(scenarios, annotations):
         n_total += 1
@@ -185,39 +186,39 @@ def leaderboard_row(summary_or_metrics: dict) -> dict:
 
 _LEADERBOARD_COLS = [
     # (summary_key, header_label)
-    ("tutor_model",             "tutor_model"),
-    ("mode",                    "mode"),
-    ("n",                       "n"),
+    ("tutor_model", "tutor_model"),
+    ("mode", "mode"),
+    ("n", "n"),
     ("appropriate_scaffolding", "appropriate_scaffolding"),
-    ("appropriate_rigor",       "appropriate_rigor"),
-    ("avoids_overscaffold",     "avoids_overscaffold"),
-    ("tutor_lat_p50",           "tutor_lat_p50"),
-    ("tutor_lat_p95",           "tutor_lat_p95"),
-    ("tokens_total",            "tokens_total"),
+    ("appropriate_rigor", "appropriate_rigor"),
+    ("avoids_overscaffold", "avoids_overscaffold"),
+    ("tutor_lat_p50", "tutor_lat_p50"),
+    ("tutor_lat_p95", "tutor_lat_p95"),
+    ("tokens_total", "tokens_total"),
 ]
 
 
 def _extract_row(summary: dict) -> dict:
     """Pull the leaderboard-column values out of a run summary dict."""
-    cal_s  = (summary.get("scaffold_calibrated") or {})
-    cal_r  = (summary.get("rigor_calibrated")    or {})
-    over   = (summary.get("overscaffold")         or {})
-    lat    = ((summary.get("latency")             or {}).get("tutor") or {})
-    tokens = ((summary.get("tokens")              or {}).get("total") or {})
+    cal_s = summary.get("scaffold_calibrated") or {}
+    cal_r = summary.get("rigor_calibrated") or {}
+    over = summary.get("overscaffold") or {}
+    lat = (summary.get("latency") or {}).get("tutor") or {}
+    tokens = (summary.get("tokens") or {}).get("total") or {}
 
     over_rate = over.get("rate")
     avoids = (1.0 - over_rate) if isinstance(over_rate, (int, float)) else None
 
     return {
-        "tutor_model":             summary.get("tutor_model", ""),
-        "mode":                    summary.get("mode", ""),
-        "n":                       summary.get("n_scenarios", 0),
+        "tutor_model": summary.get("tutor_model", ""),
+        "mode": summary.get("mode", ""),
+        "n": summary.get("n_scenarios", 0),
         "appropriate_scaffolding": cal_s.get("score"),
-        "appropriate_rigor":       cal_r.get("score"),
-        "avoids_overscaffold":     avoids,
-        "tutor_lat_p50":           lat.get("p50_seconds"),
-        "tutor_lat_p95":           lat.get("p95_seconds"),
-        "tokens_total":            tokens.get("total_tokens"),
+        "appropriate_rigor": cal_r.get("score"),
+        "avoids_overscaffold": avoids,
+        "tutor_lat_p50": lat.get("p50_seconds"),
+        "tutor_lat_p95": lat.get("p95_seconds"),
+        "tokens_total": tokens.get("total_tokens"),
     }
 
 
@@ -269,12 +270,12 @@ def leaderboard(runs: list) -> tuple:
 
     rows.sort(key=_sort_key)
 
-    col_keys  = [k for k, _ in _LEADERBOARD_COLS]
+    col_keys = [k for k, _ in _LEADERBOARD_COLS]
     col_heads = [h for _, h in _LEADERBOARD_COLS]
 
     # --- Markdown ---
     header = "| " + " | ".join(col_heads) + " |"
-    sep    = "|" + "|".join("---" for _ in col_heads) + "|"
+    sep = "|" + "|".join("---" for _ in col_heads) + "|"
     md_lines = [header, sep]
     for r in rows:
         cells = [_fmt_md(r.get(k)) for k in col_keys]
@@ -282,8 +283,9 @@ def leaderboard(runs: list) -> tuple:
     markdown = "\n".join(md_lines)
 
     # --- CSV ---
-    import io
     import csv as _csv
+    import io
+
     buf = io.StringIO()
     writer = _csv.writer(buf)
     writer.writerow(col_heads)
@@ -311,16 +313,18 @@ def format_run_summary(
     score is shown as ``mean ± std``.
     """
     trials = metrics.get("trials", 1)
-    core = metrics.get("mean", metrics)      # trials>1 nests the aggregate under "mean"
+    core = metrics.get("mean", metrics)  # trials>1 nests the aggregate under "mean"
     spread = metrics.get("spread") or {}
 
-    row = _extract_row({
-        **core,
-        "latency": metrics.get("latency"),
-        "tokens": metrics.get("tokens"),
-        "tutor_model": tutor_model,
-        "mode": mode,
-    })
+    row = _extract_row(
+        {
+            **core,
+            "latency": metrics.get("latency"),
+            "tokens": metrics.get("tokens"),
+            "tutor_model": tutor_model,
+            "mode": mode,
+        }
+    )
 
     def _sub(spread_dict, subkey, field):
         sub = spread_dict.get(subkey) if isinstance(spread_dict, dict) else None
@@ -347,9 +351,21 @@ def format_run_summary(
     lines.append("  " + "-" * 44)
 
     metric_rows = [
-        ("Appropriate Scaffolding", row.get("appropriate_scaffolding"), _sub(spread, "scaffold_calibrated", "score")),
-        ("Appropriate Rigor",       row.get("appropriate_rigor"),       _sub(spread, "rigor_calibrated", "score")),
-        ("Avoids Over-Scaffolding", row.get("avoids_overscaffold"),     _sub(spread, "overscaffold", "rate")),
+        (
+            "Appropriate Scaffolding",
+            row.get("appropriate_scaffolding"),
+            _sub(spread, "scaffold_calibrated", "score"),
+        ),
+        (
+            "Appropriate Rigor",
+            row.get("appropriate_rigor"),
+            _sub(spread, "rigor_calibrated", "score"),
+        ),
+        (
+            "Avoids Over-Scaffolding",
+            row.get("avoids_overscaffold"),
+            _sub(spread, "overscaffold", "rate"),
+        ),
     ]
     for label, value, std in metric_rows:
         lines.append(f"  {label:<26} {_fmt_metric(value, std)}")
@@ -391,6 +407,7 @@ def format_run_summary(
 # HTML viewer
 # ---------------------------------------------------------------------------
 
+
 def view(runs: list) -> str:
     """Build a self-contained HTML viewer for a list of run summaries.
 
@@ -416,21 +433,24 @@ def view(runs: list) -> str:
     payload_runs = []
     for s in runs:
         row = _extract_row(s)
-        payload_runs.append({
-            "tutor_model":             row["tutor_model"],
-            "mode":                    row["mode"],
-            "n":                       row["n"],
-            "appropriate_scaffolding": _safe(row["appropriate_scaffolding"]),
-            "appropriate_rigor":       _safe(row["appropriate_rigor"]),
-            "avoids_overscaffold":     _safe(row["avoids_overscaffold"]),
-            "tutor_lat_p50":           _safe(row["tutor_lat_p50"]),
-            "tutor_lat_p95":           _safe(row["tutor_lat_p95"]),
-            "tokens_total":            row["tokens_total"],
-        })
+        payload_runs.append(
+            {
+                "tutor_model": row["tutor_model"],
+                "mode": row["mode"],
+                "n": row["n"],
+                "appropriate_scaffolding": _safe(row["appropriate_scaffolding"]),
+                "appropriate_rigor": _safe(row["appropriate_rigor"]),
+                "avoids_overscaffold": _safe(row["avoids_overscaffold"]),
+                "tutor_lat_p50": _safe(row["tutor_lat_p50"]),
+                "tutor_lat_p95": _safe(row["tutor_lat_p95"]),
+                "tokens_total": row["tokens_total"],
+            }
+        )
 
     blob = _json.dumps(payload_runs, ensure_ascii=True)
 
-    html = r"""<!DOCTYPE html>
+    html = (
+        r"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -487,7 +507,9 @@ tr:hover td { background: #f9f9fc; }
 </table>
 
 <script>
-const RUNS = """ + blob + r""";
+const RUNS = """
+        + blob
+        + r""";
 
 function fmt(v, places) {
   if (v === null || v === undefined) return null;
@@ -562,4 +584,5 @@ render();
 </script>
 </body>
 </html>"""
+    )
     return html

--- a/src/tutorsim/results.py
+++ b/src/tutorsim/results.py
@@ -10,15 +10,15 @@ On-disk layout::
 
 All JSON is UTF-8.  Pass ``results_root`` to redirect to a tmp dir in tests.
 """
+
 import json
-import os
 from pathlib import Path
 from typing import Optional
-
 
 # ---------------------------------------------------------------------------
 # Run-id naming
 # ---------------------------------------------------------------------------
+
 
 def make_run_id(tutor: str, mode: str, dataset: str, date: str) -> str:
     """Build a self-documenting run id: ``{tutor}_{mode}_{dataset}_{date}``.
@@ -40,6 +40,7 @@ def make_run_id(tutor: str, mode: str, dataset: str, date: str) -> str:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 def _run_dir(run_id: str, results_root: str = "results") -> Path:
     return Path(results_root) / run_id
@@ -65,6 +66,7 @@ def _read_json(path: Path) -> Optional[dict]:
 # Config
 # ---------------------------------------------------------------------------
 
+
 def write_config(run_id: str, config: dict, results_root: str = "results") -> None:
     """Write ``config.json`` for *run_id*."""
     _write_json(_run_dir(run_id, results_root) / "config.json", config)
@@ -79,15 +81,18 @@ def read_config(run_id: str, results_root: str = "results") -> Optional[dict]:
 # Transcripts
 # ---------------------------------------------------------------------------
 
-def write_transcript(run_id: str, scenario_id: str, transcript_dict: dict,
-                     results_root: str = "results") -> None:
+
+def write_transcript(
+    run_id: str, scenario_id: str, transcript_dict: dict, results_root: str = "results"
+) -> None:
     """Write ``transcripts/<scenario_id>.json`` for *run_id*."""
     path = _run_dir(run_id, results_root) / "transcripts" / f"{scenario_id}.json"
     _write_json(path, transcript_dict)
 
 
-def read_transcript(run_id: str, scenario_id: str,
-                    results_root: str = "results") -> Optional[dict]:
+def read_transcript(
+    run_id: str, scenario_id: str, results_root: str = "results"
+) -> Optional[dict]:
     """Read transcript for *scenario_id*; returns ``None`` if missing."""
     path = _run_dir(run_id, results_root) / "transcripts" / f"{scenario_id}.json"
     return _read_json(path)
@@ -97,15 +102,18 @@ def read_transcript(run_id: str, scenario_id: str,
 # Scores
 # ---------------------------------------------------------------------------
 
-def write_score(run_id: str, scenario_id: str, annotation_dict: dict,
-                results_root: str = "results") -> None:
+
+def write_score(
+    run_id: str, scenario_id: str, annotation_dict: dict, results_root: str = "results"
+) -> None:
     """Write ``scores/<scenario_id>.json`` for *run_id*."""
     path = _run_dir(run_id, results_root) / "scores" / f"{scenario_id}.json"
     _write_json(path, annotation_dict)
 
 
-def read_score(run_id: str, scenario_id: str,
-               results_root: str = "results") -> Optional[dict]:
+def read_score(
+    run_id: str, scenario_id: str, results_root: str = "results"
+) -> Optional[dict]:
     """Read score for *scenario_id*; returns ``None`` if missing."""
     path = _run_dir(run_id, results_root) / "scores" / f"{scenario_id}.json"
     return _read_json(path)
@@ -114,6 +122,7 @@ def read_score(run_id: str, scenario_id: str,
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+
 
 def write_summary(run_id: str, summary: dict, results_root: str = "results") -> None:
     """Write ``summary.json`` for *run_id*."""
@@ -129,22 +138,24 @@ def read_summary(run_id: str, results_root: str = "results") -> Optional[dict]:
 # Resume guard
 # ---------------------------------------------------------------------------
 
+
 def is_done(run_id: str, scenario_id: str, results_root: str = "results") -> bool:
     """Return True iff BOTH transcript AND score exist for *scenario_id*.
 
     A scenario is considered done only when its transcript has been saved
     AND scoring is present — meaning nothing needs to be re-run.
     """
-    transcript_path = (_run_dir(run_id, results_root)
-                       / "transcripts" / f"{scenario_id}.json")
-    score_path = (_run_dir(run_id, results_root)
-                  / "scores" / f"{scenario_id}.json")
+    transcript_path = (
+        _run_dir(run_id, results_root) / "transcripts" / f"{scenario_id}.json"
+    )
+    score_path = _run_dir(run_id, results_root) / "scores" / f"{scenario_id}.json"
     return transcript_path.exists() and score_path.exists()
 
 
 # ---------------------------------------------------------------------------
 # Listing runs
 # ---------------------------------------------------------------------------
+
 
 def list_runs(results_root: str = "results") -> list[str]:
     """Return run_ids present on disk under *results_root*.

--- a/src/tutorsim/scoring.py
+++ b/src/tutorsim/scoring.py
@@ -15,7 +15,7 @@ No module-level SDK imports.
 import json
 import logging
 import re as _re
-from dataclasses import dataclass, asdict, field
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from tutorsim.resources import resource_text
@@ -32,6 +32,7 @@ VALID_ANNOTATION_TYPES = {"scaffolding", "rapport"}
 # Annotate-pass: excerpt builder
 # Benchmark forces context_window=0 (context_before=0, context_after=0).
 # ---------------------------------------------------------------------------
+
 
 def _format_excerpt(
     conversation: dict,
@@ -127,6 +128,7 @@ def _suggestion_text(situation_label_agg: str | None) -> str:
 #   - No screenshot support needed here
 # ---------------------------------------------------------------------------
 
+
 def _load_annotate_prompt(ann_type: str) -> str:
     """Load the scorer annotate prompt for the given annotation type."""
     return resource_text(f"{_SCORER_PROMPTS_DIR}/annotate/{ann_type}.md")
@@ -185,7 +187,9 @@ def _build_annotate_entries(
 
             prompt = prompt_cache[ann_type]
             prompt = prompt.replace("{annotator_style}", "")
-            prompt = prompt.replace("{suggestion}", _suggestion_text(det.get("situation_label_agg")))
+            prompt = prompt.replace(
+                "{suggestion}", _suggestion_text(det.get("situation_label_agg"))
+            )
             prompt = prompt.replace("{excerpt}", excerpt)
             prompt = prompt.replace("{turn_start}", str(turn_start))
             prompt = prompt.replace("{turn_end}", str(turn_end))
@@ -199,6 +203,7 @@ def _build_annotate_entries(
 # ---------------------------------------------------------------------------
 # Annotate-pass: parse and merge
 # ---------------------------------------------------------------------------
+
 
 def _parse_and_merge(
     raw_entries: dict,
@@ -242,7 +247,9 @@ def _parse_and_merge(
             parsed["_usage"] = data.get("usage", {})
             analyses[key] = parsed
         except json.JSONDecodeError as e:
-            errors.append({"key": key, "error": f"JSON parse error: {e}", "raw": text[:500]})
+            errors.append(
+                {"key": key, "error": f"JSON parse error: {e}", "raw": text[:500]}
+            )
 
     if errors:
         logger.warning("Parse errors: %d", len(errors))
@@ -254,7 +261,9 @@ def _parse_and_merge(
 
     for conv_id, conv_data in detections_by_conv.items():
         detections = conv_data.get("detections", [])
-        p1_usage = conv_data.get("usage", {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+        p1_usage = conv_data.get(
+            "usage", {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        )
         total_usage = dict(p1_usage)
 
         annotations = []
@@ -264,27 +273,33 @@ def _parse_and_merge(
 
             if key in analyses:
                 a = analyses[key]
-                annotations.append({
-                    "annotation_type": ann_type,
-                    "turn_start": det.get("turn_start"),
-                    "turn_end": det.get("turn_end"),
-                    "situation": a.get("situation", ""),
-                    "action": a.get("action", ""),
-                    "result": a.get("result", ""),
-                })
+                annotations.append(
+                    {
+                        "annotation_type": ann_type,
+                        "turn_start": det.get("turn_start"),
+                        "turn_end": det.get("turn_end"),
+                        "situation": a.get("situation", ""),
+                        "action": a.get("action", ""),
+                        "result": a.get("result", ""),
+                    }
+                )
 
                 p2_usage = a.get("_usage", {})
                 for field in ("input_tokens", "output_tokens", "total_tokens"):
-                    total_usage[field] = total_usage.get(field, 0) + p2_usage.get(field, 0)
+                    total_usage[field] = total_usage.get(field, 0) + p2_usage.get(
+                        field, 0
+                    )
             else:
-                annotations.append({
-                    "annotation_type": ann_type,
-                    "turn_start": det.get("turn_start", 0),
-                    "turn_end": det.get("turn_end", 0),
-                    "situation": "",
-                    "action": "[Analysis unavailable -- batch failed for this moment]",
-                    "result": "",
-                })
+                annotations.append(
+                    {
+                        "annotation_type": ann_type,
+                        "turn_start": det.get("turn_start", 0),
+                        "turn_end": det.get("turn_end", 0),
+                        "situation": "",
+                        "action": "[Analysis unavailable -- batch failed for this moment]",
+                        "result": "",
+                    }
+                )
 
         results[conv_id] = {
             "conversation_id": conv_id,
@@ -292,8 +307,10 @@ def _parse_and_merge(
             "usage": total_usage,
             "pass1_detections": len(detections),
             "pass2_analyzed": sum(
-                1 for i, d in enumerate(detections)
-                if f"{conv_id}__{d.get('annotation_type', 'scaffolding')}__{i}" in analyses
+                1
+                for i, d in enumerate(detections)
+                if f"{conv_id}__{d.get('annotation_type', 'scaffolding')}__{i}"
+                in analyses
             ),
         }
 
@@ -304,6 +321,7 @@ def _parse_and_merge(
 # Annotation dataclass
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class Annotation:
     """A scored annotation produced by the 3-pass annotator pipeline.
@@ -313,16 +331,22 @@ class Annotation:
     """
 
     scenario_id: str
-    annotation_type: str          # "scaffolding" | "rapport"
+    annotation_type: str  # "scaffolding" | "rapport"
     turn_start: int
     turn_end: int
     situation: str
     action: str
     result: str
-    action_decomposed: list       # action decomposition phrases
-    overscaffold_decomposed: list # over-scaffolding decomposition phrases
-    action_label: str             # "scaffolding" | "rigor" | "both" | "neither" | "unclear"
-    usage: dict = field(default_factory=lambda: {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+    action_decomposed: list  # action decomposition phrases
+    overscaffold_decomposed: list  # over-scaffolding decomposition phrases
+    action_label: str  # "scaffolding" | "rigor" | "both" | "neither" | "unclear"
+    usage: dict = field(
+        default_factory=lambda: {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        }
+    )
 
     def to_dict(self) -> dict[str, Any]:
         """Return all fields as a plain dict."""
@@ -332,6 +356,7 @@ class Annotation:
 # ---------------------------------------------------------------------------
 # Synthetic conversation builder
 # ---------------------------------------------------------------------------
+
 
 def _build_synthetic_conversation(
     scenario: Any,
@@ -357,23 +382,27 @@ def _build_synthetic_conversation(
     # Prefix turns from scenario.context: [{turn_number, role, text}]
     # Role stored lowercase in new schema; annotator pipeline expects uppercase.
     for ctx_turn in scenario.context:
-        turns.append({
-            "turn_number": ctx_turn["turn_number"],
-            "role": ctx_turn["role"].upper(),
-            "text": ctx_turn["text"],
-            "type": "DIALOGUE",
-            "timestamp": "",
-        })
+        turns.append(
+            {
+                "turn_number": ctx_turn["turn_number"],
+                "role": ctx_turn["role"].upper(),
+                "text": ctx_turn["text"],
+                "type": "DIALOGUE",
+                "timestamp": "",
+            }
+        )
 
     # Generated turns from transcript.generated_turns: already {turn_number, role, text}
     for gen_turn in transcript.generated_turns:
-        turns.append({
-            "turn_number": gen_turn["turn_number"],
-            "role": gen_turn["role"],
-            "text": gen_turn["text"],
-            "type": "DIALOGUE",
-            "timestamp": "",
-        })
+        turns.append(
+            {
+                "turn_number": gen_turn["turn_number"],
+                "role": gen_turn["role"],
+                "text": gen_turn["text"],
+                "type": "DIALOGUE",
+                "timestamp": "",
+            }
+        )
 
     # ---- Build conversation dict (remapped: conversation_id = scenario.id) ----
     # Original annotator_bridge used scenario.conv_id as conversation_id, then
@@ -400,9 +429,7 @@ def _build_synthetic_conversation(
 
     cut_turn = scenario.provenance.get("cut_turn", "?")
     hint = scenario.rubric.get("hint", "")
-    description = (
-        f"AI tutor continuation from cut at turn {cut_turn}: {hint}"
-    )
+    description = f"AI tutor continuation from cut at turn {cut_turn}: {hint}"
 
     # situation_label_agg from scenario.dimension (= rubric["gold"])
     situation_label_agg = scenario.dimension
@@ -504,7 +531,7 @@ def _parse_decomposed(text: str) -> "tuple[list[str], bool]":
         pass
 
     # Attempt 2: extract a bracketed array from surrounding text
-    m = _re.search(r'\[.*\]', text, _re.DOTALL)
+    m = _re.search(r"\[.*\]", text, _re.DOTALL)
     if m:
         try:
             parsed = json.loads(m.group(0))
@@ -516,21 +543,25 @@ def _parse_decomposed(text: str) -> "tuple[list[str], bool]":
     return [], True
 
 
-def _build_overscaffold_prompt(situation: str, action: str, result_text: str,
-                               template: str) -> "str | None":
+def _build_overscaffold_prompt(
+    situation: str, action: str, result_text: str, template: str
+) -> "str | None":
     """Build the over-scaffolding decomposition prompt for one annotation.
 
     Returns None when both action and result are junk -- there is no described
     tutor behavior or outcome to analyze, so the caller skips the API call and
     writes an empty facet list.
     """
-    if (action.strip().lower() in JUNK_TEXTS
-            and result_text.strip().lower() in JUNK_TEXTS):
+    if (
+        action.strip().lower() in JUNK_TEXTS
+        and result_text.strip().lower() in JUNK_TEXTS
+    ):
         return None
-    return (template
-            .replace("{situation}", situation)
-            .replace("{action}", action)
-            .replace("{result}", result_text))
+    return (
+        template.replace("{situation}", situation)
+        .replace("{action}", action)
+        .replace("{result}", result_text)
+    )
 
 
 def _build_decompose_entries(
@@ -586,13 +617,16 @@ def _build_decompose_entries(
                 if ann_type != "scaffolding":
                     continue
                 # Skip when both action and result are junk (no tutor behavior to analyze)
-                if (action.strip().lower() in JUNK_TEXTS
-                        and result_text.strip().lower() in JUNK_TEXTS):
+                if (
+                    action.strip().lower() in JUNK_TEXTS
+                    and result_text.strip().lower() in JUNK_TEXTS
+                ):
                     continue
-                prompt = (template
-                          .replace("{situation}", situation)
-                          .replace("{action}", action)
-                          .replace("{result}", result_text))
+                prompt = (
+                    template.replace("{situation}", situation)
+                    .replace("{action}", action)
+                    .replace("{result}", result_text)
+                )
                 key = f"overscaffold__{conv_id}__{idx}"
 
             entries.append(build_batch_entry(key, prompt, json_mode=True))
@@ -656,6 +690,7 @@ def _parse_action_label(text: str) -> tuple:
     Returns (label, had_error). Falls back to "unclear" if either dimension
     is missing or isn't "yes"/"no".
     """
+
     def _coerce(val) -> str | None:
         v = str(val).strip().lower()
         return v if v in ("yes", "no") else None
@@ -672,8 +707,12 @@ def _parse_action_label(text: str) -> tuple:
         pass
 
     if scaffolding is None or rigor is None:
-        m_scaf = _re.search(r'["\']?scaffolding["\']?\s*:\s*["\']?(yes|no)["\']?', text, _re.IGNORECASE)
-        m_rigor = _re.search(r'["\']?rigor["\']?\s*:\s*["\']?(yes|no)["\']?', text, _re.IGNORECASE)
+        m_scaf = _re.search(
+            r'["\']?scaffolding["\']?\s*:\s*["\']?(yes|no)["\']?', text, _re.IGNORECASE
+        )
+        m_rigor = _re.search(
+            r'["\']?rigor["\']?\s*:\s*["\']?(yes|no)["\']?', text, _re.IGNORECASE
+        )
         if scaffolding is None and m_scaf:
             scaffolding = m_scaf.group(1).lower()
         if rigor is None and m_rigor:
@@ -760,7 +799,9 @@ def _build_structure_entries(
                 skip_action.append((conv_id, idx))
             else:
                 key = f"action__{conv_id}__{idx}"
-                prompt = action_template.replace("{action_list}", _format_facet_list(action_facets))
+                prompt = action_template.replace(
+                    "{action_list}", _format_facet_list(action_facets)
+                )
                 action_entries.append(build_batch_entry(key, prompt, json_mode=True))
 
     return action_entries, skip_action
@@ -854,7 +895,8 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
     annotate_entries = _build_annotate_entries(conversations, detections)
     logger.info(
         "Classification pass 1/3 (annotate): %d entries, scorer=%s",
-        len(annotate_entries), scorer_model,
+        len(annotate_entries),
+        scorer_model,
     )
     annotate_raw = run_batch(
         client,
@@ -868,7 +910,9 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
 
     for sid, conv_data in parsed.items():
         if sid in usage_by_sid:
-            usage_by_sid[sid] = _sum_usage(usage_by_sid[sid], conv_data.get("usage", {}))
+            usage_by_sid[sid] = _sum_usage(
+                usage_by_sid[sid], conv_data.get("usage", {})
+            )
 
     # Build the results shape expected by _build_decompose_entries /
     # _build_structure_entries: {sid: {"annotations": [ann_dict, ...]}}
@@ -876,14 +920,16 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
     for sid in detections:
         annotations_list = parsed.get(sid, {}).get("annotations", [])
         if not annotations_list:
-            annotations_list = [{
-                "annotation_type": "scaffolding",
-                "turn_start": 0,
-                "turn_end": 0,
-                "situation": "",
-                "action": "[Analysis unavailable -- batch failed for this moment]",
-                "result": "",
-            }]
+            annotations_list = [
+                {
+                    "annotation_type": "scaffolding",
+                    "turn_start": 0,
+                    "turn_end": 0,
+                    "situation": "",
+                    "action": "[Analysis unavailable -- batch failed for this moment]",
+                    "result": "",
+                }
+            ]
         results[sid] = {"annotations": annotations_list}
 
     # -------------------------------------------------------------------------
@@ -892,8 +938,12 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
     # by key prefix to assign.
     # (Result decomposition was dropped along with student-outcome labelling.)
     # -------------------------------------------------------------------------
-    action_decomp_entries, action_decomp_locs = _build_decompose_entries(results, "action")
-    overscaffold_entries, overscaffold_locs = _build_decompose_entries(results, "overscaffold")
+    action_decomp_entries, action_decomp_locs = _build_decompose_entries(
+        results, "action"
+    )
+    overscaffold_entries, overscaffold_locs = _build_decompose_entries(
+        results, "overscaffold"
+    )
 
     decompose_entries = action_decomp_entries + overscaffold_entries
 
@@ -917,7 +967,9 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
             key = entry["key"]
             raw = decompose_raw.get(key, {})
             if conv_id in usage_by_sid:
-                usage_by_sid[conv_id] = _sum_usage(usage_by_sid[conv_id], raw.get("usage", {}))
+                usage_by_sid[conv_id] = _sum_usage(
+                    usage_by_sid[conv_id], raw.get("usage", {})
+                )
             text = raw.get("text", "")
             try:
                 parsed_val = json.loads(text) if text else []
@@ -929,7 +981,9 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
                 anns[idx][field_name] = facets if facets is not None else []
 
     _assign_decomposed(action_decomp_locs, action_decomp_entries, "action_decomposed")
-    _assign_decomposed(overscaffold_locs, overscaffold_entries, "overscaffold_decomposed")
+    _assign_decomposed(
+        overscaffold_locs, overscaffold_entries, "overscaffold_decomposed"
+    )
 
     # Ensure all annotations have decomposed fields (default [] for skipped ones).
     for conv_id, conv_data in results.items():
@@ -940,8 +994,8 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
     # -------------------------------------------------------------------------
     # Pass 3: Structure (action classification in one pooled batch)
     # -------------------------------------------------------------------------
-    action_struct_entries, skip_action = (
-        _build_structure_entries(results, target="scaffolding")
+    action_struct_entries, skip_action = _build_structure_entries(
+        results, target="scaffolding"
     )
     structure_entries = action_struct_entries
 
@@ -961,7 +1015,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
         structure_raw = {}
 
     # Apply default labels to skipped (no-facet) annotations.
-    for (conv_id, idx) in skip_action:
+    for conv_id, idx in skip_action:
         anns = results.get(conv_id, {}).get("annotations", [])
         if idx < len(anns):
             anns[idx]["action_label"] = DEFAULT_ACTION_LABEL
@@ -972,24 +1026,28 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
         for entry in entries:
             key = entry["key"]
             raw = structure_raw.get(key, {})
-            without_prefix = key[len(prefix):]
+            without_prefix = key[len(prefix) :]
             last_sep = without_prefix.rfind("__")
             if last_sep == -1:
                 continue
             conv_id = without_prefix[:last_sep]
-            idx_str = without_prefix[last_sep + 2:]
+            idx_str = without_prefix[last_sep + 2 :]
             try:
                 idx = int(idx_str)
             except ValueError:
                 continue
             if conv_id in usage_by_sid:
-                usage_by_sid[conv_id] = _sum_usage(usage_by_sid[conv_id], raw.get("usage", {}))
+                usage_by_sid[conv_id] = _sum_usage(
+                    usage_by_sid[conv_id], raw.get("usage", {})
+                )
             label, _ = parse_fn(raw.get("text", ""))
             anns = results.get(conv_id, {}).get("annotations", [])
             if idx < len(anns):
                 anns[idx][field_name] = label
 
-    _assign_labels(action_struct_entries, "action__", _parse_action_label, "action_label")
+    _assign_labels(
+        action_struct_entries, "action__", _parse_action_label, "action_label"
+    )
 
     # Ensure all annotations have label fields.
     for conv_id, conv_data in results.items():

--- a/src/tutorsim/student.py
+++ b/src/tutorsim/student.py
@@ -9,6 +9,7 @@ Public API:
     build_student_system_prompt(student_context, reference_transcript, persona) -> str
     resolve_student(student_id) -> dict
 """
+
 import logging
 
 from tutorsim.resources import resource_text
@@ -87,6 +88,7 @@ def build_student_system_prompt(
 # resolve_student (Task 4)
 # ---------------------------------------------------------------------------
 
+
 def resolve_student(student_id: str | None = None) -> dict:
     """Decide what the student is: registered callable or hosted model.
 
@@ -102,8 +104,8 @@ def resolve_student(student_id: str | None = None) -> dict:
         - kind == "registered": {"kind": "registered", "fn": <callable>}
         - kind == "hosted": {"kind": "hosted", "client": ModelClient, "kwargs": dict}
     """
-    from tutorsim.config import get_registered_student, student_spec
     from tutorsim.client import ModelClient
+    from tutorsim.config import get_registered_student, student_spec
 
     spec = student_spec()
     model = student_id or spec["model"]

--- a/src/tutorsim/taxonomy.py
+++ b/src/tutorsim/taxonomy.py
@@ -42,7 +42,7 @@ import importlib
 import json
 import logging
 import re
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from string import Template
 from typing import Any, Iterable, Iterator, Optional
@@ -288,9 +288,13 @@ CATEGORIES: list[dict[str, Any]] = [
 ]
 
 CATEGORY_LETTERS: list[str] = [c["letter"] for c in CATEGORIES]
-ORIENTATION_BY_LETTER: dict[str, str] = {c["letter"]: c["orientation"] for c in CATEGORIES}
+ORIENTATION_BY_LETTER: dict[str, str] = {
+    c["letter"]: c["orientation"] for c in CATEGORIES
+}
 NAME_BY_LETTER: dict[str, str] = {c["letter"]: c["name"] for c in CATEGORIES}
-DEFINITION_BY_LETTER: dict[str, str] = {c["letter"]: c["definition"] for c in CATEGORIES}
+DEFINITION_BY_LETTER: dict[str, str] = {
+    c["letter"]: c["definition"] for c in CATEGORIES
+}
 LAST_LETTER = CATEGORY_LETTERS[-1]
 
 
@@ -306,7 +310,7 @@ def _categories_block() -> str:
     """The frozen scheme rendered for prompt injection."""
     return "\n".join(
         f"{c['letter']}. {c['name']} -- {c['definition']}. "
-        f"Examples: " + "; ".join(f'\"{e}\"' for e in c["examples"][:4]) + "."
+        f"Examples: " + "; ".join(f'"{e}"' for e in c["examples"][:4]) + "."
         for c in CATEGORIES
     )
 
@@ -408,7 +412,10 @@ def filter_statement(statement: str) -> tuple[str, str, bool]:
 
 
 STRIP_REASONS: tuple[str, ...] = (
-    "non_tutor_actor", "pure_stance", "stance_negation", "non_action",
+    "non_tutor_actor",
+    "pure_stance",
+    "stance_negation",
+    "non_action",
 )
 
 
@@ -419,24 +426,25 @@ STRIP_REASONS: tuple[str, ...] = (
 # A Facet is one action statement with enough provenance to compute every
 # downstream view. Adapters yield Facet instances from each input format.
 
+
 @dataclass
 class Facet:
-    moment_id: str            # unique per (transcript, moment, annotator-or-scenario)
-    transcript_id: str        # parent transcript / conversation id
+    moment_id: str  # unique per (transcript, moment, annotator-or-scenario)
+    transcript_id: str  # parent transcript / conversation id
     turn_start: int
     turn_end: int
-    statement_index: int      # position within action_decomposed
-    statement: str            # the action_decomposed string itself
-    annotation_type: str      # always "scaffolding" after filtering
-    situation_label: str      # GT label of the moment: scaffolding|rigor|...
-    action_label: Optional[str] = None      # SAR's tutor-action call (LM only)
+    statement_index: int  # position within action_decomposed
+    statement: str  # the action_decomposed string itself
+    annotation_type: str  # always "scaffolding" after filtering
+    situation_label: str  # GT label of the moment: scaffolding|rigor|...
+    action_label: Optional[str] = None  # SAR's tutor-action call (LM only)
     result_label: Optional[str] = None
-    model: Optional[str] = None             # LM only
-    prompt: Optional[str] = None            # LM only
-    source: str = ""                        # "hf" | "tutorsim" | "canonical"
+    model: Optional[str] = None  # LM only
+    prompt: Optional[str] = None  # LM only
+    source: str = ""  # "hf" | "tutorsim" | "canonical"
     # Filled in by build_pool / classify_pool:
     stance_prefixed: bool = False
-    category: Optional[str] = None          # one of CATEGORY_LETTERS
+    category: Optional[str] = None  # one of CATEGORY_LETTERS
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -501,9 +509,7 @@ def load_key_moments_jsonl(jsonl_path: Path) -> Iterator[Facet]:
                     )
 
 
-def load_tutorsim_results(
-    results_dir: Path, scenarios_path: Path
-) -> Iterator[Facet]:
+def load_tutorsim_results(results_dir: Path, scenarios_path: Path) -> Iterator[Facet]:
     """Stream Facets from a tutorsim run results directory.
 
     Args:
@@ -672,14 +678,14 @@ def _transcript_from_scenario(scenario_id: str) -> str:
 _FACET_FIELDS: tuple[str, ...] = tuple(f.name for f in fields(Facet))
 
 
-def _atomic_write_csv(path: Path, header: Iterable[str],
-                      rows: Iterable[dict]) -> None:
+def _atomic_write_csv(path: Path, header: Iterable[str], rows: Iterable[dict]) -> None:
     """Write a CSV to a sibling .tmp then `os.replace` into the final path.
 
     Crash-mid-write leaves the .tmp on disk and the original (or no) file
     intact, so a re-run reads either the last good output or restarts.
     """
     import os
+
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
@@ -704,18 +710,19 @@ def build_pool(facets: Iterable[Facet]) -> tuple[list[Facet], list[tuple[Facet, 
     return kept, excluded
 
 
-def write_pool_csv(kept: Iterable[Facet], excluded: Iterable[tuple[Facet, str]],
-                   out_dir: Path) -> None:
+def write_pool_csv(
+    kept: Iterable[Facet], excluded: Iterable[tuple[Facet, str]], out_dir: Path
+) -> None:
     """Persist kept facets and excluded facets (with reason) under `out_dir`.
 
     Uses atomic write-and-rename so a crash mid-write never leaves a partial CSV.
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    _atomic_write_csv(out_dir / "pool.csv", _FACET_FIELDS,
-                      (f.to_dict() for f in kept))
+    _atomic_write_csv(out_dir / "pool.csv", _FACET_FIELDS, (f.to_dict() for f in kept))
     _atomic_write_csv(
-        out_dir / "excluded.csv", _FACET_FIELDS + ("reason",),
+        out_dir / "excluded.csv",
+        _FACET_FIELDS + ("reason",),
         ({**f.to_dict(), "reason": r} for f, r in excluded),
     )
 
@@ -755,10 +762,10 @@ def _coerce_facet_row(row: dict[str, str]) -> Facet:
     return Facet(**coerced)
 
 
-def pool_report(kept: list[Facet],
-                excluded: list[tuple[Facet, str]]) -> str:
+def pool_report(kept: list[Facet], excluded: list[tuple[Facet, str]]) -> str:
     """Plain-text summary of the pool: keep/strip totals and per-reason counts."""
     from collections import Counter
+
     n_total = len(kept) + len(excluded)
     n_keep = len(kept)
     stance_kept = sum(1 for f in kept if f.stance_prefixed)
@@ -769,8 +776,7 @@ def pool_report(kept: list[Facet],
         f"total facets : {n_total}",
         f"  KEEP       : {n_keep} ({100 * n_keep / n_total:.1f}%)  "
         f"[{stance_kept} stance-prefixed]",
-        f"  STRIP      : {len(excluded)} "
-        f"({100 * len(excluded) / n_total:.1f}%)",
+        f"  STRIP      : {len(excluded)} ({100 * len(excluded) / n_total:.1f}%)",
         "",
         "Strip reasons:",
     ]
@@ -853,6 +859,7 @@ def classify_pool(
     if client is None or model is None or thinking is None or batch_size is None:
         try:
             from tutorsim.config import taxonomy_spec
+
             spec = taxonomy_spec()
         except Exception:
             spec = {}
@@ -870,6 +877,7 @@ def classify_pool(
     # Replace with frequency-descending order so high-recurrence statements
     # get classified first (useful for early sanity checks).
     from collections import Counter
+
     counts = Counter(f.statement.strip() for f in kept if f.statement)
     statements = [s for s, _ in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))]
 
@@ -878,7 +886,9 @@ def classify_pool(
     n_done = len(statements) - len(pending)
     logger.info(
         "classify_pool: %d unique statements (%d already assigned, %d pending)",
-        len(statements), n_done, len(pending),
+        len(statements),
+        n_done,
+        len(pending),
     )
     if not pending:
         return assigned
@@ -890,20 +900,22 @@ def classify_pool(
         stop_after = min(first_run_probe, total_batches)
         logger.info(
             "First run with no prior progress -> stopping after %d batches "
-            "as a sanity probe. Re-run to continue.", stop_after,
+            "as a sanity probe. Re-run to continue.",
+            stop_after,
         )
     else:
         stop_after = total_batches
 
     if client is None:
         from tutorsim.client import ModelClient
+
         client = ModelClient(model)
 
     ask = _make_classifier(client, thinking=bool(thinking))
 
     for bi in range(stop_after):
         start = bi * batch_size
-        batch = pending[start:start + batch_size]
+        batch = pending[start : start + batch_size]
         if not batch:
             break
         in_flight = batch
@@ -921,7 +933,9 @@ def classify_pool(
         if in_flight:
             logger.warning(
                 "Forced %d statements to '%s' after %d retries",
-                len(in_flight), LAST_LETTER, CLASSIFIER_MAX_RETRIES,
+                len(in_flight),
+                LAST_LETTER,
+                CLASSIFIER_MAX_RETRIES,
             )
             forced = {s: LAST_LETTER for s in in_flight}
             assigned.update(forced)
@@ -940,18 +954,22 @@ def _make_classifier(client: Any, *, thinking: bool = False):
     an enum of A-M so the model cannot return any other letter.
     """
     schema = {
-        "type": "object", "additionalProperties": False,
-        "properties": {"assignments": {
-            "type": "array",
-            "items": {
-                "type": "object", "additionalProperties": False,
-                "properties": {
-                    "id": {"type": "integer"},
-                    "category": {"type": "string", "enum": CATEGORY_LETTERS},
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "assignments": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "category": {"type": "string", "enum": CATEGORY_LETTERS},
+                    },
+                    "required": ["id", "category"],
                 },
-                "required": ["id", "category"],
-            },
-        }},
+            }
+        },
         "required": ["assignments"],
     }
     cat_block = _categories_block()
@@ -981,9 +999,11 @@ def _make_classifier(client: Any, *, thinking: bool = False):
         try:
             result = json.loads(text)
         except json.JSONDecodeError:
-            logger.warning("classifier returned unparseable JSON for %s; "
-                           "treating batch as empty so retry-on-incomplete fires",
-                           label)
+            logger.warning(
+                "classifier returned unparseable JSON for %s; "
+                "treating batch as empty so retry-on-incomplete fires",
+                label,
+            )
             result = {"assignments": []}
         out: dict[str, str] = {}
         for a in result.get("assignments", []):
@@ -1028,8 +1048,9 @@ def _append_jsonl(path: Path, record: dict) -> None:
         f.write(json.dumps(record) + "\n")
 
 
-def attach_categories(facets: Iterable[Facet],
-                      assignments: dict[str, str]) -> list[Facet]:
+def attach_categories(
+    facets: Iterable[Facet], assignments: dict[str, str]
+) -> list[Facet]:
     """Set `facet.category` for every facet based on its statement.
 
     Raises KeyError on any statement missing from `assignments` so partial
@@ -1050,8 +1071,7 @@ def write_classified_csv(facets: Iterable[Facet], path: Path) -> None:
 
     Uses atomic write-and-rename so a crash mid-write never leaves a partial CSV.
     """
-    _atomic_write_csv(Path(path), _FACET_FIELDS,
-                      (f.to_dict() for f in facets))
+    _atomic_write_csv(Path(path), _FACET_FIELDS, (f.to_dict() for f in facets))
 
 
 def read_classified_csv(path: Path) -> list[Facet]:
@@ -1085,17 +1105,18 @@ def read_paper_distribution(csv_path: Path, series: str = "human"):
     col = f"{series}__macro_mean_pct"
     if col not in df.columns:
         raise KeyError(
-            f"series '{series}' not found in {csv_path} "
-            f"(expected column '{col}')"
+            f"series '{series}' not found in {csv_path} (expected column '{col}')"
         )
-    return pd.DataFrame({
-        "letter": df["letter"],
-        "name": df["name"],
-        "orientation": df["orientation"],
-        "mean_pct": df[col],
-        "ci_low": df[f"{series}__ci_low"],
-        "ci_high": df[f"{series}__ci_high"],
-    }).set_index("letter")
+    return pd.DataFrame(
+        {
+            "letter": df["letter"],
+            "name": df["name"],
+            "orientation": df["orientation"],
+            "mean_pct": df[col],
+            "ci_low": df[f"{series}__ci_low"],
+            "ci_high": df[f"{series}__ci_high"],
+        }
+    ).set_index("letter")
 
 
 # ============================================================================
@@ -1109,6 +1130,7 @@ def read_paper_distribution(csv_path: Path, series: str = "human"):
 #
 # Pandas is required from here down. Importing this module without pandas
 # is fine; only these functions raise if it's missing.
+
 
 def _require_analysis_extras() -> None:
     """Raise ImportError with an install hint if pandas is missing.
@@ -1149,6 +1171,7 @@ def _normal_ci(values, z: float = 1.96) -> tuple[float, float, float]:
         return (mean, mean, mean)
     var = sum((v - mean) ** 2 for v in values) / (n - 1)
     import math
+
     se = math.sqrt(var / n)
     return (mean, max(0.0, mean - z * se), min(1.0, mean + z * se))
 
@@ -1159,9 +1182,8 @@ def _moment_fractions(df, value_col: str, moment_col: str = "moment_id"):
     Returns a DataFrame indexed by moment_id with one column per value;
     rows sum to 1. Missing combinations are 0.
     """
-    pd = importlib.import_module("pandas")
-    counts = (df.groupby([moment_col, value_col]).size()
-                .unstack(fill_value=0))
+    importlib.import_module("pandas")
+    counts = df.groupby([moment_col, value_col]).size().unstack(fill_value=0)
     totals = counts.sum(axis=1).replace(0, 1)
     return counts.div(totals, axis=0)
 
@@ -1185,14 +1207,16 @@ def macro_distribution(df, group_keys: tuple[str, ...] = ()):
         n_moments = len(moment_frac)
         for letter in CATEGORY_LETTERS:
             mean, lo, hi = _normal_ci(moment_frac[letter].tolist())
-            out_rows.append({
-                **{k: v for k, v in zip(group_keys, key)},
-                "letter": letter,
-                "n_moments": n_moments,
-                "mean_pct": mean * 100,
-                "ci_low": lo * 100,
-                "ci_high": hi * 100,
-            })
+            out_rows.append(
+                {
+                    **{k: v for k, v in zip(group_keys, key)},
+                    "letter": letter,
+                    "n_moments": n_moments,
+                    "mean_pct": mean * 100,
+                    "ci_low": lo * 100,
+                    "ci_high": hi * 100,
+                }
+            )
     return pd.DataFrame(out_rows)
 
 
@@ -1215,14 +1239,16 @@ def macro_orientation(df, group_keys: tuple[str, ...] = ()):
         n_moments = len(moment_frac)
         for o in orients:
             mean, lo, hi = _normal_ci(moment_frac[o].tolist())
-            out_rows.append({
-                **{k: v for k, v in zip(group_keys, key)},
-                "orientation": o,
-                "n_moments": n_moments,
-                "mean_pct": mean * 100,
-                "ci_low": lo * 100,
-                "ci_high": hi * 100,
-            })
+            out_rows.append(
+                {
+                    **{k: v for k, v in zip(group_keys, key)},
+                    "orientation": o,
+                    "n_moments": n_moments,
+                    "mean_pct": mean * 100,
+                    "ci_low": lo * 100,
+                    "ci_high": hi * 100,
+                }
+            )
     return pd.DataFrame(out_rows)
 
 
@@ -1260,8 +1286,7 @@ def macro_appropriateness(df, group_keys: tuple[str, ...] = ()):
     return pd.DataFrame(out_rows)
 
 
-def prompt_effect_deltas(lm_df, model_col: str = "model",
-                         prompt_col: str = "prompt"):
+def prompt_effect_deltas(lm_df, model_col: str = "model", prompt_col: str = "prompt"):
     """Per-model SR-minus-plain deltas on the orientation rollup.
 
     Returns a DataFrame indexed by model with columns
@@ -1270,15 +1295,20 @@ def prompt_effect_deltas(lm_df, model_col: str = "model",
     _require_analysis_extras()
     pd = importlib.import_module("pandas")  # used to build the final DataFrame
     orient = macro_orientation(lm_df, group_keys=(model_col, prompt_col))
-    pivot = orient.pivot_table(index=[model_col, "orientation"],
-                               columns=prompt_col, values="mean_pct")
+    pivot = orient.pivot_table(
+        index=[model_col, "orientation"], columns=prompt_col, values="mean_pct"
+    )
     out = {}
     prompts = pivot.columns.tolist()
     if not {"plain"}.issubset(prompts):
-        raise ValueError(f"prompt_effect_deltas requires a 'plain' prompt; got {prompts}")
+        raise ValueError(
+            f"prompt_effect_deltas requires a 'plain' prompt; got {prompts}"
+        )
     sr_col = next((p for p in prompts if p != "plain"), None)
     if sr_col is None:
-        raise ValueError(f"prompt_effect_deltas requires a second prompt alongside 'plain'")
+        raise ValueError(
+            "prompt_effect_deltas requires a second prompt alongside 'plain'"
+        )
     for (model, orientation), row in pivot.iterrows():
         out.setdefault(model, {})[f"d_{orientation}"] = row[sr_col] - row["plain"]
     return pd.DataFrame(out).T.reset_index(names=model_col)
@@ -1287,12 +1317,15 @@ def prompt_effect_deltas(lm_df, model_col: str = "model",
 def js_divergence(p, q, eps: float = 1e-12) -> float:
     """Jensen-Shannon divergence in base 2; output in [0, 1]."""
     import math
-    p = list(p); q = list(q)
+
+    p = list(p)
+    q = list(q)
 
     def kl(a, b):
         out = 0.0
         for ai, bi in zip(a, b):
-            ai = max(ai, eps); bi = max(bi, eps)
+            ai = max(ai, eps)
+            bi = max(bi, eps)
             out += ai * math.log2(ai / bi)
         return out
 
@@ -1300,8 +1333,9 @@ def js_divergence(p, q, eps: float = 1e-12) -> float:
     return 0.5 * kl(p, m) + 0.5 * kl(q, m)
 
 
-def js_divergence_to_human(human_df, lm_df,
-                           group_keys: tuple[str, ...] = ("model", "prompt")):
+def js_divergence_to_human(
+    human_df, lm_df, group_keys: tuple[str, ...] = ("model", "prompt")
+):
     """Per LM cell, JS divergence between its macro distribution and human's.
 
     Returns a DataFrame with `*group_keys, n_moments, js_divergence` sorted
@@ -1310,25 +1344,34 @@ def js_divergence_to_human(human_df, lm_df,
     _require_analysis_extras()
     pd = importlib.import_module("pandas")  # used at return
     h = macro_distribution(human_df)
-    human_vec = (h.set_index("letter")["mean_pct"]
-                  .reindex(CATEGORY_LETTERS, fill_value=0.0) / 100).tolist()
+    human_vec = (
+        h.set_index("letter")["mean_pct"].reindex(CATEGORY_LETTERS, fill_value=0.0)
+        / 100
+    ).tolist()
     cells = macro_distribution(lm_df, group_keys=group_keys)
     rows = []
     for key, sub in cells.groupby(list(group_keys)):
         if not isinstance(key, tuple):
             key = (key,)
-        vec = (sub.set_index("letter")["mean_pct"]
-                  .reindex(CATEGORY_LETTERS, fill_value=0.0) / 100).tolist()
-        rows.append({
-            **{k: v for k, v in zip(group_keys, key)},
-            "n_moments": int(sub["n_moments"].iloc[0]),
-            "js_divergence": js_divergence(vec, human_vec),
-        })
+        vec = (
+            sub.set_index("letter")["mean_pct"].reindex(
+                CATEGORY_LETTERS, fill_value=0.0
+            )
+            / 100
+        ).tolist()
+        rows.append(
+            {
+                **{k: v for k, v in zip(group_keys, key)},
+                "n_moments": int(sub["n_moments"].iloc[0]),
+                "js_divergence": js_divergence(vec, human_vec),
+            }
+        )
     return pd.DataFrame(rows).sort_values("js_divergence").reset_index(drop=True)
 
 
-def build_headline_tables(human_facets: Iterable[Facet],
-                          lm_facets: Iterable[Facet]) -> dict[str, Any]:
+def build_headline_tables(
+    human_facets: Iterable[Facet], lm_facets: Iterable[Facet]
+) -> dict[str, Any]:
     """Compute all five headline tables in one pass.
 
     Returns a dict keyed by table name:
@@ -1339,8 +1382,7 @@ def build_headline_tables(human_facets: Iterable[Facet],
     human_df = facets_to_dataframe(human_facets)
     lm_df = facets_to_dataframe(lm_facets)
     human_df["cell"] = "human"
-    lm_df["cell"] = (lm_df["model"].astype(str) + " / "
-                     + lm_df["prompt"].astype(str))
+    lm_df["cell"] = lm_df["model"].astype(str) + " / " + lm_df["prompt"].astype(str)
     combined = _pd_concat([human_df, lm_df])
     return {
         "distribution": macro_distribution(combined, group_keys=("cell",)),
@@ -1363,6 +1405,7 @@ def write_headline_csvs(tables: dict[str, Any], out_dir: Path) -> None:
     """
     _require_analysis_extras()
     import os
+
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     for name, df in tables.items():
@@ -1390,7 +1433,9 @@ def read_headline_csvs(in_dir: Path) -> dict[str, Any]:
 # Each `run_*` function is idempotent and writes its outputs to disk so the
 # next stage can read them back. They are usable from Python and from the CLI.
 
-InputSpec = dict[str, Any]  # {"kind": "key_moments"|"tutorsim"|"canonical", "path": "...", "scenarios": "..."}
+InputSpec = dict[
+    str, Any
+]  # {"kind": "key_moments"|"tutorsim"|"canonical", "path": "...", "scenarios": "..."}
 
 
 def _adapter_for(spec: InputSpec) -> Iterator[Facet]:
@@ -1398,8 +1443,7 @@ def _adapter_for(spec: InputSpec) -> Iterator[Facet]:
     if kind == "key_moments":
         return load_key_moments_jsonl(Path(spec["path"]))
     if kind == "tutorsim":
-        return load_tutorsim_results(
-            Path(spec["path"]), Path(spec["scenarios"]))
+        return load_tutorsim_results(Path(spec["path"]), Path(spec["scenarios"]))
     if kind == "canonical":
         return load_canonical_jsonl(Path(spec["path"]))
     raise ValueError(f"unknown input kind: {kind!r}")
@@ -1437,8 +1481,9 @@ def run_classify(input_spec: InputSpec, out_dir: Path, **classify_kwargs) -> Pat
     return classified_path
 
 
-def run_headline(human_classified: Path, lm_classified: Path,
-                 out_dir: Path) -> dict[str, Any]:
+def run_headline(
+    human_classified: Path, lm_classified: Path, out_dir: Path
+) -> dict[str, Any]:
     """Compute the 5 headline tables from two classified.csv files."""
     human = read_classified_csv(Path(human_classified))
     lm = read_classified_csv(Path(lm_classified))
@@ -1447,8 +1492,9 @@ def run_headline(human_classified: Path, lm_classified: Path,
     return tables
 
 
-def run_all(human_input: InputSpec, lm_input: InputSpec,
-            out_dir: Path, **classify_kwargs) -> dict[str, Any]:
+def run_all(
+    human_input: InputSpec, lm_input: InputSpec, out_dir: Path, **classify_kwargs
+) -> dict[str, Any]:
     """Run the whole pipeline end-to-end.
 
     Layout under `out_dir`:
@@ -1499,12 +1545,16 @@ def classify_run(
     # first_run_probe disabled: an integrated run classifies to completion in
     # one invocation rather than stopping for a manual re-run.
     assignments = classify_pool(
-        kept, out_dir, client=client, first_run_probe=10 ** 9,
+        kept,
+        out_dir,
+        client=client,
+        first_run_probe=10**9,
     )
     classified = attach_categories(kept, assignments)
     write_classified_csv(classified, out_dir / "classified.csv")
 
     from collections import Counter
+
     counts = Counter(f.category for f in classified)
 
     # Roll categories up to their orientation (scaffolding / rigor / neutral)
@@ -1543,11 +1593,12 @@ def classify_run(
 # 8. CLI dispatcher
 # ============================================================================
 
+
 def _build_argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="tutorsim taxonomy",
         description="Classify decomposed tutor actions into A-M and produce "
-                    "headline tables. Paper figures live in working-paper notebooks.",
+        "headline tables. Paper figures live in working-paper notebooks.",
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
@@ -1555,20 +1606,36 @@ def _build_argparser() -> argparse.ArgumentParser:
 
     p_cls = sub.add_parser("classify", help="filter + classify a single input")
     p_cls.add_argument("--kind", required=True, choices=input_kinds)
-    p_cls.add_argument("--input", required=True,
-                       help="key-moments jsonl, tutorsim results/<run_id>/, "
-                            "or a canonical facet jsonl")
-    p_cls.add_argument("--scenarios",
-                       help="scenarios.jsonl (required for --kind tutorsim)")
+    p_cls.add_argument(
+        "--input",
+        required=True,
+        help="key-moments jsonl, tutorsim results/<run_id>/, "
+        "or a canonical facet jsonl",
+    )
+    p_cls.add_argument(
+        "--scenarios", help="scenarios.jsonl (required for --kind tutorsim)"
+    )
     p_cls.add_argument("--output", required=True, help="output directory")
-    p_cls.add_argument("--max-batches", type=int, default=None,
-                       help="cap LLM batches this run (e.g. for first-run probes)")
+    p_cls.add_argument(
+        "--max-batches",
+        type=int,
+        default=None,
+        help="cap LLM batches this run (e.g. for first-run probes)",
+    )
 
     p_hl = sub.add_parser("headline", help="build the 5 headline CSVs")
-    p_hl.add_argument("--human", required=True, type=Path,
-                      help="classified.csv from `taxonomy classify` for the human pool")
-    p_hl.add_argument("--lm", required=True, type=Path,
-                      help="classified.csv from `taxonomy classify` for the LM pool")
+    p_hl.add_argument(
+        "--human",
+        required=True,
+        type=Path,
+        help="classified.csv from `taxonomy classify` for the human pool",
+    )
+    p_hl.add_argument(
+        "--lm",
+        required=True,
+        type=Path,
+        help="classified.csv from `taxonomy classify` for the LM pool",
+    )
     p_hl.add_argument("--output", required=True, type=Path)
 
     p_run = sub.add_parser("run", help="classify (twice) -> headline end-to-end")
@@ -1595,8 +1662,7 @@ def cli_dispatch(argv: Optional[list[str]] = None) -> int:
             if not args.scenarios:
                 raise SystemExit("--scenarios is required when --kind tutorsim")
             spec["scenarios"] = args.scenarios
-        run_classify(spec, Path(args.output),
-                     max_batches=args.max_batches)
+        run_classify(spec, Path(args.output), max_batches=args.max_batches)
         return 0
 
     if args.cmd == "headline":
@@ -1607,15 +1673,16 @@ def cli_dispatch(argv: Optional[list[str]] = None) -> int:
         human_spec: InputSpec = {"kind": args.human_kind, "path": args.human_input}
         if args.human_kind == "tutorsim":
             if not args.human_scenarios:
-                raise SystemExit("--human-scenarios is required when --human-kind tutorsim")
+                raise SystemExit(
+                    "--human-scenarios is required when --human-kind tutorsim"
+                )
             human_spec["scenarios"] = args.human_scenarios
         lm_spec: InputSpec = {"kind": args.lm_kind, "path": args.lm_input}
         if args.lm_kind == "tutorsim":
             if not args.lm_scenarios:
                 raise SystemExit("--lm-scenarios is required when --lm-kind tutorsim")
             lm_spec["scenarios"] = args.lm_scenarios
-        run_all(human_spec, lm_spec, args.output,
-                max_batches=args.max_batches)
+        run_all(human_spec, lm_spec, args.output, max_batches=args.max_batches)
         return 0
 
     return 1

--- a/src/tutorsim/tutor.py
+++ b/src/tutorsim/tutor.py
@@ -14,6 +14,7 @@ Placeholders:
 - {student_context}        <- student_context (always available)
 - {reference_transcript}   <- reference_transcript (oracle only)
 """
+
 from tutorsim.resources import resource_text
 
 SUPPORTED_MODES = {"plain", "scaffolding_rigor", "oracle"}
@@ -59,9 +60,7 @@ def build_tutor_system_prompt(
     # Oracle-specific: substitute reference_transcript
     if mode == "oracle":
         if not reference_transcript:
-            raise ValueError(
-                "mode='oracle' requires a non-empty reference_transcript"
-            )
+            raise ValueError("mode='oracle' requires a non-empty reference_transcript")
         out = out.replace("{reference_transcript}", reference_transcript)
 
     return out
@@ -81,8 +80,8 @@ def resolve_tutor(tutor_id: str) -> dict:
     Raises:
         ValueError: If tutor_id is not registered and not in model roster.
     """
-    from tutorsim.config import get_registered_tutor, resolve_model
     from tutorsim.client import ModelClient
+    from tutorsim.config import get_registered_tutor, resolve_model
 
     # FIRST: check registry
     registered_fn = get_registered_tutor(tutor_id)

--- a/tests/analysis/test_benchmark_perf_cost.py
+++ b/tests/analysis/test_benchmark_perf_cost.py
@@ -31,10 +31,10 @@ def _ex(sid, lats, out_tok, total_tok):
 
 def test_filters_to_id_set_and_dedupes():
     exchanges = [
-        _ex("a", [2.0, 4.0], 100, 1000),   # in set
-        _ex("a", [9.0], 999, 9999),         # duplicate scenario_id -> ignored
-        _ex("b", [6.0], 60, 600),           # in set
-        _ex("z", [100.0], 1, 1),            # NOT in set -> ignored
+        _ex("a", [2.0, 4.0], 100, 1000),  # in set
+        _ex("a", [9.0], 999, 9999),  # duplicate scenario_id -> ignored
+        _ex("b", [6.0], 60, 600),  # in set
+        _ex("z", [100.0], 1, 1),  # NOT in set -> ignored
     ]
     s = bpc.summarize_exchanges(exchanges, id_set={"a", "b"})
     assert s["n_scenarios"] == 2

--- a/tests/tutorsim/test_cli.py
+++ b/tests/tutorsim/test_cli.py
@@ -3,24 +3,23 @@
 All tests mock run_conversation and score so there are no network calls.
 Uses tmp_path as results_root so nothing writes to the real results/ directory.
 """
+
 import json
 import logging
 import os
 import time
-from dataclasses import dataclass, field
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tutorsim import results as results_mod
 from tutorsim.moments import Moment
 from tutorsim.scoring import Annotation
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 def _make_scenario(sid: str, dimension: str = "scaffolding") -> Moment:
     """Build a minimal Moment for testing."""
@@ -31,8 +30,12 @@ def _make_scenario(sid: str, dimension: str = "scaffolding") -> Moment:
         student={
             "context": "Student context",
             "reference": "",
-            "trait": {"persona": "fixture persona", "trait_mode": "joined-3",
-                      "generator_model": "claude-opus-4-6", "generated_at": "2026-06-18T00:00:00"},
+            "trait": {
+                "persona": "fixture persona",
+                "trait_mode": "joined-3",
+                "generator_model": "claude-opus-4-6",
+                "generated_at": "2026-06-18T00:00:00",
+            },
         },
         rubric={"gold": dimension, "hint": "test hint"},
         provenance={"conv_id": f"conv_{sid}", "cut_turn": 1},
@@ -56,22 +59,35 @@ def _make_annotation(sid: str) -> Annotation:
     )
 
 
-def _make_transcript(sid: str, tutor_latencies=None, student_latencies=None,
-                     tutor_usage=None, student_usage=None) -> MagicMock:
+def _make_transcript(
+    sid: str,
+    tutor_latencies=None,
+    student_latencies=None,
+    tutor_usage=None,
+    student_usage=None,
+) -> MagicMock:
     """Build a mock Transcript-like object with optional latency/usage data."""
     t = MagicMock()
     t.scenario_id = sid
     t.tutor_model = "claude-opus-4-8"
     t.generated_turns = [{"turn_number": 2, "role": "TUTOR", "text": "Hi"}]
-    t.to_dict.return_value = {"scenario_id": sid, "completed": True, "generated_turns": []}
+    t.to_dict.return_value = {
+        "scenario_id": sid,
+        "completed": True,
+        "generated_turns": [],
+    }
     t.tutor_latencies = tutor_latencies if tutor_latencies is not None else []
     t.student_latencies = student_latencies if student_latencies is not None else []
-    t.tutor_usage = tutor_usage if tutor_usage is not None else {
-        "input_tokens": 0, "output_tokens": 0, "total_tokens": 0
-    }
-    t.student_usage = student_usage if student_usage is not None else {
-        "input_tokens": 0, "output_tokens": 0, "total_tokens": 0
-    }
+    t.tutor_usage = (
+        tutor_usage
+        if tutor_usage is not None
+        else {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    )
+    t.student_usage = (
+        student_usage
+        if student_usage is not None
+        else {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    )
     return t
 
 
@@ -103,22 +119,35 @@ def _score_batch_from(annotations):
         return {s.id: by_sid[s.id].pop(0) for s, _t in pairs}
 
     return _fake
+
+
 _LOAD_PATCH = "tutorsim.cli.load_moments"
+
 
 def _load_result(moments):
     """load_moments returns (moments, source_meta)."""
-    return (list(moments), {
-        "dataset_id": None, "revision": None, "data_path": None,
-        "config": "moments", "record_count": len(moments),
-        "content_hash": "0" * 64,
-    })
+    return (
+        list(moments),
+        {
+            "dataset_id": None,
+            "revision": None,
+            "data_path": None,
+            "config": "moments",
+            "record_count": len(moments),
+            "content_hash": "0" * 64,
+        },
+    )
+
+
 _CFG_PATCH = "tutorsim.cli.build_run_config"
 # The always-on taxonomy classification hook makes LLM calls; patch it out in
 # run_cell tests so the suite never hits the network. Zero usage keeps the
 # token-total assertions unaffected.
 _TAX_PATCH = "tutorsim.cli._classify_run_taxonomy"
 _TAX_RESULT = {
-    "scheme_version": "lm_extended_v1", "counts": {}, "n_facets": 0,
+    "scheme_version": "lm_extended_v1",
+    "counts": {},
+    "n_facets": 0,
     "excluded": 0,
     "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
 }
@@ -148,11 +177,12 @@ def _make_run_config(sample=2, dataset="test_ds", max_turns=4, replay_concurrenc
 # Test 1: run_cell writes all expected files and correct summary
 # ---------------------------------------------------------------------------
 
+
 def test_run_cell_writes_all_files(tmp_path):
     """run_cell over a 2-scenario fixture writes 2 transcripts + 2 scores +
     config.json + summary.json; summary metrics == aggregate of the 2 scores."""
-    from tutorsim.cli import run_cell
     import tutorsim.report as report_mod
+    from tutorsim.cli import run_cell
 
     scenarios = list(FIXTURE_SCENARIOS)
     transcripts = [_make_transcript(s.id) for s in scenarios]
@@ -162,10 +192,10 @@ def test_run_cell_writes_all_files(tmp_path):
     cfg_mock = _make_run_config(sample=2)
 
     with (
-        patch(_CFG_PATCH, return_value=cfg_mock) as mock_build_cfg,
-        patch(_LOAD_PATCH, return_value=_load_result(scenarios)) as mock_load,
-        patch(_CONV_PATCH, side_effect=transcripts) as mock_conv,
-        patch(_SCORE_PATCH, side_effect=_score_batch_from(annotations)) as mock_score,
+        patch(_CFG_PATCH, return_value=cfg_mock),
+        patch(_LOAD_PATCH, return_value=_load_result(scenarios)),
+        patch(_CONV_PATCH, side_effect=transcripts),
+        patch(_SCORE_PATCH, side_effect=_score_batch_from(annotations)),
         patch(_TAX_PATCH, return_value=_TAX_RESULT),
     ):
         run_id = run_cell(
@@ -190,13 +220,15 @@ def test_run_cell_writes_all_files(tmp_path):
 
     # 2 transcripts
     for s in scenarios:
-        assert (run_dir / "transcripts" / f"{s.id}.json").exists(), \
+        assert (run_dir / "transcripts" / f"{s.id}.json").exists(), (
             f"Missing transcript for {s.id}"
+        )
 
     # 2 scores
     for s in scenarios:
-        assert (run_dir / "scores" / f"{s.id}.json").exists(), \
+        assert (run_dir / "scores" / f"{s.id}.json").exists(), (
             f"Missing score for {s.id}"
+        )
 
     # summary.json
     assert (run_dir / "summary.json").exists()
@@ -205,7 +237,7 @@ def test_run_cell_writes_all_files(tmp_path):
     # summary metrics == aggregate of the 2 annotations
     assert summary["n_scenarios"] == expected_summary["n_scenarios"]
     assert "outcome_pos_rate" not in summary  # dropped from the paper
-    assert "scaffolding_did" not in summary   # did-rates dropped from the paper
+    assert "scaffolding_did" not in summary  # did-rates dropped from the paper
     assert "rigor_did" not in summary
     scaf = summary["scaffold_calibrated"]
     exp_scaf = expected_summary["scaffold_calibrated"]
@@ -227,6 +259,7 @@ def test_run_cell_writes_all_files(tmp_path):
 # Test 1b: run_cell writes latency + tokens blocks into summary.json (spec S7)
 # ---------------------------------------------------------------------------
 
+
 def test_run_cell_writes_latency_and_tokens(tmp_path):
     """run_cell aggregates tutor_latencies/usage from transcripts into
     summary.json latency.tutor and tokens.total blocks (spec S7).
@@ -245,14 +278,26 @@ def test_run_cell_writes_latency_and_tokens(tmp_path):
             tutor_latencies=[1.0, 3.0],
             student_latencies=[0.5],
             tutor_usage={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
-            student_usage={"input_tokens": 80, "output_tokens": 20, "total_tokens": 100},
+            student_usage={
+                "input_tokens": 80,
+                "output_tokens": 20,
+                "total_tokens": 100,
+            },
         ),
         _make_transcript(
             "scenario_002",
             tutor_latencies=[2.0],
             student_latencies=[0.8],
-            tutor_usage={"input_tokens": 200, "output_tokens": 100, "total_tokens": 300},
-            student_usage={"input_tokens": 150, "output_tokens": 50, "total_tokens": 200},
+            tutor_usage={
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "total_tokens": 300,
+            },
+            student_usage={
+                "input_tokens": 150,
+                "output_tokens": 50,
+                "total_tokens": 200,
+            },
         ),
     ]
     annotations = [_make_annotation(s.id) for s in scenarios]
@@ -286,8 +331,12 @@ def test_run_cell_writes_latency_and_tokens(tmp_path):
     assert "p95_seconds" in lat, "latency.tutor must have p95_seconds"
     # tutor_latencies = [1.0, 3.0, 2.0] -> sorted = [1.0, 2.0, 3.0]
     # n=3, p50 = s[1] = 2.0, p95_idx = max(0, min(2, round(2.85)-1)) = max(0,min(2,2)) = 2 -> 3.0
-    assert lat["p50_seconds"] == pytest.approx(2.0), f"p50 expected 2.0, got {lat['p50_seconds']}"
-    assert lat["p95_seconds"] == pytest.approx(3.0), f"p95 expected 3.0, got {lat['p95_seconds']}"
+    assert lat["p50_seconds"] == pytest.approx(2.0), (
+        f"p50 expected 2.0, got {lat['p50_seconds']}"
+    )
+    assert lat["p95_seconds"] == pytest.approx(3.0), (
+        f"p95 expected 3.0, got {lat['p95_seconds']}"
+    )
 
     # tokens.total block must be present
     assert "tokens" in summary, "summary must have 'tokens' key"
@@ -295,12 +344,15 @@ def test_run_cell_writes_latency_and_tokens(tmp_path):
     tok = summary["tokens"]["total"]
     assert "total_tokens" in tok, "tokens.total must have total_tokens"
     # tutor: 150+300=450, student: 100+200=300, total: 750
-    assert tok["total_tokens"] == 750, f"total_tokens expected 750, got {tok['total_tokens']}"
+    assert tok["total_tokens"] == 750, (
+        f"total_tokens expected 750, got {tok['total_tokens']}"
+    )
 
 
 # ---------------------------------------------------------------------------
 # Test 2: run_cell resumes (second call skips already-done scenarios)
 # ---------------------------------------------------------------------------
+
 
 def test_run_cell_resumes(tmp_path):
     """Second run_cell call finds both scenarios already done; 0 new conversation
@@ -358,11 +410,11 @@ def test_run_cell_resumes(tmp_path):
 # Test 3: score error -> logged + skipped; run completes with partial summary
 # ---------------------------------------------------------------------------
 
+
 def test_run_cell_skips_on_score_error(tmp_path):
     """A scenario whose score() raises is logged + skipped; run still completes
     and writes summary.json over the successful scenarios only."""
     from tutorsim.cli import run_cell
-    import tutorsim.report as report_mod
 
     scenarios = list(FIXTURE_SCENARIOS)
     good_scenario = scenarios[0]
@@ -446,6 +498,7 @@ def test_run_cell_raises_when_all_scenarios_fail(tmp_path):
 # Test 4: cell expansion -- tutors x modes = cells with correct lane assignment
 # ---------------------------------------------------------------------------
 
+
 def test_cell_expansion_and_lane_assignment():
     """3 tutors x 2 modes = 6 cells; each cell gets the correct provider lane."""
     from tutorsim.cli import expand_cells
@@ -473,6 +526,7 @@ def test_cell_expansion_and_lane_assignment():
 # ---------------------------------------------------------------------------
 # Test 5: scheduler -- within-lane sequential, lanes can run independently
 # ---------------------------------------------------------------------------
+
 
 def test_scheduler_within_lane_sequential(tmp_path):
     """Cells within a lane are called in order; all 6 run_cell calls complete."""
@@ -535,8 +589,10 @@ def test_scheduler_multiple_lanes_all_cells_run(tmp_path):
 # Test 6: --trials N -- conversation+score called N times; summary has mean+spread
 # ---------------------------------------------------------------------------
 
-def _make_run_config_trials(n_trials: int, sample=2, dataset="test_ds", max_turns=4,
-                            replay_concurrency=1):
+
+def _make_run_config_trials(
+    n_trials: int, sample=2, dataset="test_ds", max_turns=4, replay_concurrency=1
+):
     cfg = MagicMock()
     cfg.dataset = dataset
     cfg.data_path = None
@@ -579,7 +635,7 @@ def test_trials_3_calls_conversation_n_times(tmp_path):
         patch(_SCORE_PATCH, new=score_mock),
         patch(_TAX_PATCH, return_value=_TAX_RESULT),
     ):
-        run_id = run_cell(
+        run_cell(
             tutor="claude-opus-4-8",
             mode="plain",
             run_cfg=None,
@@ -637,8 +693,8 @@ def test_trials_summary_has_mean_and_spread(tmp_path):
 def test_trials_1_summary_matches_single_run(tmp_path):
     """trials=1: summary.json must be byte-compatible with the Task-4 single-run format
     (no 'mean'/'spread' keys -- it is the plain aggregate dict)."""
-    from tutorsim.cli import run_cell
     import tutorsim.report as report_mod
+    from tutorsim.cli import run_cell
 
     scenarios = list(FIXTURE_SCENARIOS)
     transcripts = [_make_transcript(s.id) for s in scenarios]
@@ -677,6 +733,7 @@ def test_trials_1_summary_matches_single_run(tmp_path):
 # Helper: build a fake run directory with a summary.json
 # ---------------------------------------------------------------------------
 
+
 def _make_fake_run(
     root: Path,
     run_id: str,
@@ -692,11 +749,29 @@ def _make_fake_run(
         "tutor_model": tutor_model,
         "mode": mode,
         "n_scenarios": n,
-        "scaffold_calibrated": {"score": scaffold_cal, "n_clean_yes": 6, "n_total": n, "n_overscaffold": 1},
+        "scaffold_calibrated": {
+            "score": scaffold_cal,
+            "n_clean_yes": 6,
+            "n_total": n,
+            "n_overscaffold": 1,
+        },
         "rigor_calibrated": {"score": 0.5, "n_clean_yes": 5, "n_total": n},
         "overscaffold": {"rate": 0.1, "n_yes": 1, "n_total": n, "available": True},
-        "latency": {"tutor": {"p50_seconds": 1.0, "p95_seconds": 2.5, "mean_seconds": 1.2, "n": n}},
-        "tokens": {"total": {"total_tokens": 100000, "input_tokens": 80000, "output_tokens": 20000}},
+        "latency": {
+            "tutor": {
+                "p50_seconds": 1.0,
+                "p95_seconds": 2.5,
+                "mean_seconds": 1.2,
+                "n": n,
+            }
+        },
+        "tokens": {
+            "total": {
+                "total_tokens": 100000,
+                "input_tokens": 80000,
+                "output_tokens": 20000,
+            }
+        },
     }
     (run_dir / "summary.json").write_text(
         json.dumps(summary, indent=2), encoding="utf-8"
@@ -708,14 +783,27 @@ def _make_fake_run(
 # Test 7: report subcommand writes leaderboard.md + .csv with both rows
 # ---------------------------------------------------------------------------
 
+
 def test_report_writes_leaderboard_md_and_csv(tmp_path):
     """main(['report', '--results-root', ..., '--out', ...]) writes leaderboard.md + .csv
     containing both run rows."""
     from tutorsim.cli import main
 
     results_root = tmp_path / "results"
-    _make_fake_run(results_root, "model_alpha_plain_ds_20260626", "model-alpha", "plain", scaffold_cal=0.75)
-    _make_fake_run(results_root, "model_beta_plain_ds_20260626", "model-beta", "plain", scaffold_cal=0.50)
+    _make_fake_run(
+        results_root,
+        "model_alpha_plain_ds_20260626",
+        "model-alpha",
+        "plain",
+        scaffold_cal=0.75,
+    )
+    _make_fake_run(
+        results_root,
+        "model_beta_plain_ds_20260626",
+        "model-beta",
+        "plain",
+        scaffold_cal=0.50,
+    )
 
     out_stem = str(tmp_path / "leaderboard")
 
@@ -745,12 +833,15 @@ def test_report_writes_leaderboard_md_and_csv(tmp_path):
 # Test 8: view subcommand writes non-empty HTML
 # ---------------------------------------------------------------------------
 
+
 def test_view_writes_html(tmp_path):
     """main(['view', '--results-root', ..., '--out', ...]) writes a non-empty HTML file."""
     from tutorsim.cli import main
 
     results_root = tmp_path / "results"
-    _make_fake_run(results_root, "model_alpha_plain_ds_20260626", "model-alpha", "plain")
+    _make_fake_run(
+        results_root, "model_alpha_plain_ds_20260626", "model-alpha", "plain"
+    )
 
     out_html = str(tmp_path / "viewer.html")
 
@@ -764,15 +855,15 @@ def test_view_writes_html(tmp_path):
     assert "<!DOCTYPE html>" in html_text or "<html" in html_text
 
 
-
-
 # ---------------------------------------------------------------------------
 # Test 10: --help and run --help exit 0 and list subcommands
 # ---------------------------------------------------------------------------
 
+
 def test_main_help_exits_0():
     """main(['--help']) raises SystemExit(0)."""
     from tutorsim.cli import main
+
     with pytest.raises(SystemExit) as exc_info:
         main(["--help"])
     assert exc_info.value.code == 0
@@ -781,6 +872,7 @@ def test_main_help_exits_0():
 def test_run_help_exits_0():
     """main(['run', '--help']) raises SystemExit(0)."""
     from tutorsim.cli import main
+
     with pytest.raises(SystemExit) as exc_info:
         main(["run", "--help"])
     assert exc_info.value.code == 0
@@ -789,6 +881,7 @@ def test_run_help_exits_0():
 # ---------------------------------------------------------------------------
 # Test 11: end-to-end smoke -- main(['run', ...]) with mocks
 # ---------------------------------------------------------------------------
+
 
 def test_main_run_smoke(tmp_path):
     """main(['run', '--tutors', 'claude-opus-4-8', '--sample', '1', ...]) with mocked
@@ -811,12 +904,17 @@ def test_main_run_smoke(tmp_path):
     ):
         # run_sweep returns a list of run_ids; stub it so we test main() wiring
         mock_sweep.return_value = ["claude-opus-4-8_plain_test_ds_20260626"]
-        main([
-            "run",
-            "--tutors", "claude-opus-4-8",
-            "--sample", "1",
-            "--dataset", "test_ds",
-        ])
+        main(
+            [
+                "run",
+                "--tutors",
+                "claude-opus-4-8",
+                "--sample",
+                "1",
+                "--dataset",
+                "test_ds",
+            ]
+        )
 
     # Verify run_sweep was called (proving main() wired through correctly)
     mock_sweep.assert_called_once()
@@ -831,15 +929,23 @@ def test_main_run_missing_dataset_exits_cleanly(capsys):
 
     with (
         patch(_CFG_PATCH, return_value=cfg_mock),
-        patch("tutorsim.cli.run_sweep", side_effect=DatasetNotFoundError("missing dataset")),
+        patch(
+            "tutorsim.cli.run_sweep",
+            side_effect=DatasetNotFoundError("missing dataset"),
+        ),
     ):
         with pytest.raises(SystemExit) as exc_info:
-            main([
-                "run",
-                "--tutors", "claude-opus-4-8",
-                "--sample", "1",
-                "--dataset", "missing_ds",
-            ])
+            main(
+                [
+                    "run",
+                    "--tutors",
+                    "claude-opus-4-8",
+                    "--sample",
+                    "1",
+                    "--dataset",
+                    "missing_ds",
+                ]
+            )
 
     assert exc_info.value.code == 2
     captured = capsys.readouterr()
@@ -847,7 +953,9 @@ def test_main_run_missing_dataset_exits_cleanly(capsys):
     assert "Traceback" not in captured.err
 
 
-def test_run_config_argument_becomes_active_config_for_late_resolution(tmp_path, monkeypatch):
+def test_run_config_argument_becomes_active_config_for_late_resolution(
+    tmp_path, monkeypatch
+):
     """`tutorsim run --config FILE` also affects later no-arg config lookups."""
     from tutorsim.cli import main
     from tutorsim.config import _reset_config_cache
@@ -874,7 +982,7 @@ batch: { timeout: 60 }
     observed = {}
 
     def fake_run_sweep(cells, run_cfg, *, date, results_root):
-        from tutorsim.config import resolve_model, student_spec, scorer_spec
+        from tutorsim.config import resolve_model, scorer_spec, student_spec
 
         observed["provider"] = resolve_model("gpt-4o-mini")["provider"]
         observed["student"] = student_spec()["model"]
@@ -887,12 +995,17 @@ batch: { timeout: 60 }
     _reset_config_cache()
 
     try:
-        main([
-            "run",
-            "--config", str(config_path),
-            "--tutors", "gpt-4o-mini",
-            "--dataset", "readme_mock",
-        ])
+        main(
+            [
+                "run",
+                "--config",
+                str(config_path),
+                "--tutors",
+                "gpt-4o-mini",
+                "--dataset",
+                "readme_mock",
+            ]
+        )
 
         assert observed == {
             "provider": "openai",
@@ -959,8 +1072,8 @@ def test_run_cell_pools_scoring_into_one_call(tmp_path):
 def test_run_cell_transcript_without_score_resumes_into_pool(tmp_path):
     """A moment with a transcript on disk but no score skips its conversation
     and is scored via the pool (the interrupted-run resume case)."""
-    from tutorsim.cli import run_cell
     from tutorsim import results as res
+    from tutorsim.cli import run_cell
 
     scenarios = list(FIXTURE_SCENARIOS)
     done_conv, needs_score = scenarios[0], scenarios[1]
@@ -971,9 +1084,13 @@ def test_run_cell_transcript_without_score_resumes_into_pool(tmp_path):
 
     # Pre-write ONLY the transcript for needs_score (simulates an interrupt
     # between transcript write and score write).
-    pre_tx = {"scenario_id": needs_score.id, "tutor_model": "claude-opus-4-8",
-              "generated_turns": [{"turn_number": 2, "role": "TUTOR", "text": "Hi"}],
-              "completed": True, "ended_via": "MAX_TURNS"}
+    pre_tx = {
+        "scenario_id": needs_score.id,
+        "tutor_model": "claude-opus-4-8",
+        "generated_turns": [{"turn_number": 2, "role": "TUTOR", "text": "Hi"}],
+        "completed": True,
+        "ended_via": "MAX_TURNS",
+    }
     res.write_transcript(run_id, needs_score.id, pre_tx, results_root=str(tmp_path))
 
     conv_calls = []
@@ -1021,6 +1138,7 @@ def test_run_cell_transcript_without_score_resumes_into_pool(tmp_path):
 # Taxonomy integration: the always-on hook folds into summary.json
 # ---------------------------------------------------------------------------
 
+
 def test_run_cell_folds_taxonomy_block_into_summary(tmp_path):
     """The always-on taxonomy hook's result lands in summary.json, and its
     token usage is added into tokens.total."""
@@ -1034,7 +1152,8 @@ def test_run_cell_folds_taxonomy_block_into_summary(tmp_path):
     tax_result = {
         "scheme_version": "lm_extended_v1",
         "counts": {"A": 3, "E": 1},
-        "n_facets": 4, "excluded": 1,
+        "n_facets": 4,
+        "excluded": 1,
         "usage": {"input_tokens": 700, "output_tokens": 300, "total_tokens": 1000},
     }
     with (
@@ -1044,11 +1163,18 @@ def test_run_cell_folds_taxonomy_block_into_summary(tmp_path):
         patch(_SCORE_PATCH, side_effect=_score_batch_from(annotations)),
         patch(_TAX_PATCH, return_value=tax_result) as mock_tax,
     ):
-        run_id = run_cell(tutor="claude-opus-4-8", mode="plain", run_cfg=None,
-                          date="20260626", results_root=str(tmp_path))
+        run_id = run_cell(
+            tutor="claude-opus-4-8",
+            mode="plain",
+            run_cfg=None,
+            date="20260626",
+            results_root=str(tmp_path),
+        )
 
     assert mock_tax.called
-    summary = json.loads((tmp_path / run_id / "summary.json").read_text(encoding="utf-8"))
+    summary = json.loads(
+        (tmp_path / run_id / "summary.json").read_text(encoding="utf-8")
+    )
     assert summary["taxonomy"] == tax_result
     # taxonomy usage folded into the token bookkeeping
     assert summary["tokens"]["taxonomy"] == tax_result["usage"]
@@ -1058,6 +1184,7 @@ def test_run_cell_folds_taxonomy_block_into_summary(tmp_path):
 # ---------------------------------------------------------------------------
 # Replay concurrency (result-preserving parallel replay of moments)
 # ---------------------------------------------------------------------------
+
 
 def _conv_by_sid(scenarios, delays=None, fail_ids=()):
     """run_conversation fake that returns the right transcript for its scenario.
@@ -1085,7 +1212,9 @@ def test_replay_concurrency_matches_serial(tmp_path):
     even when completion order is shuffled (reverse per-sid delays)."""
     from tutorsim.cli import run_cell
 
-    scenarios = [_make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 6)]
+    scenarios = [
+        _make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 6)
+    ]
     # Reverse delays: last-submitted finishes first under concurrency, so
     # completion order != submission order -- exercises index-order reassembly.
     delays = {s.id: 0.02 * (len(scenarios) - i) for i, s in enumerate(scenarios)}
@@ -1100,8 +1229,13 @@ def test_replay_concurrency_matches_serial(tmp_path):
             patch(_SCORE_PATCH, side_effect=_score_batch_from(anns)),
             patch(_TAX_PATCH, return_value=_TAX_RESULT),
         ):
-            return run_cell(tutor="claude-opus-4-8", mode="plain", run_cfg=None,
-                            date="20260626", results_root=str(root))
+            return run_cell(
+                tutor="claude-opus-4-8",
+                mode="plain",
+                run_cfg=None,
+                date="20260626",
+                results_root=str(root),
+            )
 
     root_serial = tmp_path / "serial"
     root_conc = tmp_path / "concurrent"
@@ -1131,7 +1265,9 @@ def test_replay_concurrency_error_isolation(tmp_path):
     moment still succeeds."""
     from tutorsim.cli import run_cell
 
-    scenarios = [_make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 5)]
+    scenarios = [
+        _make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 5)
+    ]
     bad = scenarios[1]
     good = [s for s in scenarios if s.id != bad.id]
 
@@ -1145,8 +1281,13 @@ def test_replay_concurrency_error_isolation(tmp_path):
         patch(_SCORE_PATCH, side_effect=_score_batch_from(anns)),
         patch(_TAX_PATCH, return_value=_TAX_RESULT),
     ):
-        run_id = run_cell(tutor="claude-opus-4-8", mode="plain", run_cfg=None,
-                          date="20260626", results_root=str(tmp_path))
+        run_id = run_cell(
+            tutor="claude-opus-4-8",
+            mode="plain",
+            run_cfg=None,
+            date="20260626",
+            results_root=str(tmp_path),
+        )
 
     run_dir = tmp_path / run_id
     summary = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
@@ -1174,7 +1315,9 @@ def test_replay_concurrency_resume(tmp_path):
     the already-done ones as resumed."""
     from tutorsim.cli import run_cell
 
-    scenarios = [_make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 4)]
+    scenarios = [
+        _make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 4)
+    ]
 
     # First run: complete only the first moment (sample=1).
     cfg1 = _make_run_config(sample=1, replay_concurrency=4)
@@ -1182,11 +1325,19 @@ def test_replay_concurrency_resume(tmp_path):
         patch(_CFG_PATCH, return_value=cfg1),
         patch(_LOAD_PATCH, return_value=_load_result(scenarios[:1])),
         patch(_CONV_PATCH, side_effect=_conv_by_sid(scenarios[:1])),
-        patch(_SCORE_PATCH, side_effect=_score_batch_from([_make_annotation(scenarios[0].id)])),
+        patch(
+            _SCORE_PATCH,
+            side_effect=_score_batch_from([_make_annotation(scenarios[0].id)]),
+        ),
         patch(_TAX_PATCH, return_value=_TAX_RESULT),
     ):
-        run_id = run_cell(tutor="claude-opus-4-8", mode="plain", run_cfg=None,
-                          date="20260626", results_root=str(tmp_path))
+        run_id = run_cell(
+            tutor="claude-opus-4-8",
+            mode="plain",
+            run_cfg=None,
+            date="20260626",
+            results_root=str(tmp_path),
+        )
 
     # Second run: all 3 moments; only the 2 new ones should be replayed.
     called_ids = []
@@ -1200,16 +1351,28 @@ def test_replay_concurrency_resume(tmp_path):
         patch(_CFG_PATCH, return_value=cfg2),
         patch(_LOAD_PATCH, return_value=_load_result(scenarios)),
         patch(_CONV_PATCH, side_effect=_tracking_conv),
-        patch(_SCORE_PATCH, side_effect=_score_batch_from([_make_annotation(s.id) for s in scenarios[1:]])),
+        patch(
+            _SCORE_PATCH,
+            side_effect=_score_batch_from(
+                [_make_annotation(s.id) for s in scenarios[1:]]
+            ),
+        ),
         patch(_TAX_PATCH, return_value=_TAX_RESULT),
     ):
-        run_id2 = run_cell(tutor="claude-opus-4-8", mode="plain", run_cfg=None,
-                           date="20260626", results_root=str(tmp_path))
+        run_id2 = run_cell(
+            tutor="claude-opus-4-8",
+            mode="plain",
+            run_cfg=None,
+            date="20260626",
+            results_root=str(tmp_path),
+        )
 
     assert run_id2 == run_id
     assert sorted(called_ids) == [scenarios[1].id, scenarios[2].id]
 
-    summary = json.loads((tmp_path / run_id2 / "summary.json").read_text(encoding="utf-8"))
+    summary = json.loads(
+        (tmp_path / run_id2 / "summary.json").read_text(encoding="utf-8")
+    )
     assert summary["run_counts"]["resumed"] == 1
     assert summary["run_counts"]["succeeded"] == 3
     assert summary["run_counts"]["failed"] == 0
@@ -1221,7 +1384,9 @@ def test_replay_concurrency_transcripts_survive_interrupt(tmp_path):
     conversation is on disk for resume instead of being lost."""
     from tutorsim.cli import run_cell
 
-    scenarios = [_make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 3)]
+    scenarios = [
+        _make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 3)
+    ]
     fast, doomed = scenarios
 
     def _conv(scenario, **kwargs):
@@ -1239,8 +1404,13 @@ def test_replay_concurrency_transcripts_survive_interrupt(tmp_path):
         patch(_TAX_PATCH, return_value=_TAX_RESULT),
         pytest.raises(KeyboardInterrupt),
     ):
-        run_cell(tutor="claude-opus-4-8", mode="plain", run_cfg=None,
-                 date="20260626", results_root=str(tmp_path))
+        run_cell(
+            tutor="claude-opus-4-8",
+            mode="plain",
+            run_cfg=None,
+            date="20260626",
+            results_root=str(tmp_path),
+        )
 
     # The completed moment was persisted before the interrupt; the doomed one
     # never produced a transcript.
@@ -1253,11 +1423,14 @@ def test_replay_concurrency_worker_logs_reach_run_log(tmp_path):
     client retry warnings) are captured in results/<run_id>/run.log."""
     from tutorsim.cli import run_cell
 
-    scenarios = [_make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 4)]
+    scenarios = [
+        _make_scenario(f"scenario_{i:03d}", "scaffolding") for i in range(1, 4)
+    ]
 
     def _conv(scenario, **kwargs):
         logging.getLogger("tutorsim.client").warning(
-            "simulated retry for %s", scenario.id)
+            "simulated retry for %s", scenario.id
+        )
         return _make_transcript(scenario.id)
 
     cfg = _make_run_config(sample=len(scenarios), replay_concurrency=3)
@@ -1269,8 +1442,13 @@ def test_replay_concurrency_worker_logs_reach_run_log(tmp_path):
         patch(_SCORE_PATCH, side_effect=_score_batch_from(anns)),
         patch(_TAX_PATCH, return_value=_TAX_RESULT),
     ):
-        run_id = run_cell(tutor="claude-opus-4-8", mode="plain", run_cfg=None,
-                          date="20260626", results_root=str(tmp_path))
+        run_id = run_cell(
+            tutor="claude-opus-4-8",
+            mode="plain",
+            run_cfg=None,
+            date="20260626",
+            results_root=str(tmp_path),
+        )
 
     content = (tmp_path / run_id / "run.log").read_text(encoding="utf-8")
     for s in scenarios:

--- a/tests/tutorsim/test_client.py
+++ b/tests/tutorsim/test_client.py
@@ -1,20 +1,36 @@
 import json
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from tutorsim.client import infer_provider, _anthropic_thinking_param, _strip_json_fences, _mime_from_path, build_batch_entry, write_jsonl, ModelClient, ModelResponse, run_sync_entries, run_batch
+
+from tutorsim.client import (
+    ModelClient,
+    ModelResponse,
+    _anthropic_thinking_param,
+    _mime_from_path,
+    _strip_json_fences,
+    build_batch_entry,
+    infer_provider,
+    run_batch,
+    run_sync_entries,
+    write_jsonl,
+)
 
 
-@pytest.mark.parametrize("model,expected", [
-    ("claude-opus-4-6", "anthropic"),
-    ("claude-haiku-4-5-20251001", "anthropic"),
-    ("gpt-5.5-2026-04-23", "openai"),
-    ("o1-preview", "openai"),
-    ("o3-mini", "openai"),
-    ("o4-mini", "openai"),
-    ("gemini-3.1-pro-preview", "gemini"),
-    ("deepseek-ai/DeepSeek-V3", "together"),
-    ("meta-llama/Llama-3.3-70B", "together"),
-])
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("claude-opus-4-6", "anthropic"),
+        ("claude-haiku-4-5-20251001", "anthropic"),
+        ("gpt-5.5-2026-04-23", "openai"),
+        ("o1-preview", "openai"),
+        ("o3-mini", "openai"),
+        ("o4-mini", "openai"),
+        ("gemini-3.1-pro-preview", "gemini"),
+        ("deepseek-ai/DeepSeek-V3", "together"),
+        ("meta-llama/Llama-3.3-70B", "together"),
+    ],
+)
 def test_infer_provider_routes_by_prefix(model, expected):
     assert infer_provider(model) == expected
 
@@ -30,7 +46,14 @@ def test_infer_provider_unknown_raises():
 
 class TestAnthropicThinkingParam:
     def test_adaptive_models_get_adaptive_shape(self):
-        for m in ("claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-sonnet-5", "claude-fable-5"):
+        for m in (
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-sonnet-5",
+            "claude-fable-5",
+        ):
             assert _anthropic_thinking_param(m, 0) == {"type": "adaptive"}
 
     def test_haiku_4_5_gets_legacy_enabled_shape(self):
@@ -38,10 +61,12 @@ class TestAnthropicThinkingParam:
         # (extended thinking only, per the Anthropic models overview) --
         # sending {"type": "adaptive"} there would 400.
         assert _anthropic_thinking_param("claude-haiku-4-5", 4096) == {
-            "type": "enabled", "budget_tokens": 4096,
+            "type": "enabled",
+            "budget_tokens": 4096,
         }
         assert _anthropic_thinking_param("claude-haiku-4-5-20251001", 0) == {
-            "type": "enabled", "budget_tokens": 16384,
+            "type": "enabled",
+            "budget_tokens": 16384,
         }
 
     def test_unknown_or_future_model_defaults_to_adaptive(self):
@@ -53,12 +78,14 @@ class TestAnthropicThinkingParam:
 
     def test_legacy_model_gets_enabled_with_budget(self):
         assert _anthropic_thinking_param("claude-sonnet-4-5", 8192) == {
-            "type": "enabled", "budget_tokens": 8192,
+            "type": "enabled",
+            "budget_tokens": 8192,
         }
 
     def test_legacy_model_zero_budget_defaults_16384(self):
         assert _anthropic_thinking_param("claude-sonnet-4-5", 0) == {
-            "type": "enabled", "budget_tokens": 16384,
+            "type": "enabled",
+            "budget_tokens": 16384,
         }
 
 
@@ -89,7 +116,9 @@ def test_build_batch_entry_json_mode_shape():
 
 
 def test_build_batch_entry_optional_fields():
-    e = build_batch_entry("k", "p", images=["a.png"], json_mode=False, cacheable_prefix="PRE")
+    e = build_batch_entry(
+        "k", "p", images=["a.png"], json_mode=False, cacheable_prefix="PRE"
+    )
     assert "response_mime_type" not in e["request"]["generation_config"]
     assert e["request"]["images"] == ["a.png"]
     assert e["cacheable_prefix"] == "PRE"
@@ -123,6 +152,7 @@ def test_modelclient_missing_key_raises(monkeypatch):
 # Task 6: generate() + provider builders + retry + usage/latency
 # ===================================================================
 
+
 def _fake_anthropic_message(text="hi", in_tok=10, out_tok=5):
     msg = MagicMock()
     block = MagicMock()
@@ -142,7 +172,9 @@ def test_generate_anthropic_returns_text_and_usage(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     with patch("anthropic.Anthropic") as MockAnthropic:
         client_obj = MagicMock()
-        client_obj.messages.create.return_value = _fake_anthropic_message("answer", 12, 3)
+        client_obj.messages.create.return_value = _fake_anthropic_message(
+            "answer", 12, 3
+        )
         MockAnthropic.return_value = client_obj
         c = ModelClient("claude-opus-4-6")
         resp = c.generate("Q", json_mode=False, max_tokens=64)
@@ -155,8 +187,10 @@ def test_generate_anthropic_returns_text_and_usage(monkeypatch):
 
 def test_generate_retries_then_succeeds(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    with patch("anthropic.Anthropic") as MockAnthropic, \
-         patch("tutorsim.client.time.sleep"):
+    with (
+        patch("anthropic.Anthropic") as MockAnthropic,
+        patch("tutorsim.client.time.sleep"),
+    ):
         client_obj = MagicMock()
         client_obj.messages.create.side_effect = [
             RuntimeError("boom"),
@@ -172,8 +206,10 @@ def test_generate_retries_then_succeeds(monkeypatch):
 def test_generate_exhausts_retries_raises(monkeypatch):
     """After max_retries failures, generate() raises RuntimeError."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    with patch("anthropic.Anthropic") as MockAnthropic, \
-         patch("tutorsim.client.time.sleep"):
+    with (
+        patch("anthropic.Anthropic") as MockAnthropic,
+        patch("tutorsim.client.time.sleep"),
+    ):
         client_obj = MagicMock()
         client_obj.messages.create.side_effect = RuntimeError("always fails")
         MockAnthropic.return_value = client_obj
@@ -199,7 +235,9 @@ def test_generate_anthropic_json_mode_adds_system_message(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     with patch("anthropic.Anthropic") as MockAnthropic:
         client_obj = MagicMock()
-        client_obj.messages.create.return_value = _fake_anthropic_message('{"a":1}', 5, 3)
+        client_obj.messages.create.return_value = _fake_anthropic_message(
+            '{"a":1}', 5, 3
+        )
         MockAnthropic.return_value = client_obj
         c = ModelClient("claude-opus-4-6")
         c.generate("Q", json_mode=True)
@@ -217,7 +255,9 @@ def test_generate_anthropic_output_schema_sets_format(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     with patch("anthropic.Anthropic") as MockAnthropic:
         client_obj = MagicMock()
-        client_obj.messages.create.return_value = _fake_anthropic_message('{"x":1}', 5, 2)
+        client_obj.messages.create.return_value = _fake_anthropic_message(
+            '{"x":1}', 5, 2
+        )
         MockAnthropic.return_value = client_obj
         c = ModelClient("claude-opus-4-8")
         schema = {
@@ -242,7 +282,8 @@ def test_generate_output_schema_rejected_for_non_anthropic(monkeypatch):
 
 
 def test_get_retry_config_values():
-    from tutorsim.config import get_retry_config, get_batch_timeout
+    from tutorsim.config import get_batch_timeout, get_retry_config
+
     cfg = get_retry_config()
     assert cfg["max_retries"] == 5
     assert cfg["base_delay"] == 5
@@ -255,14 +296,13 @@ def test_get_retry_config_values():
 
 from tutorsim.client import (
     VISION_CAPABLE_PREFIXES,
-    validate_vision_support,
     _base64_bytes,
-    _presigned_url,
     _build_image_blocks_anthropic,
-    _build_image_blocks_openai,
     _build_image_blocks_gemini,
+    _build_image_blocks_openai,
+    _presigned_url,
     _should_use_presigned_url,
-    _interleave_text_and_images,
+    validate_vision_support,
 )
 
 
@@ -298,6 +338,7 @@ class TestShouldUsePresignedUrl:
 class TestBase64Bytes:
     def test_returns_base64_string_from_file(self, tmp_path):
         import base64
+
         p = tmp_path / "test.png"
         raw = b"\x89PNG fake"
         p.write_bytes(raw)
@@ -311,7 +352,9 @@ class TestBase64Bytes:
 class TestPresignedUrl:
     def test_delegates_to_backend(self):
         with patch("tutorsim.client._get_backend") as mock_be:
-            mock_be.return_value.get_presigned_url.return_value = "https://example.com/img.png"
+            mock_be.return_value.get_presigned_url.return_value = (
+                "https://example.com/img.png"
+            )
             result = _presigned_url("images/img.png", expires_seconds=3600)
         assert result == "https://example.com/img.png"
         mock_be.return_value.get_presigned_url.assert_called_once_with(
@@ -325,7 +368,9 @@ class TestBuildImageBlocksAnthropic:
 
     def test_base64_block_shape(self):
         with patch("tutorsim.client._base64_bytes", return_value="ZmFrZQ=="):
-            blocks = _build_image_blocks_anthropic(["photo.png"], use_url=False, enable_cache=False)
+            blocks = _build_image_blocks_anthropic(
+                ["photo.png"], use_url=False, enable_cache=False
+            )
         assert len(blocks) == 1
         b = blocks[0]
         assert b["type"] == "image"
@@ -336,19 +381,28 @@ class TestBuildImageBlocksAnthropic:
 
     def test_cache_control_added_when_enable_cache(self):
         with patch("tutorsim.client._base64_bytes", return_value="ZmFrZQ=="):
-            blocks = _build_image_blocks_anthropic(["photo.jpg"], use_url=False, enable_cache=True)
+            blocks = _build_image_blocks_anthropic(
+                ["photo.jpg"], use_url=False, enable_cache=True
+            )
         assert blocks[0]["cache_control"] == {"type": "ephemeral"}
 
     def test_url_block_shape(self):
-        with patch("tutorsim.client._presigned_url", return_value="https://s3.example.com/img.png"):
-            blocks = _build_image_blocks_anthropic(["photo.png"], use_url=True, enable_cache=False)
+        with patch(
+            "tutorsim.client._presigned_url",
+            return_value="https://s3.example.com/img.png",
+        ):
+            blocks = _build_image_blocks_anthropic(
+                ["photo.png"], use_url=True, enable_cache=False
+            )
         b = blocks[0]
         assert b["source"]["type"] == "url"
         assert b["source"]["url"] == "https://s3.example.com/img.png"
 
     def test_multiple_images(self):
         with patch("tutorsim.client._base64_bytes", side_effect=["b64a", "b64b"]):
-            blocks = _build_image_blocks_anthropic(["a.png", "b.webp"], use_url=False, enable_cache=False)
+            blocks = _build_image_blocks_anthropic(
+                ["a.png", "b.webp"], use_url=False, enable_cache=False
+            )
         assert len(blocks) == 2
         assert blocks[0]["source"]["media_type"] == "image/png"
         assert blocks[1]["source"]["media_type"] == "image/webp"
@@ -365,7 +419,10 @@ class TestBuildImageBlocksOpenAI:
         assert "ZmFrZQ==" in b["image_url"]["url"]
 
     def test_presigned_url_shape(self):
-        with patch("tutorsim.client._presigned_url", return_value="https://cdn.example.com/img.jpg"):
+        with patch(
+            "tutorsim.client._presigned_url",
+            return_value="https://cdn.example.com/img.jpg",
+        ):
             blocks = _build_image_blocks_openai(["photo.jpg"], use_url=True)
         b = blocks[0]
         assert b["image_url"]["url"] == "https://cdn.example.com/img.jpg"
@@ -401,13 +458,22 @@ def test_anthropic_cacheable_prefix_is_separate_block(monkeypatch):
     with patch("anthropic.Anthropic") as anth:
         client_obj = MagicMock()
         captured = {}
+
         def _create(**kwargs):
             captured.update(kwargs)
             m = MagicMock()
-            b = MagicMock(); b.type = "text"; b.text = "ok"; m.content = [b]
-            m.usage = MagicMock(input_tokens=1, output_tokens=1,
-                                cache_creation_input_tokens=0, cache_read_input_tokens=0)
+            b = MagicMock()
+            b.type = "text"
+            b.text = "ok"
+            m.content = [b]
+            m.usage = MagicMock(
+                input_tokens=1,
+                output_tokens=1,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
             return m
+
         client_obj.messages.create.side_effect = _create
         anth.return_value = client_obj
         c = ModelClient("claude-opus-4-6")
@@ -424,13 +490,15 @@ def test_anthropic_cacheable_prefix_is_separate_block(monkeypatch):
 # Task 8: run_sync_entries + run_batch (anthropic/openai/gemini)
 # ===================================================================
 
+
 def test_run_sync_entries_collects_by_key(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     with patch("anthropic.Anthropic") as MockAnthropic:
         MockAnthropic.return_value = MagicMock()
         c = ModelClient("claude-opus-4-6")
         with patch.object(
-            c, "generate",
+            c,
+            "generate",
             return_value=ModelResponse(
                 "R", {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}, 0.0
             ),
@@ -451,13 +519,19 @@ def test_run_sync_entries_records_error_per_key(monkeypatch):
             out = run_sync_entries(c, [build_batch_entry("k1", "p1")])
     assert out["k1"]["text"] == ""
     assert "boom" in out["k1"]["error"]
-    assert out["k1"]["usage"] == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    assert out["k1"]["usage"] == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+    }
 
 
 def test_run_batch_anthropic_remaps_custom_ids(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    with patch("anthropic.Anthropic") as MockAnthropic, \
-         patch("tutorsim.client.time.sleep"):
+    with (
+        patch("anthropic.Anthropic") as MockAnthropic,
+        patch("tutorsim.client.time.sleep"),
+    ):
         client_obj = MagicMock()
         batch = MagicMock()
         batch.id = "b1"
@@ -478,11 +552,15 @@ def test_run_batch_anthropic_remaps_custom_ids(monkeypatch):
             r.result.message = msg
             return r
 
-        client_obj.messages.batches.results.return_value = [_result(0, "A"), _result(1, "B")]
+        client_obj.messages.batches.results.return_value = [
+            _result(0, "A"),
+            _result(1, "B"),
+        ]
         MockAnthropic.return_value = client_obj
         c = ModelClient("claude-opus-4-6")
         out = run_batch(
-            c, [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")],
+            c,
+            [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")],
             poll_interval=0,
         )
     assert out["kA"]["text"] == "A"
@@ -493,8 +571,10 @@ def test_run_batch_anthropic_sends_thinking_and_effort(monkeypatch):
     """Batch requests must carry the same thinking/effort params as sync calls
     (benchmark fidelity: batch mode may not silently diverge from run_conversation)."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    with patch("anthropic.Anthropic") as MockAnthropic, \
-         patch("tutorsim.client.time.sleep"):
+    with (
+        patch("anthropic.Anthropic") as MockAnthropic,
+        patch("tutorsim.client.time.sleep"),
+    ):
         client_obj = MagicMock()
         batch = MagicMock()
         batch.id = "b1"
@@ -505,8 +585,11 @@ def test_run_batch_anthropic_sends_thinking_and_effort(monkeypatch):
         MockAnthropic.return_value = client_obj
         c = ModelClient("claude-opus-4-8")
         run_batch(
-            c, [build_batch_entry("kA", "pA")],
-            poll_interval=0, thinking=True, effort="xhigh",
+            c,
+            [build_batch_entry("kA", "pA")],
+            poll_interval=0,
+            thinking=True,
+            effort="xhigh",
         )
         (submitted,) = client_obj.messages.batches.create.call_args.kwargs["requests"]
     assert submitted["params"]["thinking"] == {"type": "adaptive"}
@@ -516,8 +599,10 @@ def test_run_batch_anthropic_sends_thinking_and_effort(monkeypatch):
 def test_run_batch_anthropic_resume_rebuilds_id_map(monkeypatch):
     """Resume via existing_batch_id must rebuild the deterministic r{i} map."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
-    with patch("anthropic.Anthropic") as MockAnthropic, \
-         patch("tutorsim.client.time.sleep"):
+    with (
+        patch("anthropic.Anthropic") as MockAnthropic,
+        patch("tutorsim.client.time.sleep"),
+    ):
         client_obj = MagicMock()
         batch = MagicMock()
         batch.id = "b1"
@@ -537,12 +622,17 @@ def test_run_batch_anthropic_resume_rebuilds_id_map(monkeypatch):
             r.result.message = msg
             return r
 
-        client_obj.messages.batches.results.return_value = [_result(0, "A"), _result(1, "B")]
+        client_obj.messages.batches.results.return_value = [
+            _result(0, "A"),
+            _result(1, "B"),
+        ]
         MockAnthropic.return_value = client_obj
         c = ModelClient("claude-opus-4-6")
         out = run_batch(
-            c, [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")],
-            poll_interval=0, existing_batch_id="b1",
+            c,
+            [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")],
+            poll_interval=0,
+            existing_batch_id="b1",
         )
     # No fresh submission on resume.
     client_obj.messages.batches.create.assert_not_called()
@@ -553,8 +643,7 @@ def test_run_batch_anthropic_resume_rebuilds_id_map(monkeypatch):
 
 def test_run_batch_openai_parses_results(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    with patch("openai.OpenAI") as MockOpenAI, \
-         patch("tutorsim.client.time.sleep"):
+    with patch("openai.OpenAI") as MockOpenAI, patch("tutorsim.client.time.sleep"):
         client_obj = MagicMock()
         uploaded = MagicMock()
         uploaded.id = "file-1"
@@ -567,13 +656,21 @@ def test_run_batch_openai_parses_results(monkeypatch):
         client_obj.batches.retrieve.return_value = batch
 
         lines = "\n".join(
-            json.dumps({
-                "custom_id": cid,
-                "response": {"body": {
-                    "choices": [{"message": {"content": text}}],
-                    "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
-                }},
-            })
+            json.dumps(
+                {
+                    "custom_id": cid,
+                    "response": {
+                        "body": {
+                            "choices": [{"message": {"content": text}}],
+                            "usage": {
+                                "prompt_tokens": 2,
+                                "completion_tokens": 3,
+                                "total_tokens": 5,
+                            },
+                        }
+                    },
+                }
+            )
             for cid, text in [("kA", "A"), ("kB", "B")]
         )
         content_obj = MagicMock()
@@ -582,7 +679,8 @@ def test_run_batch_openai_parses_results(monkeypatch):
         MockOpenAI.return_value = client_obj
         c = ModelClient("gpt-5.4")
         out = run_batch(
-            c, [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")],
+            c,
+            [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")],
             poll_interval=0,
         )
     assert out["kA"]["text"] == "A"
@@ -593,8 +691,7 @@ def test_run_batch_openai_parses_results(monkeypatch):
 
 def test_run_batch_gemini_parses_results(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "key-test")
-    with patch("google.genai.Client") as MockGenai, \
-         patch("tutorsim.client.time.sleep"):
+    with patch("google.genai.Client") as MockGenai, patch("tutorsim.client.time.sleep"):
         client_obj = MagicMock()
         uploaded = MagicMock()
         uploaded.name = "files/up1"
@@ -607,24 +704,27 @@ def test_run_batch_gemini_parses_results(monkeypatch):
         client_obj.batches.get.return_value = batch
 
         lines = "\n".join(
-            json.dumps({
-                "key": key,
-                "response": {
-                    "candidates": [{"content": {"parts": [{"text": text}]}}],
-                    "usageMetadata": {
-                        "promptTokenCount": 4,
-                        "candidatesTokenCount": 6,
-                        "totalTokenCount": 10,
+            json.dumps(
+                {
+                    "key": key,
+                    "response": {
+                        "candidates": [{"content": {"parts": [{"text": text}]}}],
+                        "usageMetadata": {
+                            "promptTokenCount": 4,
+                            "candidatesTokenCount": 6,
+                            "totalTokenCount": 10,
+                        },
                     },
-                },
-            })
+                }
+            )
             for key, text in [("kA", "A"), ("kB", "B")]
         )
         client_obj.files.download.return_value = lines.encode("utf-8")
         MockGenai.return_value = client_obj
         c = ModelClient("gemini-3.1-pro-preview")
         out = run_batch(
-            c, [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")],
+            c,
+            [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")],
             poll_interval=0,
         )
     assert out["kA"]["text"] == "A"

--- a/tests/tutorsim/test_config.py
+++ b/tests/tutorsim/test_config.py
@@ -6,16 +6,32 @@ def test_packaged_default_config_parses_and_has_expected_roster():
     cfg = cfgmod.load_config()
     assert set(cfg["providers"]) == {"anthropic", "openai", "gemini", "together"}
     assert set(cfg["models"]) == {
-        "claude-opus-4-8", "claude-sonnet-4-6", "claude-sonnet-5",
-        "gemini-2.5-pro", "gemini-3.5-flash",
-        "gpt-5.4-mini-2026-03-17", "gpt-5.5-2026-04-23", "deepseek-ai/DeepSeek-V4-Pro",
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+        "claude-sonnet-5",
+        "gemini-2.5-pro",
+        "gemini-3.5-flash",
+        "gpt-5.4-mini-2026-03-17",
+        "gpt-5.5-2026-04-23",
+        "deepseek-ai/DeepSeek-V4-Pro",
     }
     assert cfg["models"]["claude-opus-4-8"] == {"thinking": True, "effort": "xhigh"}
-    assert cfg["models"]["claude-sonnet-5"] == {"thinking": "adaptive", "effort": "xhigh"}
+    assert cfg["models"]["claude-sonnet-5"] == {
+        "thinking": "adaptive",
+        "effort": "xhigh",
+    }
     assert cfg["models"]["deepseek-ai/DeepSeek-V4-Pro"] == {}
-    assert cfg["student"] == {"model": "claude-opus-4-6", "mode": "oracle", "thinking": False}
+    assert cfg["student"] == {
+        "model": "claude-opus-4-6",
+        "mode": "oracle",
+        "thinking": False,
+    }
     assert cfg["scorer"] == {"model": "claude-opus-4-6", "thinking": "adaptive"}
-    assert cfg["taxonomy"] == {"model": "claude-opus-4-8", "thinking": False, "batch_size": 50}
+    assert cfg["taxonomy"] == {
+        "model": "claude-opus-4-8",
+        "thinking": False,
+        "batch_size": 50,
+    }
     assert cfg["defaults"] == {"trials": 1, "max_turns": 5}
     assert cfg["retry"] == {"max_retries": 5, "base_delay": 5}
     assert cfg["batch"] == {"timeout": 86400}
@@ -92,6 +108,7 @@ def test_resolve_model_gemini():
 
 def test_resolve_model_unknown_raises():
     import pytest
+
     with pytest.raises(ValueError):
         cfgmod.resolve_model("gpt-9-imaginary")
 
@@ -114,13 +131,21 @@ def test_build_run_config_defaults():
     # row-sampling implementation) and only misled about reproducibility.
     assert not hasattr(rc, "seed")
     assert rc.sample is None
-    assert rc.resolved_tutors["claude-opus-4-8"] == {"thinking": True, "effort": "xhigh"}
+    assert rc.resolved_tutors["claude-opus-4-8"] == {
+        "thinking": True,
+        "effort": "xhigh",
+    }
 
 
 def test_build_run_config_overrides():
-    rc = cfgmod.build_run_config(tutors=["gpt-5.5-2026-04-23"], modes=["plain"], sample=10, trials=3)
+    rc = cfgmod.build_run_config(
+        tutors=["gpt-5.5-2026-04-23"], modes=["plain"], sample=10, trials=3
+    )
     assert rc.modes == ["plain"] and rc.sample == 10 and rc.trials == 3
-    assert rc.resolved_tutors["gpt-5.5-2026-04-23"] == {"thinking": True, "reasoning_effort": "high"}
+    assert rc.resolved_tutors["gpt-5.5-2026-04-23"] == {
+        "thinking": True,
+        "reasoning_effort": "high",
+    }
 
 
 def test_register_and_lookup_tutor():
@@ -166,4 +191,7 @@ def test_groundtruth_phase_config_shape():
 def test_get_labeller_config_routes_by_type():
     cfgmod._reset_config_cache()
     labeller = cfgmod.get_labeller_config()
-    assert labeller == {"scaffolding": "classify_scaffolding", "rapport": "classify_rapport"}
+    assert labeller == {
+        "scaffolding": "classify_scaffolding",
+        "rapport": "classify_rapport",
+    }

--- a/tests/tutorsim/test_conversation.py
+++ b/tests/tutorsim/test_conversation.py
@@ -2,16 +2,18 @@
 
 TDD: tests written first, then implementation.
 """
-import pytest
-from unittest.mock import MagicMock
+
 from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
 
 from tutorsim.moments import Moment as Scenario
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _resp(text, usage=None, latency=None):
     """Build a fake LLM response."""
@@ -29,7 +31,11 @@ _FROZEN_TRAIT = {
 def _make_scenario(cut_turn=5, persona="fake-persona"):
     """Build a minimal Scenario for testing (carries a frozen student trait)."""
     context = [
-        {"turn_number": i + 1, "role": "tutor" if i % 2 == 0 else "student", "text": f"text {i + 1}"}
+        {
+            "turn_number": i + 1,
+            "role": "tutor" if i % 2 == 0 else "student",
+            "text": f"text {i + 1}",
+        }
         for i in range(cut_turn)
     ]
     return Scenario(
@@ -95,9 +101,11 @@ def _patch_all(monkeypatch, tutor_responses, student_responses):
 # Tests: module imports and Transcript dataclass
 # ---------------------------------------------------------------------------
 
+
 def test_imports():
     """Module and Transcript are importable."""
     from tutorsim.conversation import Transcript, run_conversation
+
     assert Transcript is not None
     assert run_conversation is not None
 
@@ -105,6 +113,7 @@ def test_imports():
 def test_transcript_defaults():
     """Transcript has sensible defaults."""
     from tutorsim.conversation import Transcript
+
     t = Transcript(scenario_id="abc", tutor_model="m")
     assert t.scenario_id == "abc"
     assert t.tutor_model == "m"
@@ -120,6 +129,7 @@ def test_transcript_defaults():
 def test_transcript_to_dict():
     """to_dict() returns all fields."""
     from tutorsim.conversation import Transcript
+
     t = Transcript(scenario_id="x", tutor_model="y")
     d = t.to_dict()
     assert d["scenario_id"] == "x"
@@ -131,8 +141,10 @@ def test_transcript_to_dict():
 # Tests: private helpers
 # ---------------------------------------------------------------------------
 
+
 def test_parse_tutor_tokens_no_tokens():
     from tutorsim.conversation import _parse_tutor_tokens
+
     text, ended, changed = _parse_tutor_tokens("Hello there!")
     assert text == "Hello there!"
     assert ended is False
@@ -141,6 +153,7 @@ def test_parse_tutor_tokens_no_tokens():
 
 def test_parse_tutor_tokens_end():
     from tutorsim.conversation import _parse_tutor_tokens
+
     text, ended, changed = _parse_tutor_tokens("Great work! [END]")
     assert "[END]" not in text
     assert ended is True
@@ -149,6 +162,7 @@ def test_parse_tutor_tokens_end():
 
 def test_parse_tutor_tokens_problem_change():
     from tutorsim.conversation import _parse_tutor_tokens
+
     text, ended, changed = _parse_tutor_tokens("OK, let's move on. [PROBLEM_CHANGE]")
     assert "[PROBLEM_CHANGE]" not in text
     assert ended is False
@@ -158,6 +172,7 @@ def test_parse_tutor_tokens_problem_change():
 def test_parse_tutor_tokens_next_problem_legacy():
     """[NEXT_PROBLEM] is the legacy alias for [PROBLEM_CHANGE]."""
     from tutorsim.conversation import _parse_tutor_tokens
+
     text, ended, changed = _parse_tutor_tokens("Done! [NEXT_PROBLEM]")
     assert "[NEXT_PROBLEM]" not in text
     assert ended is False
@@ -167,6 +182,7 @@ def test_parse_tutor_tokens_next_problem_legacy():
 def test_parse_tutor_tokens_end_takes_precedence():
     """When both END and PROBLEM_CHANGE appear, ended wins."""
     from tutorsim.conversation import _parse_tutor_tokens
+
     text, ended, changed = _parse_tutor_tokens("[END] [PROBLEM_CHANGE]")
     assert ended is True
     assert changed is False
@@ -174,33 +190,39 @@ def test_parse_tutor_tokens_end_takes_precedence():
 
 def test_split_messages_single():
     from tutorsim.conversation import _split_messages
+
     assert _split_messages("Hello") == ["Hello"]
 
 
 def test_split_messages_next_delimiter():
     from tutorsim.conversation import _split_messages
+
     result = _split_messages("Msg1 [NEXT] Msg2")
     assert result == ["Msg1", "Msg2"]
 
 
 def test_split_messages_new_message_delimiter():
     from tutorsim.conversation import _split_messages
+
     result = _split_messages("Msg1 [NEW_MESSAGE] Msg2")
     assert result == ["Msg1", "Msg2"]
 
 
 def test_split_messages_empty_string():
     from tutorsim.conversation import _split_messages
+
     assert _split_messages("") == []
 
 
 def test_split_messages_whitespace_only():
     from tutorsim.conversation import _split_messages
+
     assert _split_messages("   ") == []
 
 
 def test_add_usage():
     from tutorsim.conversation import _add_usage
+
     total = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
     _add_usage(total, {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5})
     assert total == {"input_tokens": 13, "output_tokens": 7, "total_tokens": 20}
@@ -209,6 +231,7 @@ def test_add_usage():
 def test_add_usage_missing_keys():
     """Missing keys in new dict are treated as 0."""
     from tutorsim.conversation import _add_usage
+
     total = {"input_tokens": 10, "output_tokens": 0, "total_tokens": 10}
     _add_usage(total, {})
     assert total["input_tokens"] == 10
@@ -217,6 +240,7 @@ def test_add_usage_missing_keys():
 def test_format_transcript_prefix():
     """_format_transcript_prefix uses real turn_number and UPPERCASE role."""
     from tutorsim.conversation import _format_transcript_prefix
+
     context = [
         {"turn_number": 26, "role": "tutor", "text": "Hello!"},
         {"turn_number": 27, "role": "student", "text": "Hi there."},
@@ -228,6 +252,7 @@ def test_format_transcript_prefix():
 def test_format_transcript_prefix_real_turn_numbers():
     """Non-sequential turn numbers (e.g. from enrichments) are preserved exactly."""
     from tutorsim.conversation import _format_transcript_prefix
+
     context = [
         {"turn_number": 5, "role": "tutor", "text": "A"},
         {"turn_number": 7, "role": "student", "text": "B"},
@@ -239,6 +264,7 @@ def test_format_transcript_prefix_real_turn_numbers():
 
 def test_format_transcript_prefix_empty():
     from tutorsim.conversation import _format_transcript_prefix
+
     assert _format_transcript_prefix([]) == ""
 
 
@@ -246,12 +272,18 @@ def test_format_transcript_prefix_empty():
 # Tests: run_conversation happy path
 # ---------------------------------------------------------------------------
 
+
 def test_run_conversation_single_round_end(monkeypatch):
     """Tutor says [END] after first turn -> conversation stops after 1 tutor turn."""
     from tutorsim.conversation import run_conversation
 
     scenario = _make_scenario(cut_turn=5)
-    tutor_resp = [_resp("Good job! [END]", usage={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15})]
+    tutor_resp = [
+        _resp(
+            "Good job! [END]",
+            usage={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        )
+    ]
     student_resp = []  # never called
 
     tutor_client, student_client = _patch_all(monkeypatch, tutor_resp, student_resp)
@@ -387,6 +419,7 @@ def test_run_conversation_multi_message_split(monkeypatch):
 # Tests: usage accumulation
 # ---------------------------------------------------------------------------
 
+
 def test_run_conversation_usage_accumulated(monkeypatch):
     """Token usage is summed across all tutor calls."""
     from tutorsim.conversation import run_conversation
@@ -396,7 +429,9 @@ def test_run_conversation_usage_accumulated(monkeypatch):
     usage2 = {"input_tokens": 8, "output_tokens": 3, "total_tokens": 11}
 
     tutor_resp = [_resp("T1", usage=usage1), _resp("[END]", usage=usage2)]
-    student_resp = [_resp("S1", usage={"input_tokens": 4, "output_tokens": 2, "total_tokens": 6})]
+    student_resp = [
+        _resp("S1", usage={"input_tokens": 4, "output_tokens": 2, "total_tokens": 6})
+    ]
 
     _patch_all(monkeypatch, tutor_resp, student_resp)
 
@@ -440,6 +475,7 @@ def test_run_conversation_none_latency_not_appended(monkeypatch):
 # Tests: scenario_id and tutor_model on Transcript
 # ---------------------------------------------------------------------------
 
+
 def test_run_conversation_transcript_ids(monkeypatch):
     """Transcript carries correct scenario_id and tutor_model."""
     from tutorsim.conversation import run_conversation
@@ -456,6 +492,7 @@ def test_run_conversation_transcript_ids(monkeypatch):
 # ---------------------------------------------------------------------------
 # Tests: registered (callable) tutor/student
 # ---------------------------------------------------------------------------
+
 
 def test_registered_tutor(monkeypatch):
     """Registered tutor callable is invoked with generated_turns."""
@@ -476,8 +513,12 @@ def test_registered_tutor(monkeypatch):
         "tutorsim.conversation.resolve_student",
         lambda id=None: {"kind": "registered", "fn": lambda turns: "student reply"},
     )
-    monkeypatch.setattr("tutorsim.conversation.build_tutor_system_prompt", lambda mode, **kw: "SYS")
-    monkeypatch.setattr("tutorsim.conversation.build_student_system_prompt", lambda **kw: "SYS")
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_tutor_system_prompt", lambda mode, **kw: "SYS"
+    )
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_student_system_prompt", lambda **kw: "SYS"
+    )
 
     result = run_conversation(scenario, "custom-tutor", max_turns=4)
 
@@ -513,8 +554,12 @@ def test_registered_student(monkeypatch):
         "tutorsim.conversation.resolve_student",
         lambda id=None: {"kind": "registered", "fn": fake_student},
     )
-    monkeypatch.setattr("tutorsim.conversation.build_tutor_system_prompt", lambda mode, **kw: "SYS")
-    monkeypatch.setattr("tutorsim.conversation.build_student_system_prompt", lambda **kw: "SYS")
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_tutor_system_prompt", lambda mode, **kw: "SYS"
+    )
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_student_system_prompt", lambda **kw: "SYS"
+    )
 
     result = run_conversation(scenario, "custom-tutor", max_turns=4)
 
@@ -525,6 +570,7 @@ def test_registered_student(monkeypatch):
 # ---------------------------------------------------------------------------
 # Tests: cacheable prefix passed to generate
 # ---------------------------------------------------------------------------
+
 
 def test_cacheable_prefix_passed_to_client(monkeypatch):
     """Client.generate is called with cacheable_prefix (the static head)."""
@@ -547,8 +593,13 @@ def test_cacheable_prefix_passed_to_client(monkeypatch):
         "tutorsim.conversation.resolve_student",
         lambda id=None: {"kind": "hosted", "client": student_client, "kwargs": {}},
     )
-    monkeypatch.setattr("tutorsim.conversation.build_tutor_system_prompt", lambda mode, **kw: "TUTOR_SYS")
-    monkeypatch.setattr("tutorsim.conversation.build_student_system_prompt", lambda **kw: "STUDENT_SYS")
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_tutor_system_prompt",
+        lambda mode, **kw: "TUTOR_SYS",
+    )
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_student_system_prompt", lambda **kw: "STUDENT_SYS"
+    )
 
     run_conversation(scenario, "fake-tutor", max_turns=4)
 
@@ -564,6 +615,7 @@ def test_cacheable_prefix_passed_to_client(monkeypatch):
 # Tests: frozen student trait (schema v2 — the runtime consumes, never generates)
 # ---------------------------------------------------------------------------
 
+
 def test_frozen_persona_flows_into_student_system_prompt(monkeypatch):
     """The persona handed to build_student_system_prompt is the scenario's
     frozen student.trait.persona — no trait generation happens."""
@@ -574,7 +626,9 @@ def test_frozen_persona_flows_into_student_system_prompt(monkeypatch):
 
     tutor_client = MagicMock()
     tutor_client.model = "fake-tutor"
-    tutor_client.generate = MagicMock(side_effect=[_resp("Hello there"), _resp("[END]")])
+    tutor_client.generate = MagicMock(
+        side_effect=[_resp("Hello there"), _resp("[END]")]
+    )
     student_client = MagicMock()
     student_client.model = "fake-student"
     student_client.generate = MagicMock(return_value=_resp("OK"))
@@ -587,13 +641,18 @@ def test_frozen_persona_flows_into_student_system_prompt(monkeypatch):
         "tutorsim.conversation.resolve_student",
         lambda id=None: {"kind": "hosted", "client": student_client, "kwargs": {}},
     )
-    monkeypatch.setattr("tutorsim.conversation.build_tutor_system_prompt", lambda mode, **kw: "TUTOR_SYS")
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_tutor_system_prompt",
+        lambda mode, **kw: "TUTOR_SYS",
+    )
 
     def capture_student_prompt(**kw):
         seen.update(kw)
         return "STUDENT_SYS"
 
-    monkeypatch.setattr("tutorsim.conversation.build_student_system_prompt", capture_student_prompt)
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_student_system_prompt", capture_student_prompt
+    )
 
     run_conversation(scenario, "fake-tutor", max_turns=4)
     assert seen.get("persona") == "oracle-frozen-persona"
@@ -622,8 +681,13 @@ def test_hosted_student_without_trait_is_hard_error(monkeypatch):
         "tutorsim.conversation.resolve_student",
         lambda id=None: {"kind": "hosted", "client": student_client, "kwargs": {}},
     )
-    monkeypatch.setattr("tutorsim.conversation.build_tutor_system_prompt", lambda mode, **kw: "TUTOR_SYS")
-    monkeypatch.setattr("tutorsim.conversation.build_student_system_prompt", lambda **kw: "STUDENT_SYS")
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_tutor_system_prompt",
+        lambda mode, **kw: "TUTOR_SYS",
+    )
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_student_system_prompt", lambda **kw: "STUDENT_SYS"
+    )
 
     with pytest.raises(RuntimeError, match="frozen student trait"):
         run_conversation(scenario, "fake-tutor", max_turns=4)
@@ -644,8 +708,12 @@ def test_registered_student_needs_no_trait(monkeypatch):
         "tutorsim.conversation.resolve_student",
         lambda id=None: {"kind": "registered", "fn": lambda turns: "student reply"},
     )
-    monkeypatch.setattr("tutorsim.conversation.build_tutor_system_prompt", lambda mode, **kw: "SYS")
-    monkeypatch.setattr("tutorsim.conversation.build_student_system_prompt", lambda **kw: "SYS")
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_tutor_system_prompt", lambda mode, **kw: "SYS"
+    )
+    monkeypatch.setattr(
+        "tutorsim.conversation.build_student_system_prompt", lambda **kw: "SYS"
+    )
 
     result = run_conversation(scenario, "custom-tutor", max_turns=4)
     assert result.ended_via == "END"
@@ -655,11 +723,17 @@ def test_registered_student_needs_no_trait(monkeypatch):
 # Helpers for batch tests
 # ---------------------------------------------------------------------------
 
+
 def _make_scenario_id(sid: str, cut_turn: int = 5) -> "Scenario":
     """Like _make_scenario but with a custom scenario id."""
     from tutorsim.moments import Moment as Scenario
+
     context = [
-        {"turn_number": i + 1, "role": "tutor" if i % 2 == 0 else "student", "text": f"text {i + 1}"}
+        {
+            "turn_number": i + 1,
+            "role": "tutor" if i % 2 == 0 else "student",
+            "text": f"text {i + 1}",
+        }
         for i in range(cut_turn)
     ]
     return Scenario(
@@ -688,8 +762,13 @@ def _make_scenario_id(sid: str, cut_turn: int = 5) -> "Scenario":
     )
 
 
-def _patch_batch(monkeypatch, tutor_batch_results: list[dict], student_batch_results: list[dict],
-                 tutor_kwargs: dict | None = None, student_kwargs: dict | None = None):
+def _patch_batch(
+    monkeypatch,
+    tutor_batch_results: list[dict],
+    student_batch_results: list[dict],
+    tutor_kwargs: dict | None = None,
+    student_kwargs: dict | None = None,
+):
     """Patch resolve_tutor, resolve_student, system prompts, trait, and tutorsim.client.run_batch.
 
     tutor_batch_results: list of {sid: {"text": ...}} dicts, one per round.
@@ -707,11 +786,19 @@ def _patch_batch(monkeypatch, tutor_batch_results: list[dict], student_batch_res
 
     monkeypatch.setattr(
         "tutorsim.conversation.resolve_tutor",
-        lambda id: {"kind": "hosted", "client": tutor_client, "kwargs": tutor_kwargs or {}},
+        lambda id: {
+            "kind": "hosted",
+            "client": tutor_client,
+            "kwargs": tutor_kwargs or {},
+        },
     )
     monkeypatch.setattr(
         "tutorsim.conversation.resolve_student",
-        lambda id=None: {"kind": "hosted", "client": student_client, "kwargs": student_kwargs or {}},
+        lambda id=None: {
+            "kind": "hosted",
+            "client": student_client,
+            "kwargs": student_kwargs or {},
+        },
     )
     monkeypatch.setattr(
         "tutorsim.conversation.build_tutor_system_prompt",
@@ -746,9 +833,11 @@ def _patch_batch(monkeypatch, tutor_batch_results: list[dict], student_batch_res
 # Tests: run_conversations_batch
 # ---------------------------------------------------------------------------
 
+
 def test_batch_import():
     """run_conversations_batch is importable."""
     from tutorsim.conversation import run_conversations_batch
+
     assert run_conversations_batch is not None
 
 
@@ -761,8 +850,14 @@ def test_batch_two_scenarios_returns_two_transcripts(monkeypatch):
 
     # Round 1: both tutors reply normally, both students reply normally.
     # max_turns=2 => 1 round (1 tutor + 1 student = 2 speaking turns).
-    tutor_round1 = {"sid-1": {"text": "Hello from tutor"}, "sid-2": {"text": "Hi from tutor"}}
-    student_round1 = {"sid-1": {"text": "Student reply 1"}, "sid-2": {"text": "Student reply 2"}}
+    tutor_round1 = {
+        "sid-1": {"text": "Hello from tutor"},
+        "sid-2": {"text": "Hi from tutor"},
+    }
+    student_round1 = {
+        "sid-1": {"text": "Student reply 1"},
+        "sid-2": {"text": "Student reply 2"},
+    }
 
     _patch_batch(monkeypatch, [tutor_round1], [student_round1])
 
@@ -788,7 +883,9 @@ def test_batch_forwards_roster_thinking_and_effort_to_run_batch(monkeypatch):
     student_round1 = {"sid-1": {"text": "Student reply"}}
 
     run_batch_mock = _patch_batch(
-        monkeypatch, [tutor_round1], [student_round1],
+        monkeypatch,
+        [tutor_round1],
+        [student_round1],
         tutor_kwargs={"thinking": True, "effort": "xhigh"},
         student_kwargs={"thinking": False},
     )
@@ -845,7 +942,9 @@ def test_batch_ended_scenario_pruned_from_later_rounds(monkeypatch):
     # Round 2 tutor: only s2 active.
     tutor_round2 = {"sid-2": {"text": "Final turn. [END]"}}
 
-    run_batch_mock = _patch_batch(monkeypatch, [tutor_round1, tutor_round2], [student_round1])
+    run_batch_mock = _patch_batch(
+        monkeypatch, [tutor_round1, tutor_round2], [student_round1]
+    )
 
     results = run_conversations_batch(
         [s1, s2], tutor_id="fake-tutor", max_turns=6, poll_interval=0
@@ -866,7 +965,12 @@ def test_batch_latencies_omitted(monkeypatch):
 
     s1 = _make_scenario_id("sid-1", cut_turn=3)
 
-    tutor_round1 = {"sid-1": {"text": "Hello", "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8}}}
+    tutor_round1 = {
+        "sid-1": {
+            "text": "Hello",
+            "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+        }
+    }
     student_round1 = {"sid-1": {"text": "Hi back"}}
 
     _patch_batch(monkeypatch, [tutor_round1], [student_round1])
@@ -905,6 +1009,7 @@ def test_batch_round_based_ordering(monkeypatch):
 # End-to-end integration test: tutor.py + student.py + conversation.py
 # ---------------------------------------------------------------------------
 
+
 def test_run_conversation_e2e_mocked_models(monkeypatch):
     """End-to-end mocked conversation: verifies tutor + student + conversation compose.
 
@@ -924,16 +1029,18 @@ def test_run_conversation_e2e_mocked_models(monkeypatch):
     tutor_resps = [
         _resp(
             "Great start! [NEW_MESSAGE] Keep thinking about that.",
-            usage={"input_tokens": 100, "output_tokens": 30, "total_tokens": 130}
+            usage={"input_tokens": 100, "output_tokens": 30, "total_tokens": 130},
         ),
-        _resp("[END]", usage={"input_tokens": 95, "output_tokens": 5, "total_tokens": 100})
+        _resp(
+            "[END]", usage={"input_tokens": 95, "output_tokens": 5, "total_tokens": 100}
+        ),
     ]
 
     # Student returns a canned reply
     student_resps = [
         _resp(
             "I see. Let me try again.",
-            usage={"input_tokens": 80, "output_tokens": 20, "total_tokens": 100}
+            usage={"input_tokens": 80, "output_tokens": 20, "total_tokens": 100},
         )
     ]
 

--- a/tests/tutorsim/test_dataset_balanced_520.py
+++ b/tests/tutorsim/test_dataset_balanced_520.py
@@ -61,20 +61,14 @@ class TestExactCounts:
         assert counts["scaffolding"] == 260, (
             f"Expected 260 scaffolding, got {counts['scaffolding']}"
         )
-        assert counts["rigor"] == 260, (
-            f"Expected 260 rigor, got {counts['rigor']}"
-        )
+        assert counts["rigor"] == 260, f"Expected 260 rigor, got {counts['rigor']}"
 
     def test_all_have_non_empty_context(self, raw_moments):
         empty = [s["id"] for s in raw_moments if not s.get("context")]
         assert not empty, f"Moments with empty context: {empty}"
 
     def test_all_have_rubric_gold(self, raw_moments):
-        missing = [
-            s["id"]
-            for s in raw_moments
-            if not s.get("rubric", {}).get("gold")
-        ]
+        missing = [s["id"] for s in raw_moments if not s.get("rubric", {}).get("gold")]
         assert not missing, f"Moments missing rubric.gold: {missing}"
 
     def test_ids_are_unique(self, raw_moments):

--- a/tests/tutorsim/test_logging_setup.py
+++ b/tests/tutorsim/test_logging_setup.py
@@ -6,9 +6,9 @@ import threading
 import pytest
 
 from tutorsim.logging_setup import (
+    _HANDLER_TAG,
     LOG_FILE_ENV,
     LOG_LEVEL_ENV,
-    _HANDLER_TAG,
     log_context,
     per_run_log_file,
     setup_logging,
@@ -29,8 +29,7 @@ def _restore_logging_state(monkeypatch):
     old_handlers = root.handlers[:]
     old_root_level = root.level
     pkg_levels = {
-        name: logging.getLogger(name).level
-        for name in ("tutorsim", "tutorsim_build")
+        name: logging.getLogger(name).level for name in ("tutorsim", "tutorsim_build")
     }
     yield
     for handler in root.handlers[:]:
@@ -226,10 +225,17 @@ def test_log_context_is_thread_local(tmp_path):
 def test_cli_run_parser_accepts_log_flags():
     from tutorsim.cli import _build_parser
 
-    args = _build_parser().parse_args([
-        "run", "--tutors", "some-model",
-        "--log-level", "DEBUG", "--log-file", "run.log",
-    ])
+    args = _build_parser().parse_args(
+        [
+            "run",
+            "--tutors",
+            "some-model",
+            "--log-level",
+            "DEBUG",
+            "--log-file",
+            "run.log",
+        ]
+    )
     assert args.log_level == "DEBUG"
     assert args.log_file == "run.log"
 
@@ -248,6 +254,7 @@ def test_per_run_log_file_registered_worker_thread_captured(tmp_path):
     log = logging.getLogger("tutorsim.client")
 
     with per_run_log_file(str(log_file)) as handle:
+
         def worker():
             bind_worker_logging(handle, "tutor-x/plain")
             log.warning("retry warning from worker")

--- a/tests/tutorsim/test_logging_setup.py
+++ b/tests/tutorsim/test_logging_setup.py
@@ -254,17 +254,27 @@ def test_per_run_log_file_registered_worker_thread_captured(tmp_path):
     log = logging.getLogger("tutorsim.client")
 
     with per_run_log_file(str(log_file)) as handle:
+        # Keep both threads alive at once via a barrier. threading ident()s are
+        # recycled after a thread exits, so running these sequentially could
+        # hand the unregistered "stranger" the just-freed id of the registered
+        # worker -- letting it pass the thread filter and flaking the final
+        # assertion. Concurrent liveness guarantees distinct ids, which is also
+        # how real worker-pool and main threads coexist during a run.
+        both_alive = threading.Barrier(2)
 
         def worker():
             bind_worker_logging(handle, "tutor-x/plain")
+            both_alive.wait()
             log.warning("retry warning from worker")
 
         def stranger():
+            both_alive.wait()
             log.warning("record from unregistered thread")
 
-        for target in (worker, stranger):
-            t = threading.Thread(target=target)
+        threads = [threading.Thread(target=t) for t in (worker, stranger)]
+        for t in threads:
             t.start()
+        for t in threads:
             t.join()
 
     content = log_file.read_text(encoding="utf-8")

--- a/tests/tutorsim/test_moments.py
+++ b/tests/tutorsim/test_moments.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tutorsim.moments import (
     DatasetNotFoundError,
     Moment,
@@ -18,7 +19,11 @@ def test_moment_roundtrip():
             {"turn_number": 7, "role": "student", "text": "ok"},
         ],
         dimension="scaffolding",
-        student={"mode": "oracle", "reference": "Turn 8. STUDENT: ...", "context": "Grade 5, fractions"},
+        student={
+            "mode": "oracle",
+            "reference": "Turn 8. STUDENT: ...",
+            "context": "Grade 5, fractions",
+        },
         rubric={"gold": "scaffolding", "hint": "The student gave a guess."},
         provenance={"conv_id": "conv", "cut_turn": 7, "turn_start": 5, "turn_end": 7},
     )
@@ -39,25 +44,39 @@ def test_from_dict_normalizes_cut_votes_forms():
         "student": {"mode": "oracle", "reference": "", "context": ""},
         "rubric": {"gold": "rigor", "hint": ""},
     }
-    released = dict(base, provenance={
-        "conv_id": "c", "cut_turn": 27,
-        "cut_votes": [{"cut_turn": 27, "votes": 7}, {"cut_turn": 32, "votes": 1}],
-    })
-    internal = dict(base, provenance={
-        "conv_id": "c", "cut_turn": 27,
-        "cut_votes": {"27": 7, "32": 1},
-    })
-    int_keyed = dict(base, provenance={
-        "conv_id": "c", "cut_turn": 27,
-        "cut_votes": {27: 7, 32: 1},
-    })
+    released = dict(
+        base,
+        provenance={
+            "conv_id": "c",
+            "cut_turn": 27,
+            "cut_votes": [{"cut_turn": 27, "votes": 7}, {"cut_turn": 32, "votes": 1}],
+        },
+    )
+    internal = dict(
+        base,
+        provenance={
+            "conv_id": "c",
+            "cut_turn": 27,
+            "cut_votes": {"27": 7, "32": 1},
+        },
+    )
+    int_keyed = dict(
+        base,
+        provenance={
+            "conv_id": "c",
+            "cut_turn": 27,
+            "cut_votes": {27: 7, 32: 1},
+        },
+    )
     expected = {"27": 7, "32": 1}
     assert Moment.from_dict(released).provenance["cut_votes"] == expected
     assert Moment.from_dict(internal).provenance["cut_votes"] == expected
     assert Moment.from_dict(int_keyed).provenance["cut_votes"] == expected
     # And the hash over normalized records is form-independent
     h = records_content_hash
-    assert h([Moment.from_dict(released).to_dict()]) == h([Moment.from_dict(internal).to_dict()])
+    assert h([Moment.from_dict(released).to_dict()]) == h(
+        [Moment.from_dict(internal).to_dict()]
+    )
 
 
 def test_load_moments_data_path_reads_in_file_order():

--- a/tests/tutorsim/test_report.py
+++ b/tests/tutorsim/test_report.py
@@ -31,14 +31,16 @@ leaderboard_row:
   avoids_overscaffold = 1 - 1/6 = 5/6
 """
 
-import pytest
 from types import SimpleNamespace
-from tutorsim.report import aggregate, leaderboard_row
 
+import pytest
+
+from tutorsim.report import aggregate, leaderboard_row
 
 # ---------------------------------------------------------------------------
 # Minimal stubs -- no SDK imports, no I/O
 # ---------------------------------------------------------------------------
+
 
 def _make_scenario(dimension: str) -> SimpleNamespace:
     """Minimal Scenario stub: only .dimension is read by aggregate."""
@@ -61,24 +63,25 @@ def _make_annotation(
 # Fixture
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def six_pairs():
     """6 (scenario, annotation) pairs covering all scoring branches."""
     scenarios = [
         _make_scenario("scaffolding"),  # pair 1: clean scaf hit
         _make_scenario("scaffolding"),  # pair 2: right action but over-scaffold
-        _make_scenario("rigor"),        # pair 3: clean rigor hit, pos outcome
-        _make_scenario("rigor"),        # pair 4: rigor miss
-        _make_scenario("both"),         # pair 5: excluded from did-rate denominators
+        _make_scenario("rigor"),  # pair 3: clean rigor hit, pos outcome
+        _make_scenario("rigor"),  # pair 4: rigor miss
+        _make_scenario("both"),  # pair 5: excluded from did-rate denominators
         _make_scenario("scaffolding"),  # pair 6: scaf miss, pos outcome
     ]
     annotations = [
-        _make_annotation("scaffolding", []),               # pair 1
-        _make_annotation("both",        ["gave answer"]),  # pair 2: over-scaffold
-        _make_annotation("rigor",       []),               # pair 3
-        _make_annotation("neither",     []),               # pair 4
-        _make_annotation("both",        []),               # pair 5
-        _make_annotation("neither",     []),               # pair 6
+        _make_annotation("scaffolding", []),  # pair 1
+        _make_annotation("both", ["gave answer"]),  # pair 2: over-scaffold
+        _make_annotation("rigor", []),  # pair 3
+        _make_annotation("neither", []),  # pair 4
+        _make_annotation("both", []),  # pair 5
+        _make_annotation("neither", []),  # pair 6
     ]
     return scenarios, annotations
 
@@ -86,6 +89,7 @@ def six_pairs():
 # ---------------------------------------------------------------------------
 # Golden test
 # ---------------------------------------------------------------------------
+
 
 def test_aggregate_golden(six_pairs):
     """aggregate() returns the EXACT metric dict for the golden fixture."""
@@ -101,26 +105,26 @@ def test_aggregate_golden(six_pairs):
 
     # --- overscaffold ---
     ov = result["overscaffold"]
-    assert ov["n_yes"]    == 1
-    assert ov["n_total"]  == 6
-    assert ov["rate"]     == pytest.approx(1 / 6)
-    assert ov["available"] is True   # Annotation dataclass always has the field
+    assert ov["n_yes"] == 1
+    assert ov["n_total"] == 6
+    assert ov["rate"] == pytest.approx(1 / 6)
+    assert ov["available"] is True  # Annotation dataclass always has the field
 
     # --- outcome_pos_rate dropped from the paper; must not be reported ---
     assert "outcome_pos_rate" not in result
 
     # --- scaffold_calibrated ---
     sc = result["scaffold_calibrated"]
-    assert sc["n_clean_yes"]   == 1   # pair 1 only (pair 2 has over-scaffold)
-    assert sc["n_overscaffold"]== 1   # pair 2
-    assert sc["n_total"]       == 3
-    assert sc["score"]         == pytest.approx(1 / 3)
+    assert sc["n_clean_yes"] == 1  # pair 1 only (pair 2 has over-scaffold)
+    assert sc["n_overscaffold"] == 1  # pair 2
+    assert sc["n_total"] == 3
+    assert sc["score"] == pytest.approx(1 / 3)
 
     # --- rigor_calibrated ---
     rc = result["rigor_calibrated"]
     assert rc["n_clean_yes"] == 1
-    assert rc["n_total"]     == 2
-    assert rc["score"]       == pytest.approx(1 / 2)
+    assert rc["n_total"] == 2
+    assert rc["score"] == pytest.approx(1 / 2)
 
 
 def test_aggregate_golden_full_dict(six_pairs):
@@ -156,33 +160,43 @@ def test_aggregate_golden_full_dict(six_pairs):
     assert result["n_scenarios"] == expected["n_scenarios"]
     for key in ("scaffold_calibrated", "rigor_calibrated"):
         assert result[key]["n_clean_yes"] == expected[key]["n_clean_yes"]
-        assert result[key]["n_total"]     == expected[key]["n_total"]
-    assert result["scaffold_calibrated"]["n_overscaffold"] == expected["scaffold_calibrated"]["n_overscaffold"]
-    assert result["overscaffold"]["n_yes"]   == expected["overscaffold"]["n_yes"]
+        assert result[key]["n_total"] == expected[key]["n_total"]
+    assert (
+        result["scaffold_calibrated"]["n_overscaffold"]
+        == expected["scaffold_calibrated"]["n_overscaffold"]
+    )
+    assert result["overscaffold"]["n_yes"] == expected["overscaffold"]["n_yes"]
     assert result["overscaffold"]["n_total"] == expected["overscaffold"]["n_total"]
     assert result["overscaffold"]["available"] == expected["overscaffold"]["available"]
 
     # Check floating-point values approximately
-    assert result["overscaffold"]["rate"]        == pytest.approx(expected["overscaffold"]["rate"])
-    assert result["scaffold_calibrated"]["score"] == pytest.approx(expected["scaffold_calibrated"]["score"])
-    assert result["rigor_calibrated"]["score"]   == pytest.approx(expected["rigor_calibrated"]["score"])
+    assert result["overscaffold"]["rate"] == pytest.approx(
+        expected["overscaffold"]["rate"]
+    )
+    assert result["scaffold_calibrated"]["score"] == pytest.approx(
+        expected["scaffold_calibrated"]["score"]
+    )
+    assert result["rigor_calibrated"]["score"] == pytest.approx(
+        expected["rigor_calibrated"]["score"]
+    )
 
 
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
 
+
 def test_aggregate_empty():
     """aggregate([],[]) returns all zeros and None rates."""
     result = aggregate([], [])
     assert result["n_scenarios"] == 0
-    assert result["overscaffold"]["rate"]        is None
-    assert result["overscaffold"]["available"]   is False
+    assert result["overscaffold"]["rate"] is None
+    assert result["overscaffold"]["available"] is False
     assert "outcome_pos_rate" not in result
     assert "scaffolding_did" not in result
     assert "rigor_did" not in result
     assert result["scaffold_calibrated"]["score"] is None
-    assert result["rigor_calibrated"]["score"]   is None
+    assert result["rigor_calibrated"]["score"] is None
 
 
 def test_aggregate_neither_gold_excluded():
@@ -242,11 +256,34 @@ def _make_run_summary(
         "tutor_model": tutor_model,
         "mode": mode,
         "n_scenarios": n,
-        "scaffold_calibrated": {"score": scaffold_cal, "n_clean_yes": 0, "n_total": n, "n_overscaffold": 0},
-        "rigor_calibrated":    {"score": rigor_cal,    "n_clean_yes": 0, "n_total": n},
-        "overscaffold":        {"rate": overscaffold_rate, "n_yes": 0, "n_total": n, "available": overscaffold_rate is not None},
-        "latency":             {"tutor": {"p50_seconds": tutor_lat_p50, "p95_seconds": tutor_lat_p95, "mean_seconds": 1.0, "n": n}},
-        "tokens":              {"total": {"total_tokens": tokens_total, "input_tokens": 0, "output_tokens": 0}},
+        "scaffold_calibrated": {
+            "score": scaffold_cal,
+            "n_clean_yes": 0,
+            "n_total": n,
+            "n_overscaffold": 0,
+        },
+        "rigor_calibrated": {"score": rigor_cal, "n_clean_yes": 0, "n_total": n},
+        "overscaffold": {
+            "rate": overscaffold_rate,
+            "n_yes": 0,
+            "n_total": n,
+            "available": overscaffold_rate is not None,
+        },
+        "latency": {
+            "tutor": {
+                "p50_seconds": tutor_lat_p50,
+                "p95_seconds": tutor_lat_p95,
+                "mean_seconds": 1.0,
+                "n": n,
+            }
+        },
+        "tokens": {
+            "total": {
+                "total_tokens": tokens_total,
+                "input_tokens": 0,
+                "output_tokens": 0,
+            }
+        },
     }
 
 
@@ -289,9 +326,15 @@ SUMMARY_NONE = _make_run_summary(
 
 # Reader-facing column names match the paper's three metrics.
 EXPECTED_COLUMNS = [
-    "tutor_model", "mode", "n",
-    "appropriate_scaffolding", "appropriate_rigor", "avoids_overscaffold",
-    "tutor_lat_p50", "tutor_lat_p95", "tokens_total",
+    "tutor_model",
+    "mode",
+    "n",
+    "appropriate_scaffolding",
+    "appropriate_rigor",
+    "avoids_overscaffold",
+    "tutor_lat_p50",
+    "tutor_lat_p95",
+    "tokens_total",
 ]
 
 
@@ -323,7 +366,9 @@ def test_leaderboard_column_order_in_header():
     for col, pos in zip(EXPECTED_COLUMNS, positions):
         assert pos != -1, f"Column '{col}' not found in header: {header_line}"
     # Columns must be in ascending order of position
-    assert positions == sorted(positions), f"Columns out of order: {list(zip(EXPECTED_COLUMNS, positions))}"
+    assert positions == sorted(positions), (
+        f"Columns out of order: {list(zip(EXPECTED_COLUMNS, positions))}"
+    )
     # Dropped from the paper; must not resurface
     assert "outcome_pos" not in header_line
     assert "did_scaf" not in header_line
@@ -341,7 +386,11 @@ def test_leaderboard_avoids_overscaffold_formula():
 def test_leaderboard_sorted_desc_by_appropriate_scaffolding():
     """Rows sorted descending by appropriate_scaffolding (model-alpha first)."""
     md, _ = leaderboard([SUMMARY_B, SUMMARY_A])  # pass in reverse order
-    lines = [l for l in md.split("\n") if "|" in l and "---" not in l and "tutor_model" not in l]
+    lines = [
+        l
+        for l in md.split("\n")
+        if "|" in l and "---" not in l and "tutor_model" not in l
+    ]
     assert lines[0].count("model-alpha") >= 1 or "0.750" in lines[0]
     assert lines[1].count("model-beta") >= 1 or "0.500" in lines[1]
     # More direct: first data row has higher appropriate_scaffolding value
@@ -355,7 +404,11 @@ def test_leaderboard_none_formatting():
     # appropriate_scaffolding is None => should appear as '-' in md
     data_lines = [l for l in md.split("\n") if "model-gamma" in l]
     assert len(data_lines) == 1
-    assert "| - |" in data_lines[0] or "|-|" in data_lines[0] or data_lines[0].count("| - ") > 0
+    assert (
+        "| - |" in data_lines[0]
+        or "|-|" in data_lines[0]
+        or data_lines[0].count("| - ") > 0
+    )
 
     # CSV: None fields should be empty strings (not 'None' or '-')
     csv_lines = [l for l in csv_str.split("\n") if "model-gamma" in l]
@@ -366,7 +419,11 @@ def test_leaderboard_none_formatting():
 def test_leaderboard_none_sorted_last():
     """Rows with appropriate_scaffolding=None sort after rows with a value."""
     md, _ = leaderboard([SUMMARY_NONE, SUMMARY_A])
-    lines = [l for l in md.split("\n") if "|" in l and "---" not in l and "tutor_model" not in l]
+    lines = [
+        l
+        for l in md.split("\n")
+        if "|" in l and "---" not in l and "tutor_model" not in l
+    ]
     assert "model-alpha" in lines[0]
     assert "model-gamma" in lines[1]
 
@@ -409,6 +466,7 @@ def test_view_embeds_score_values():
 # Spec S7: leaderboard lat/tokens columns show non-"-" when summary carries blocks
 # ---------------------------------------------------------------------------
 
+
 def test_leaderboard_latency_and_tokens_non_dash():
     """A summary with latency.tutor p50/p95 and tokens.total.total_tokens
     produces non-'-' columns in the leaderboard markdown (spec S7).
@@ -419,7 +477,9 @@ def test_leaderboard_latency_and_tokens_non_dash():
 
     # tutor_lat_p50 and tutor_lat_p95 must appear as numbers, not as '-'
     data_lines = [l for l in md.split("\n") if "model-alpha" in l]
-    assert len(data_lines) == 1, f"Expected exactly one data row for model-alpha, got: {data_lines}"
+    assert len(data_lines) == 1, (
+        f"Expected exactly one data row for model-alpha, got: {data_lines}"
+    )
     row = data_lines[0]
 
     # '1.234' and '3.456' must appear in the row (not replaced by '-')
@@ -432,8 +492,9 @@ def test_leaderboard_latency_and_tokens_non_dash():
     none_lines = [l for l in md_none.split("\n") if "model-gamma" in l]
     assert len(none_lines) == 1
     # None values -> '-' in markdown
-    assert "| - |" in none_lines[0] or none_lines[0].count("| - ") >= 2, \
+    assert "| - |" in none_lines[0] or none_lines[0].count("| - ") >= 2, (
         f"Expected '-' for None lat/tokens in: {none_lines[0]}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -446,9 +507,18 @@ from tutorsim.report import format_run_summary
 def test_format_run_summary_single_trial():
     """Single-trial metrics render the paper's three reader metrics + counts."""
     metrics = dict(SUMMARY_A)
-    metrics["run_counts"] = {"attempted": 100, "succeeded": 98, "failed": 2, "resumed": 1}
-    out = format_run_summary(metrics, tutor_model="model-alpha", mode="scaffolding_rigor",
-                             run_id="model-alpha_scaffolding_rigor_x")
+    metrics["run_counts"] = {
+        "attempted": 100,
+        "succeeded": 98,
+        "failed": 2,
+        "resumed": 1,
+    }
+    out = format_run_summary(
+        metrics,
+        tutor_model="model-alpha",
+        mode="scaffolding_rigor",
+        run_id="model-alpha_scaffolding_rigor_x",
+    )
 
     assert "Run summary: model-alpha_scaffolding_rigor_x" in out
     assert "tutor=model-alpha" in out and "mode=scaffolding_rigor" in out
@@ -456,7 +526,7 @@ def test_format_run_summary_single_trial():
     # Reader-facing metrics, 3dp, same derivation as the leaderboard.
     assert "Appropriate Scaffolding    0.750" in out
     assert "Appropriate Rigor          0.600" in out
-    assert "Avoids Over-Scaffolding    0.900" in out   # 1 - 0.10
+    assert "Avoids Over-Scaffolding    0.900" in out  # 1 - 0.10
     assert "98/100" in out and "failed 2" in out and "resumed 1" in out
     assert "500000" in out
     # No spread markers for a single trial.
@@ -467,12 +537,18 @@ def test_format_run_summary_single_trial():
 def test_format_run_summary_renders_taxonomy_block():
     """A taxonomy block renders the count + orientation-mix lines."""
     metrics = dict(SUMMARY_A)
-    metrics["run_counts"] = {"attempted": 100, "succeeded": 100, "failed": 0, "resumed": 0}
+    metrics["run_counts"] = {
+        "attempted": 100,
+        "succeeded": 100,
+        "failed": 0,
+        "resumed": 0,
+    }
     metrics["taxonomy"] = {
         "scheme_version": "lm_extended_v1",
         "counts": {"A": 10},
         "orientation": {"scaffolding": 250, "rigor": 90, "neutral": 60},
-        "n_facets": 400, "excluded": 38,
+        "n_facets": 400,
+        "excluded": 38,
         "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
     }
     out = format_run_summary(metrics, tutor_model="model-alpha", mode="plain")
@@ -496,30 +572,44 @@ def test_format_run_summary_trials_shows_mean_and_spread():
         "trials": 3,
         "mean": {
             "n_scenarios": 100,
-            "scaffold_calibrated": {"score": 0.75, "n_clean_yes": 0, "n_total": 100, "n_overscaffold": 0},
-            "rigor_calibrated":    {"score": 0.60, "n_clean_yes": 0, "n_total": 100},
-            "overscaffold":        {"rate": 0.10, "n_yes": 0, "n_total": 100, "available": True},
+            "scaffold_calibrated": {
+                "score": 0.75,
+                "n_clean_yes": 0,
+                "n_total": 100,
+                "n_overscaffold": 0,
+            },
+            "rigor_calibrated": {"score": 0.60, "n_clean_yes": 0, "n_total": 100},
+            "overscaffold": {
+                "rate": 0.10,
+                "n_yes": 0,
+                "n_total": 100,
+                "available": True,
+            },
         },
         "spread": {
             "scaffold_calibrated": {"score": 0.02},
-            "rigor_calibrated":    {"score": 0.03},
-            "overscaffold":        {"rate": 0.01},
+            "rigor_calibrated": {"score": 0.03},
+            "overscaffold": {"rate": 0.01},
         },
         "latency": {"tutor": {"p50_seconds": 1.2, "p95_seconds": 3.4}},
-        "tokens":  {"total": {"total_tokens": 500000}},
+        "tokens": {"total": {"total_tokens": 500000}},
         "run_counts": {"attempted": 300, "succeeded": 300, "failed": 0, "resumed": 0},
     }
-    out = format_run_summary(metrics, tutor_model="model-alpha", mode="scaffolding_rigor")
+    out = format_run_summary(
+        metrics, tutor_model="model-alpha", mode="scaffolding_rigor"
+    )
 
     assert "trials=3" in out
     assert "0.750 ± 0.020" in out
     assert "0.600 ± 0.030" in out
-    assert "0.900 ± 0.010" in out   # avoids = 1 - mean rate; std carries through
+    assert "0.900 ± 0.010" in out  # avoids = 1 - mean rate; std carries through
 
 
 def test_format_run_summary_none_metrics_render_dash():
     """None scores/latency/tokens render as '-' rather than crashing."""
-    out = format_run_summary(SUMMARY_NONE, tutor_model="model-gamma", mode="scaffolding_only")
+    out = format_run_summary(
+        SUMMARY_NONE, tutor_model="model-gamma", mode="scaffolding_only"
+    )
     assert "Appropriate Scaffolding    -" in out
     assert "Appropriate Rigor          -" in out
     assert "Avoids Over-Scaffolding    -" in out

--- a/tests/tutorsim/test_results.py
+++ b/tests/tutorsim/test_results.py
@@ -1,22 +1,23 @@
 """Tests for tutorsim.results — the run-results store (TDD: write tests first)."""
-import json
-import pytest
-from pathlib import Path
 
 from tutorsim.results import (
-    make_run_id,
-    write_config, read_config,
-    write_transcript, read_transcript,
-    write_score, read_score,
-    write_summary, read_summary,
     is_done,
     list_runs,
+    make_run_id,
+    read_config,
+    read_score,
+    read_summary,
+    read_transcript,
+    write_config,
+    write_score,
+    write_summary,
+    write_transcript,
 )
-
 
 # ---------------------------------------------------------------------------
 # make_run_id
 # ---------------------------------------------------------------------------
+
 
 def test_make_run_id_basic():
     result = make_run_id("claude-opus-4-8", "plain", "balanced_520", "20260626")
@@ -24,7 +25,9 @@ def test_make_run_id_basic():
 
 
 def test_make_run_id_slash_replaced():
-    result = make_run_id("deepseek-ai/DeepSeek-V4-Pro", "plain", "balanced_520", "20260626")
+    result = make_run_id(
+        "deepseek-ai/DeepSeek-V4-Pro", "plain", "balanced_520", "20260626"
+    )
     assert "/" not in result
     assert result == "deepseek-ai_DeepSeek-V4-Pro_plain_balanced_520_20260626"
 
@@ -37,6 +40,7 @@ def test_make_run_id_multiple_slashes():
 # ---------------------------------------------------------------------------
 # config round-trip
 # ---------------------------------------------------------------------------
+
 
 def test_write_read_config(tmp_path):
     run_id = "testrun_plain_ds_20260626"
@@ -54,10 +58,14 @@ def test_read_config_missing_returns_none(tmp_path):
 # transcript round-trip
 # ---------------------------------------------------------------------------
 
+
 def test_write_read_transcript(tmp_path):
     run_id = "testrun_plain_ds_20260626"
     scenario_id = "conv-abc_m1"
-    transcript = {"scenario_id": scenario_id, "turns": [{"role": "tutor", "text": "Hello"}]}
+    transcript = {
+        "scenario_id": scenario_id,
+        "turns": [{"role": "tutor", "text": "Hello"}],
+    }
     write_transcript(run_id, scenario_id, transcript, results_root=str(tmp_path))
     loaded = read_transcript(run_id, scenario_id, results_root=str(tmp_path))
     assert loaded == transcript
@@ -70,6 +78,7 @@ def test_read_transcript_missing_returns_none(tmp_path):
 # ---------------------------------------------------------------------------
 # score round-trip
 # ---------------------------------------------------------------------------
+
 
 def test_write_read_score(tmp_path):
     run_id = "testrun_plain_ds_20260626"
@@ -88,6 +97,7 @@ def test_read_score_missing_returns_none(tmp_path):
 # summary round-trip
 # ---------------------------------------------------------------------------
 
+
 def test_write_read_summary(tmp_path):
     run_id = "testrun_plain_ds_20260626"
     summary = {"n_scenarios": 10, "scaffolding_rate": 0.8}
@@ -103,6 +113,7 @@ def test_read_summary_missing_returns_none(tmp_path):
 # ---------------------------------------------------------------------------
 # is_done (resume guard)
 # ---------------------------------------------------------------------------
+
 
 def test_is_done_false_when_neither_exists(tmp_path):
     run_id = "testrun_plain_ds_20260626"
@@ -127,8 +138,12 @@ def test_is_done_false_when_only_score(tmp_path):
 def test_is_done_true_when_both_exist(tmp_path):
     run_id = "testrun_plain_ds_20260626"
     scenario_id = "conv-abc_m1"
-    write_transcript(run_id, scenario_id, {"scenario_id": scenario_id, "completed": True},
-                     results_root=str(tmp_path))
+    write_transcript(
+        run_id,
+        scenario_id,
+        {"scenario_id": scenario_id, "completed": True},
+        results_root=str(tmp_path),
+    )
     write_score(run_id, scenario_id, {"score": 1.0}, results_root=str(tmp_path))
     assert is_done(run_id, scenario_id, results_root=str(tmp_path)) is True
 
@@ -136,6 +151,7 @@ def test_is_done_true_when_both_exist(tmp_path):
 # ---------------------------------------------------------------------------
 # list_runs
 # ---------------------------------------------------------------------------
+
 
 def test_list_runs_empty(tmp_path):
     assert list_runs(results_root=str(tmp_path)) == []

--- a/tests/tutorsim/test_scoring.py
+++ b/tests/tutorsim/test_scoring.py
@@ -2,14 +2,18 @@ import pytest
 
 from tutorsim.resources import resource_text
 
-@pytest.mark.parametrize("rel", [
-    "annotate/scaffolding.md",
-    "decompose/decompose_action.md",
-    "decompose/decompose_result.md",
-    "decompose/decompose_overscaffold.md",
-    "structure/classify_action.md",
-    "structure/classify_student_result.md",
-])
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "annotate/scaffolding.md",
+        "decompose/decompose_action.md",
+        "decompose/decompose_result.md",
+        "decompose/decompose_overscaffold.md",
+        "structure/classify_action.md",
+        "structure/classify_student_result.md",
+    ],
+)
 def test_scorer_prompt_exists_and_nonempty(rel):
     text = resource_text(f"prompts/scorer/{rel}")
     assert text.strip(), f"empty prompts/scorer/{rel}"
@@ -19,9 +23,9 @@ def test_scorer_prompt_exists_and_nonempty(rel):
 # Task 2: Annotation dataclass + _build_synthetic_conversation
 # ---------------------------------------------------------------------------
 
-from tutorsim.scoring import Annotation, _build_synthetic_conversation
-from tutorsim.moments import Moment as Scenario
 from tutorsim.conversation import Transcript
+from tutorsim.moments import Moment as Scenario
+from tutorsim.scoring import Annotation, _build_synthetic_conversation
 
 
 @pytest.fixture
@@ -70,6 +74,7 @@ def fixture_transcript(fixture_scenario):
 
 # --- Annotation round-trip ---
 
+
 def test_annotation_to_dict_has_all_fields():
     ann = Annotation(
         scenario_id="testset:conv-abc__hum_5_12",
@@ -85,9 +90,15 @@ def test_annotation_to_dict_has_all_fields():
     )
     d = ann.to_dict()
     expected_fields = {
-        "scenario_id", "annotation_type", "turn_start", "turn_end",
-        "situation", "action", "result",
-        "action_decomposed", "overscaffold_decomposed",
+        "scenario_id",
+        "annotation_type",
+        "turn_start",
+        "turn_end",
+        "situation",
+        "action",
+        "result",
+        "action_decomposed",
+        "overscaffold_decomposed",
         "action_label",
     }
     assert expected_fields.issubset(set(d.keys()))
@@ -121,8 +132,13 @@ def test_annotation_to_dict_round_trips_values():
 
 # --- _build_synthetic_conversation ---
 
-def test_build_synthetic_conversation_keyed_by_scenario_id(fixture_scenario, fixture_transcript):
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+
+def test_build_synthetic_conversation_keyed_by_scenario_id(
+    fixture_scenario, fixture_transcript
+):
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     # Both must be keyed by scenario.id
     assert fixture_scenario.id in conv_dict
     assert fixture_scenario.id in detections
@@ -144,7 +160,9 @@ def test_build_synthetic_conversation_turns_order(fixture_scenario, fixture_tran
     assert turns[5]["turn_number"] == 8
 
 
-def test_build_synthetic_conversation_roles_uppercased(fixture_scenario, fixture_transcript):
+def test_build_synthetic_conversation_roles_uppercased(
+    fixture_scenario, fixture_transcript
+):
     conv_dict, _ = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
     turns = conv_dict[fixture_scenario.id]["turns"]
     # Context turns should have roles uppercased
@@ -168,20 +186,26 @@ def test_build_synthetic_conversation_turn_shape(fixture_scenario, fixture_trans
         assert "timestamp" in turn
 
 
-def test_build_synthetic_conversation_conversation_id(fixture_scenario, fixture_transcript):
+def test_build_synthetic_conversation_conversation_id(
+    fixture_scenario, fixture_transcript
+):
     conv_dict, _ = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
     conv = conv_dict[fixture_scenario.id]
     assert conv["conversation_id"] == fixture_scenario.id
 
 
-def test_build_synthetic_conversation_single_detection(fixture_scenario, fixture_transcript):
+def test_build_synthetic_conversation_single_detection(
+    fixture_scenario, fixture_transcript
+):
     _, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
     det_entry = detections[fixture_scenario.id]
     detection_list = det_entry["detections"]
     assert len(detection_list) == 1
 
 
-def test_build_synthetic_conversation_detection_turn_range(fixture_scenario, fixture_transcript):
+def test_build_synthetic_conversation_detection_turn_range(
+    fixture_scenario, fixture_transcript
+):
     _, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
     det = detections[fixture_scenario.id]["detections"][0]
     # turn_start = first generated turn number (6), turn_end = last (8)
@@ -189,13 +213,17 @@ def test_build_synthetic_conversation_detection_turn_range(fixture_scenario, fix
     assert det["turn_end"] == 8
 
 
-def test_build_synthetic_conversation_detection_annotation_type(fixture_scenario, fixture_transcript):
+def test_build_synthetic_conversation_detection_annotation_type(
+    fixture_scenario, fixture_transcript
+):
     _, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
     det = detections[fixture_scenario.id]["detections"][0]
     assert det["annotation_type"] == "scaffolding"
 
 
-def test_build_synthetic_conversation_detection_situation_label_agg(fixture_scenario, fixture_transcript):
+def test_build_synthetic_conversation_detection_situation_label_agg(
+    fixture_scenario, fixture_transcript
+):
     _, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
     det = detections[fixture_scenario.id]["detections"][0]
     # situation_label_agg = scenario.dimension (= rubric["gold"])
@@ -203,7 +231,9 @@ def test_build_synthetic_conversation_detection_situation_label_agg(fixture_scen
     assert det["situation_label_agg"] == "scaffolding"
 
 
-def test_build_synthetic_conversation_detection_situation_hint(fixture_scenario, fixture_transcript):
+def test_build_synthetic_conversation_detection_situation_hint(
+    fixture_scenario, fixture_transcript
+):
     _, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
     det = detections[fixture_scenario.id]["detections"][0]
     # situation description includes the rubric hint
@@ -215,18 +245,20 @@ def test_build_synthetic_conversation_detection_situation_hint(fixture_scenario,
 # ---------------------------------------------------------------------------
 
 from tutorsim.scoring import (
-    _format_excerpt,
-    _suggestion_text,
     _build_annotate_entries,
+    _format_excerpt,
     _parse_and_merge,
+    _suggestion_text,
 )
-
 
 # --- _format_excerpt (context_window=0) ---
 
+
 def test_format_excerpt_markers_present(fixture_scenario, fixture_transcript):
     """The excerpt must contain START and END markers."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     conv = conv_dict[fixture_scenario.id]
     det = detections[fixture_scenario.id]["detections"][0]
     excerpt = _format_excerpt(conv, det["turn_start"], det["turn_end"], 0, 0)
@@ -236,7 +268,9 @@ def test_format_excerpt_markers_present(fixture_scenario, fixture_transcript):
 
 def test_format_excerpt_omit_header_emitted(fixture_scenario, fixture_transcript):
     """When context_window=0 and generated turns don't start at 1, omit header is emitted."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     conv = conv_dict[fixture_scenario.id]
     det = detections[fixture_scenario.id]["detections"][0]
     # turn_start=6, min_turn=3: excerpt_start=6 > min_turn=3 => header expected
@@ -246,7 +280,9 @@ def test_format_excerpt_omit_header_emitted(fixture_scenario, fixture_transcript
 
 def test_format_excerpt_only_detected_range(fixture_scenario, fixture_transcript):
     """With context_window=0, only turns [turn_start, turn_end] appear (plus markers)."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     conv = conv_dict[fixture_scenario.id]
     det = detections[fixture_scenario.id]["detections"][0]
     excerpt = _format_excerpt(conv, det["turn_start"], det["turn_end"], 0, 0)
@@ -262,7 +298,9 @@ def test_format_excerpt_only_detected_range(fixture_scenario, fixture_transcript
 
 def test_format_excerpt_in_range_marker(fixture_scenario, fixture_transcript):
     """Each turn in [turn_start, turn_end] gets a ' <<<' suffix."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     conv = conv_dict[fixture_scenario.id]
     det = detections[fixture_scenario.id]["detections"][0]
     excerpt = _format_excerpt(conv, det["turn_start"], det["turn_end"], 0, 0)
@@ -273,7 +311,9 @@ def test_format_excerpt_in_range_marker(fixture_scenario, fixture_transcript):
 
 def test_format_excerpt_golden_string(fixture_scenario, fixture_transcript):
     """Golden: exact excerpt string for the fixture (context_window=0)."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     conv = conv_dict[fixture_scenario.id]
     det = detections[fixture_scenario.id]["detections"][0]
     excerpt = _format_excerpt(conv, det["turn_start"], det["turn_end"], 0, 0)
@@ -290,6 +330,7 @@ def test_format_excerpt_golden_string(fixture_scenario, fixture_transcript):
 
 
 # --- _suggestion_text ---
+
 
 def test_suggestion_text_scaffolding():
     assert _suggestion_text("scaffolding") == (
@@ -335,17 +376,24 @@ def test_suggestion_text_unrecognized():
 
 # --- _build_annotate_entries: golden-prompt test ---
 
+
 def test_build_annotate_entries_key_scheme(fixture_scenario, fixture_transcript):
     """Key must be '{scenario_id}__scaffolding__0' for the first detection."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     entries = _build_annotate_entries(conv_dict, detections)
     assert len(entries) == 1
     assert entries[0]["key"] == f"{fixture_scenario.id}__scaffolding__0"
 
 
-def test_build_annotate_entries_prompt_contains_excerpt(fixture_scenario, fixture_transcript):
+def test_build_annotate_entries_prompt_contains_excerpt(
+    fixture_scenario, fixture_transcript
+):
     """The prompt must contain the exact markered excerpt."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     entries = _build_annotate_entries(conv_dict, detections)
     prompt = entries[0]["request"]["contents"][0]["parts"][0]["text"]
     assert ">>> DETECTED MOMENT START (Turn 6) <<<" in prompt
@@ -353,17 +401,28 @@ def test_build_annotate_entries_prompt_contains_excerpt(fixture_scenario, fixtur
     assert "Turn 6. TUTOR: Can you try the first step? <<<" in prompt
 
 
-def test_build_annotate_entries_prompt_contains_suggestion(fixture_scenario, fixture_transcript):
+def test_build_annotate_entries_prompt_contains_suggestion(
+    fixture_scenario, fixture_transcript
+):
     """The prompt must contain the suggestion sentence for 'scaffolding'."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     entries = _build_annotate_entries(conv_dict, detections)
     prompt = entries[0]["request"]["contents"][0]["parts"][0]["text"]
-    assert "A team of teachers believe that this moment is appropriate for scaffolding." in prompt
+    assert (
+        "A team of teachers believe that this moment is appropriate for scaffolding."
+        in prompt
+    )
 
 
-def test_build_annotate_entries_annotator_style_absent(fixture_scenario, fixture_transcript):
+def test_build_annotate_entries_annotator_style_absent(
+    fixture_scenario, fixture_transcript
+):
     """{annotator_style} must be replaced with '' (empty string, not present as literal)."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     entries = _build_annotate_entries(conv_dict, detections)
     prompt = entries[0]["request"]["contents"][0]["parts"][0]["text"]
     assert "{annotator_style}" not in prompt
@@ -371,7 +430,9 @@ def test_build_annotate_entries_annotator_style_absent(fixture_scenario, fixture
 
 def test_build_annotate_entries_json_mode_enabled(fixture_scenario, fixture_transcript):
     """The batch entry must have json_mode enabled (response_mime_type = application/json)."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     entries = _build_annotate_entries(conv_dict, detections)
     gen_config = entries[0]["request"]["generation_config"]
     assert gen_config.get("response_mime_type") == "application/json"
@@ -379,7 +440,9 @@ def test_build_annotate_entries_json_mode_enabled(fixture_scenario, fixture_tran
 
 def test_build_annotate_entries_golden_prompt(fixture_scenario, fixture_transcript):
     """Golden: the substituted prompt is BYTE-EXACT equal to the expected prompt."""
-    conv_dict, detections = _build_synthetic_conversation(fixture_scenario, fixture_transcript)
+    conv_dict, detections = _build_synthetic_conversation(
+        fixture_scenario, fixture_transcript
+    )
     entries = _build_annotate_entries(conv_dict, detections)
     assert entries[0]["key"] == f"{fixture_scenario.id}__scaffolding__0"
 
@@ -389,7 +452,9 @@ def test_build_annotate_entries_golden_prompt(fixture_scenario, fixture_transcri
     # the code applies, with the fixture's values.
     template = resource_text("prompts/scorer/annotate/scaffolding.md")
 
-    suggestion = "A team of teachers believe that this moment is appropriate for scaffolding."
+    suggestion = (
+        "A team of teachers believe that this moment is appropriate for scaffolding."
+    )
     expected_excerpt = (
         "[... turns 1-5 omitted ...]\n"
         "\n"
@@ -414,11 +479,14 @@ def test_build_annotate_entries_golden_prompt(fixture_scenario, fixture_transcri
 
 # --- _parse_and_merge ---
 
+
 def test_parse_and_merge_extracts_fields():
     """Parse extracts situation/action/result from JSON response."""
     detections_by_conv = {
         "conv1": {
-            "detections": [{"annotation_type": "scaffolding", "turn_start": 6, "turn_end": 8}],
+            "detections": [
+                {"annotation_type": "scaffolding", "turn_start": 6, "turn_end": 8}
+            ],
             "usage": {"input_tokens": 100, "output_tokens": 0, "total_tokens": 100},
         }
     }
@@ -440,7 +508,9 @@ def test_parse_and_merge_accumulates_usage():
     """Usage from p1 (detections) and p2 (parsed) are summed."""
     detections_by_conv = {
         "conv1": {
-            "detections": [{"annotation_type": "scaffolding", "turn_start": 6, "turn_end": 8}],
+            "detections": [
+                {"annotation_type": "scaffolding", "turn_start": 6, "turn_end": 8}
+            ],
             "usage": {"input_tokens": 100, "output_tokens": 0, "total_tokens": 100},
         }
     }
@@ -461,7 +531,9 @@ def test_parse_and_merge_fallback_action_text():
     """When no parsed result for a key, fallback action text is used."""
     detections_by_conv = {
         "conv1": {
-            "detections": [{"annotation_type": "scaffolding", "turn_start": 6, "turn_end": 8}],
+            "detections": [
+                {"annotation_type": "scaffolding", "turn_start": 6, "turn_end": 8}
+            ],
             "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
         }
     }
@@ -477,7 +549,9 @@ def test_parse_and_merge_list_response_takes_first():
     """If the JSON response is a list, [0] is used."""
     detections_by_conv = {
         "conv1": {
-            "detections": [{"annotation_type": "scaffolding", "turn_start": 1, "turn_end": 2}],
+            "detections": [
+                {"annotation_type": "scaffolding", "turn_start": 1, "turn_end": 2}
+            ],
             "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
         }
     }
@@ -497,7 +571,9 @@ def test_parse_and_merge_missing_json_keys_default_empty():
     """Missing situation/action/result keys default to ''."""
     detections_by_conv = {
         "conv1": {
-            "detections": [{"annotation_type": "scaffolding", "turn_start": 1, "turn_end": 2}],
+            "detections": [
+                {"annotation_type": "scaffolding", "turn_start": 1, "turn_end": 2}
+            ],
             "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
         }
     }
@@ -541,12 +617,13 @@ def test_parse_and_merge_pass1_pass2_counts():
 # Task 4: Decompose pass — _coerce_facets, _build_decompose_entries, junk skip
 # ---------------------------------------------------------------------------
 
-from tutorsim.scoring import _coerce_facets, _build_decompose_entries
+from tutorsim.scoring import _build_decompose_entries, _coerce_facets
 
 JUNK_TEXTS = {"", "n/a", "test", "sdf", "this is a test annotation"}
 
 
 # --- _coerce_facets ---
+
 
 def test_coerce_facets_bare_array():
     """A bare JSON array should return the list of strings."""
@@ -592,6 +669,7 @@ def test_coerce_facets_returns_none_for_invalid():
 
 
 # --- _build_decompose_entries: action prompt ---
+
 
 def test_build_decompose_entries_action_substitutes_action():
     """Action entry prompt must contain the action text via {action} substitution."""
@@ -748,13 +826,13 @@ def test_build_decompose_entries_overscaffold_both_junk_skipped():
 # ---------------------------------------------------------------------------
 
 from tutorsim.scoring import (
+    _build_structure_entries,
     _parse_action_label,
     _parse_result_label,
-    _build_structure_entries,
 )
 
-
 # --- _parse_action_label ---
+
 
 def test_parse_action_label_scaffolding_only():
     label, err = _parse_action_label('{"scaffolding":"yes","rigor":"no"}')
@@ -831,6 +909,7 @@ def test_parse_action_label_invalid_value_unclear():
 
 # --- _parse_result_label ---
 
+
 def test_parse_result_label_A_returns_pos():
     label, err = _parse_result_label("A")
     assert label == "pos"
@@ -904,6 +983,7 @@ def test_parse_result_label_letter_after_text_not_matched():
 
 
 # --- _build_structure_entries: action classification only ---
+
 
 def _make_decomposed_results(action_facets, ann_type="scaffolding"):
     """Helper: build results dict with one annotation having given facets."""
@@ -998,11 +1078,13 @@ def test_build_structure_entries_target_filter_rapport():
 
 # --- Default labels (no facets) ---
 
+
 def test_no_action_facets_default_label_neither():
     """No action facets -> default action_label 'neither'."""
     # This tests the convention the caller must apply after _build_structure_entries.
     # The default is encoded in DEFAULT_ACTION_LABEL.
     from tutorsim.scoring import DEFAULT_ACTION_LABEL
+
     assert DEFAULT_ACTION_LABEL == "neither"
 
 
@@ -1010,6 +1092,7 @@ def test_default_result_label_kept_for_tutorsim_build():
     """DEFAULT_RESULT_LABEL is no longer used by the runtime scorer but is
     imported by tutorsim_build.groundtruth -- pin its value."""
     from tutorsim.scoring import DEFAULT_RESULT_LABEL
+
     assert DEFAULT_RESULT_LABEL == "no_evidence"
 
 
@@ -1018,14 +1101,16 @@ def test_default_result_label_kept_for_tutorsim_build():
 # ---------------------------------------------------------------------------
 
 import json as _json
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 
 def _make_raw_entries(mapping):
     """Build a run_batch-style {key: {text, usage}} dict from a plain dict."""
     return {
-        k: {"text": v if isinstance(v, str) else _json.dumps(v),
-            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}}
+        k: {
+            "text": v if isinstance(v, str) else _json.dumps(v),
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        }
         for k, v in mapping.items()
     }
 
@@ -1049,6 +1134,7 @@ def _patch_score(fake_run_batch, fake_client=None):
     if fake_client is None:
         fake_client = _make_fake_score_client()
     from contextlib import ExitStack
+
     stack = ExitStack()
     stack.enter_context(patch("tutorsim.client.run_batch", side_effect=fake_run_batch))
     stack.enter_context(patch("tutorsim.client.ModelClient", return_value=fake_client))
@@ -1062,7 +1148,11 @@ def test_score_returns_annotation(fixture_scenario, fixture_transcript):
     sid = fixture_scenario.id  # "testset:conv-abc__hum_5_12"
 
     annotate_key = f"{sid}__scaffolding__0"
-    annotate_resp = {"situation": "Student stuck on division.", "action": "Tutor guided step-by-step.", "result": "Student made progress."}
+    annotate_resp = {
+        "situation": "Student stuck on division.",
+        "action": "Tutor guided step-by-step.",
+        "result": "Student made progress.",
+    }
     decompose_action_key = f"action__{sid}__0"
     decompose_overscaffold_key = f"overscaffold__{sid}__0"
     structure_action_key = f"action__{sid}__0"
@@ -1075,15 +1165,19 @@ def test_score_returns_annotation(fixture_scenario, fixture_transcript):
             return _make_raw_entries({annotate_key: annotate_resp})
         elif decompose_overscaffold_key in keys:
             # Decompose pass: action + overscaffold entries
-            return _make_raw_entries({
-                decompose_action_key: ["guided student", "broke down problem"],
-                decompose_overscaffold_key: [],
-            })
+            return _make_raw_entries(
+                {
+                    decompose_action_key: ["guided student", "broke down problem"],
+                    decompose_overscaffold_key: [],
+                }
+            )
         else:
             # Structure pass: action (JSON)
-            return _make_raw_entries({
-                structure_action_key: {"scaffolding": "yes", "rigor": "no"},
-            })
+            return _make_raw_entries(
+                {
+                    structure_action_key: {"scaffolding": "yes", "rigor": "no"},
+                }
+            )
 
     with _patch_score(fake_run_batch)[0]:
         result = score(fixture_scenario, fixture_transcript)
@@ -1121,18 +1215,30 @@ def test_score_three_passes_in_order(fixture_scenario, fixture_transcript):
         keys = {e["key"] for e in entries}
         if annotate_key in keys:
             call_order.append("annotate")
-            return _make_raw_entries({annotate_key: {"situation": "s", "action": "Tutor helped.", "result": "r"}})
+            return _make_raw_entries(
+                {
+                    annotate_key: {
+                        "situation": "s",
+                        "action": "Tutor helped.",
+                        "result": "r",
+                    }
+                }
+            )
         elif overscaffold_key in keys:
             call_order.append("decompose")
-            return _make_raw_entries({
-                f"action__{sid}__0": ["facet1"],
-                overscaffold_key: [],
-            })
+            return _make_raw_entries(
+                {
+                    f"action__{sid}__0": ["facet1"],
+                    overscaffold_key: [],
+                }
+            )
         else:
             call_order.append("structure")
-            return _make_raw_entries({
-                f"action__{sid}__0": {"scaffolding": "yes", "rigor": "no"},
-            })
+            return _make_raw_entries(
+                {
+                    f"action__{sid}__0": {"scaffolding": "yes", "rigor": "no"},
+                }
+            )
 
     with _patch_score(fake_run_batch)[0]:
         score(fixture_scenario, fixture_transcript)
@@ -1148,24 +1254,37 @@ def test_score_scorer_model_is_claude_opus_4_6(fixture_scenario, fixture_transcr
 
     sid = fixture_scenario.id
     annotate_key = f"{sid}__scaffolding__0"
-    decompose_action_key = f"action__{sid}__0"
 
     def fake_run_batch(client, entries, **kwargs):
         keys = {e["key"] for e in entries}
         if annotate_key in keys:
-            return _make_raw_entries({annotate_key: {"situation": "s", "action": "Tutor guided.", "result": "r"}})
+            return _make_raw_entries(
+                {
+                    annotate_key: {
+                        "situation": "s",
+                        "action": "Tutor guided.",
+                        "result": "r",
+                    }
+                }
+            )
         elif f"overscaffold__{sid}__0" in keys:
-            return _make_raw_entries({
-                f"action__{sid}__0": ["facet1"],
-                f"overscaffold__{sid}__0": [],
-            })
+            return _make_raw_entries(
+                {
+                    f"action__{sid}__0": ["facet1"],
+                    f"overscaffold__{sid}__0": [],
+                }
+            )
         else:
-            return _make_raw_entries({
-                f"action__{sid}__0": {"scaffolding": "yes", "rigor": "no"},
-            })
+            return _make_raw_entries(
+                {
+                    f"action__{sid}__0": {"scaffolding": "yes", "rigor": "no"},
+                }
+            )
 
-    with patch("tutorsim.client.run_batch", side_effect=fake_run_batch), \
-         patch("tutorsim.client.ModelClient") as mock_mc:
+    with (
+        patch("tutorsim.client.run_batch", side_effect=fake_run_batch),
+        patch("tutorsim.client.ModelClient") as mock_mc,
+    ):
         # Make the mock instance have the right model attribute
         fake_client = MagicMock()
         fake_client.model = "claude-opus-4-6"
@@ -1177,7 +1296,9 @@ def test_score_scorer_model_is_claude_opus_4_6(fixture_scenario, fixture_transcr
         # Check that ModelClient was instantiated with claude-opus-4-6
         assert mock_mc.called, "ModelClient was not instantiated"
         init_args = mock_mc.call_args
-        model_arg = init_args.args[0] if init_args.args else init_args.kwargs.get("model")
+        model_arg = (
+            init_args.args[0] if init_args.args else init_args.kwargs.get("model")
+        )
         assert model_arg == "claude-opus-4-6", (
             f"Expected scorer model 'claude-opus-4-6', got {model_arg!r}"
         )
@@ -1189,13 +1310,16 @@ def test_score_accumulates_usage_across_passes(fixture_scenario, fixture_transcr
 
     sid = fixture_scenario.id
     annotate_key = f"{sid}__scaffolding__0"
-    decompose_action_key = f"action__{sid}__0"
 
     def make_resp(keys_vals, tokens_per_key):
         return {
             k: {
                 "text": v if isinstance(v, str) else _json.dumps(v),
-                "usage": {"input_tokens": tokens_per_key, "output_tokens": tokens_per_key, "total_tokens": tokens_per_key * 2}
+                "usage": {
+                    "input_tokens": tokens_per_key,
+                    "output_tokens": tokens_per_key,
+                    "total_tokens": tokens_per_key * 2,
+                },
             }
             for k, v in keys_vals.items()
         }
@@ -1203,16 +1327,31 @@ def test_score_accumulates_usage_across_passes(fixture_scenario, fixture_transcr
     def fake_run_batch(client, entries, **kwargs):
         keys = {e["key"] for e in entries}
         if annotate_key in keys:
-            return make_resp({annotate_key: {"situation": "s", "action": "Tutor helped.", "result": "r"}}, 100)
+            return make_resp(
+                {
+                    annotate_key: {
+                        "situation": "s",
+                        "action": "Tutor helped.",
+                        "result": "r",
+                    }
+                },
+                100,
+            )
         elif f"overscaffold__{sid}__0" in keys:
-            return make_resp({
-                f"action__{sid}__0": ["f1"],
-                f"overscaffold__{sid}__0": [],
-            }, 200)
+            return make_resp(
+                {
+                    f"action__{sid}__0": ["f1"],
+                    f"overscaffold__{sid}__0": [],
+                },
+                200,
+            )
         else:
-            return make_resp({
-                f"action__{sid}__0": {"scaffolding": "yes", "rigor": "no"},
-            }, 300)
+            return make_resp(
+                {
+                    f"action__{sid}__0": {"scaffolding": "yes", "rigor": "no"},
+                },
+                300,
+            )
 
     with _patch_score(fake_run_batch)[0]:
         result = score(fixture_scenario, fixture_transcript)
@@ -1227,7 +1366,7 @@ def test_score_accumulates_usage_across_passes(fixture_scenario, fixture_transcr
 # Ground-truth build shims: _parse_decomposed + _build_overscaffold_prompt
 # ---------------------------------------------------------------------------
 
-from tutorsim.scoring import _parse_decomposed, _build_overscaffold_prompt
+from tutorsim.scoring import _build_overscaffold_prompt, _parse_decomposed
 
 
 def test_parse_decomposed_bare_array():
@@ -1269,6 +1408,7 @@ def test_build_overscaffold_prompt_substitutes_all_three():
 # score_batch: pooled 3-pass scoring across many scenarios
 # ---------------------------------------------------------------------------
 
+
 def _second_scenario():
     """A second, distinct scenario for pooling tests."""
     return Scenario(
@@ -1280,14 +1420,23 @@ def _second_scenario():
         dimension="rigor",
         student={"mode": "oracle", "reference": "", "context": "Grade 4, Math"},
         rubric={"gold": "rigor", "hint": "Student guessed."},
-        provenance={"conv_id": "conv-xyz", "cut_turn": 2, "turn_start": 2, "turn_end": 4},
+        provenance={
+            "conv_id": "conv-xyz",
+            "cut_turn": 2,
+            "turn_start": 2,
+            "turn_end": 4,
+        },
     )
 
 
 def _second_transcript(scenario):
     t = Transcript(scenario_id=scenario.id, tutor_model="test-model")
     t.generated_turns = [
-        {"turn_number": 3, "role": "TUTOR", "text": "Are you sure? Walk me through it."},
+        {
+            "turn_number": 3,
+            "role": "TUTOR",
+            "text": "Are you sure? Walk me through it.",
+        },
         {"turn_number": 4, "role": "STUDENT", "text": "Oh, it's 4."},
     ]
     return t
@@ -1301,31 +1450,45 @@ def _fake_pooled_run_batch(sids):
     calls = []
 
     def fake_run_batch(client, entries, **kwargs):
-        calls.append({
-            "display_name": kwargs.get("display_name"),
-            "keys": [e["key"] for e in entries],
-        })
+        calls.append(
+            {
+                "display_name": kwargs.get("display_name"),
+                "keys": [e["key"] for e in entries],
+            }
+        )
         keys = {e["key"] for e in entries}
         out = {}
         for sid in sids:
             if f"{sid}__scaffolding__0" in keys:
-                out.update(_make_raw_entries({
-                    f"{sid}__scaffolding__0": {
-                        "situation": f"situation for {sid}",
-                        "action": f"action for {sid}",
-                        "result": f"result for {sid}",
-                    },
-                }))
+                out.update(
+                    _make_raw_entries(
+                        {
+                            f"{sid}__scaffolding__0": {
+                                "situation": f"situation for {sid}",
+                                "action": f"action for {sid}",
+                                "result": f"result for {sid}",
+                            },
+                        }
+                    )
+                )
             if f"overscaffold__{sid}__0" in keys:
-                out.update(_make_raw_entries({
-                    f"action__{sid}__0": [f"facet-a {sid}"],
-                    f"overscaffold__{sid}__0": [],
-                }))
+                out.update(
+                    _make_raw_entries(
+                        {
+                            f"action__{sid}__0": [f"facet-a {sid}"],
+                            f"overscaffold__{sid}__0": [],
+                        }
+                    )
+                )
             elif f"action__{sid}__0" in keys:
                 # Structure pass (action JSON)
-                out.update(_make_raw_entries({
-                    f"action__{sid}__0": {"scaffolding": "yes", "rigor": "no"},
-                }))
+                out.update(
+                    _make_raw_entries(
+                        {
+                            f"action__{sid}__0": {"scaffolding": "yes", "rigor": "no"},
+                        }
+                    )
+                )
         return out
 
     return fake_run_batch, calls
@@ -1345,7 +1508,9 @@ def test_score_batch_pools_three_run_batch_calls(fixture_scenario, fixture_trans
 
     assert len(calls) == 3, f"Expected 3 pooled run_batch calls, got {len(calls)}"
     assert [c["display_name"] for c in calls] == [
-        "scorer_annotate", "scorer_decompose", "scorer_structure",
+        "scorer_annotate",
+        "scorer_decompose",
+        "scorer_structure",
     ]
     # Every pass's entry set must cover BOTH scenarios (pooled, not per-moment)
     for call in calls:
@@ -1366,7 +1531,9 @@ def test_score_batch_pools_three_run_batch_calls(fixture_scenario, fixture_trans
     assert a2.action_decomposed == [f"facet-a {s2.id}"]
 
 
-def test_score_batch_attributes_usage_per_scenario(fixture_scenario, fixture_transcript):
+def test_score_batch_attributes_usage_per_scenario(
+    fixture_scenario, fixture_transcript
+):
     """Each Annotation.usage counts only its own scenario's entries."""
     from tutorsim.scoring import score_batch
 
@@ -1385,7 +1552,9 @@ def test_score_batch_attributes_usage_per_scenario(fixture_scenario, fixture_tra
         )
 
 
-def test_score_batch_empty_transcript_gets_minimal_annotation(fixture_scenario, fixture_transcript):
+def test_score_batch_empty_transcript_gets_minimal_annotation(
+    fixture_scenario, fixture_transcript
+):
     """A pair with no generated turns yields the minimal Annotation, no batch entries."""
     from tutorsim.scoring import score_batch
 
@@ -1402,7 +1571,10 @@ def test_score_batch_empty_transcript_gets_minimal_annotation(fixture_scenario, 
     for call in calls:
         assert not any(s2.id in k for k in call["keys"])
     # The non-empty pair still scores normally
-    assert annotations[fixture_scenario.id].situation == f"situation for {fixture_scenario.id}"
+    assert (
+        annotations[fixture_scenario.id].situation
+        == f"situation for {fixture_scenario.id}"
+    )
 
 
 def test_score_batch_empty_input():
@@ -1424,6 +1596,8 @@ def test_score_delegates_to_pooled_path(fixture_scenario, fixture_transcript):
         single = score(fixture_scenario, fixture_transcript)
     fake_run_batch2, _ = _fake_pooled_run_batch([fixture_scenario.id])
     with _patch_score(fake_run_batch2)[0]:
-        pooled = score_batch([(fixture_scenario, fixture_transcript)])[fixture_scenario.id]
+        pooled = score_batch([(fixture_scenario, fixture_transcript)])[
+            fixture_scenario.id
+        ]
 
     assert single.to_dict() == pooled.to_dict()

--- a/tests/tutorsim/test_student.py
+++ b/tests/tutorsim/test_student.py
@@ -3,11 +3,11 @@
 Trait generation moved to tutorsim_build (frozen personas ship in the
 release); its tests live in tests/tutorsim_build/test_traits.py.
 """
-import pytest
 
 # ---------------------------------------------------------------------------
 # Tests: build_student_system_prompt (oracle mode) -- Task 4
 # ---------------------------------------------------------------------------
+
 
 class TestBuildStudentSystemPrompt:
     """Tests for build_student_system_prompt() -- oracle prompt render + substitutions."""
@@ -101,18 +101,20 @@ class TestBuildStudentSystemPrompt:
 # Tests: resolve_student -- Task 4
 # ---------------------------------------------------------------------------
 
+
 class TestResolveStudent:
     """Tests for resolve_student() -- hosted model resolution + registry."""
 
     def test_resolve_student_no_id_returns_hosted_claude_opus(self, monkeypatch):
         """resolve_student() with no args returns hosted claude-opus-4-6 with thinking=False."""
-        import os
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
 
         # Patch anthropic.Anthropic so no real HTTP call is made.
         import unittest.mock as mock
+
         with mock.patch("anthropic.Anthropic"):
             from tutorsim.student import resolve_student
+
             result = resolve_student()
 
         assert result["kind"] == "hosted"
@@ -121,8 +123,9 @@ class TestResolveStudent:
 
     def test_resolve_student_registered(self, monkeypatch):
         """A @register_student-decorated callable is returned by resolve_student(name)."""
-        from tutorsim.config import register_student, _STUDENT_REGISTRY
         import unittest.mock as mock
+
+        from tutorsim.config import _STUDENT_REGISTRY, register_student
 
         # Register a dummy student.
         @register_student("dummy")
@@ -132,6 +135,7 @@ class TestResolveStudent:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         with mock.patch("anthropic.Anthropic"):
             from tutorsim.student import resolve_student
+
             result = resolve_student("dummy")
 
         assert result["kind"] == "registered"

--- a/tests/tutorsim/test_taxonomy.py
+++ b/tests/tutorsim/test_taxonomy.py
@@ -5,11 +5,10 @@ the input adapters, pool + CSV round-trips, the LLM classifier with a fake
 client (resume safety, JSON-error handling, total_tokens recording), and
 atomic CSV writes.
 """
+
 from __future__ import annotations
 
-import csv
 import json
-import math
 from dataclasses import asdict
 from pathlib import Path
 
@@ -17,33 +16,48 @@ import pytest
 
 from tutorsim import taxonomy as tx
 
-
 # ---------------------------------------------------------------------------
 # 1. filter_statement: the four reason codes + keep
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("statement, expected_bucket, expected_reason", [
-    # KEEPs (real tutor actions with a real verb)
-    ("The tutor asks guiding questions about the next step.", "keep", ""),
-    ("After confirmation, the tutor offers a hint.", "keep", ""),
-    ("The tutor scaffolds by introducing a different representation.", "keep", ""),
-    # non_tutor_actor: subject is the student / interaction / etc.
-    ("The student answers correctly.", "strip", "non_tutor_actor"),
-    ("There is no withdrawal of support.", "strip", "non_tutor_actor"),
-    ("No attempt is made to review the student's work.", "strip", "non_tutor_actor"),
-    ("The interaction consists entirely of casual banter.", "strip", "non_tutor_actor"),
-    # pure_stance: stance phrase + only filler
-    ("The tutor is scaffolding.", "strip", "pure_stance"),
-    ("The tutor pushes for rigor.", "strip", "pure_stance"),
-    ("The tutor uses a mix of scaffolding and rigor.", "strip", "pure_stance"),
-    # stance_negation: stance phrase + negation
-    ("The tutor does not push for rigor.", "strip", "stance_negation"),
-    ("The tutor is not scaffolding.", "strip", "stance_negation"),
-    # non_action: tutor verb but the verb is a negation
-    ("The tutor does not ask the student to explain.", "strip", "non_action"),
-    ("The tutor takes no substantive pedagogical action.", "strip", "non_action"),
-    ("The tutor fails to acknowledge the student's correct answer.", "strip", "non_action"),
-])
+
+@pytest.mark.parametrize(
+    "statement, expected_bucket, expected_reason",
+    [
+        # KEEPs (real tutor actions with a real verb)
+        ("The tutor asks guiding questions about the next step.", "keep", ""),
+        ("After confirmation, the tutor offers a hint.", "keep", ""),
+        ("The tutor scaffolds by introducing a different representation.", "keep", ""),
+        # non_tutor_actor: subject is the student / interaction / etc.
+        ("The student answers correctly.", "strip", "non_tutor_actor"),
+        ("There is no withdrawal of support.", "strip", "non_tutor_actor"),
+        (
+            "No attempt is made to review the student's work.",
+            "strip",
+            "non_tutor_actor",
+        ),
+        (
+            "The interaction consists entirely of casual banter.",
+            "strip",
+            "non_tutor_actor",
+        ),
+        # pure_stance: stance phrase + only filler
+        ("The tutor is scaffolding.", "strip", "pure_stance"),
+        ("The tutor pushes for rigor.", "strip", "pure_stance"),
+        ("The tutor uses a mix of scaffolding and rigor.", "strip", "pure_stance"),
+        # stance_negation: stance phrase + negation
+        ("The tutor does not push for rigor.", "strip", "stance_negation"),
+        ("The tutor is not scaffolding.", "strip", "stance_negation"),
+        # non_action: tutor verb but the verb is a negation
+        ("The tutor does not ask the student to explain.", "strip", "non_action"),
+        ("The tutor takes no substantive pedagogical action.", "strip", "non_action"),
+        (
+            "The tutor fails to acknowledge the student's correct answer.",
+            "strip",
+            "non_action",
+        ),
+    ],
+)
 def test_filter_statement(statement, expected_bucket, expected_reason):
     bucket, reason, _ = tx.filter_statement(statement)
     assert bucket == expected_bucket, statement
@@ -61,6 +75,7 @@ def test_filter_statement_stance_prefixed_flag():
 # ---------------------------------------------------------------------------
 # 2. Scheme integrity
 # ---------------------------------------------------------------------------
+
 
 def test_frozen_scheme_shape():
     assert len(tx.CATEGORIES) == 13
@@ -83,11 +98,17 @@ def test_categories_have_required_fields():
 # 3. Pool + CSV round-trip
 # ---------------------------------------------------------------------------
 
+
 def _mk_facet(stmt: str, **overrides) -> tx.Facet:
     base = dict(
-        moment_id="m0", transcript_id="t0", turn_start=1, turn_end=2,
-        statement_index=0, statement=stmt,
-        annotation_type="scaffolding", situation_label="scaffolding",
+        moment_id="m0",
+        transcript_id="t0",
+        turn_start=1,
+        turn_end=2,
+        statement_index=0,
+        statement=stmt,
+        annotation_type="scaffolding",
+        situation_label="scaffolding",
         source="canonical",
     )
     base.update(overrides)
@@ -141,6 +162,7 @@ def test_atomic_write_leaves_no_tmp_after_success(tmp_path):
 # 4. Adapters
 # ---------------------------------------------------------------------------
 
+
 def _write_key_moments_jsonl(path: Path, rows: list[dict]) -> None:
     with path.open("w") as f:
         for r in rows:
@@ -149,28 +171,37 @@ def _write_key_moments_jsonl(path: Path, rows: list[dict]) -> None:
 
 def test_load_key_moments_jsonl(tmp_path):
     src = tmp_path / "kmoments.jsonl"
-    _write_key_moments_jsonl(src, [
-        {
-            "conversation_id": "conv-1",
-            "num_turns": 100,
-            "key_moments": [
-                # scaffolding moment we should pull in
-                {"annotation_type": "scaffolding",
-                 "turn_start": 5, "turn_end": 7,
-                 "situation_label_agg": "scaffolding",
-                 "annotator_id": "ann-A",
-                 "action_decomposed": [
-                     "The tutor asks a guiding question.",
-                     "The tutor offers a hint.",
-                 ]},
-                # rapport moment we should SKIP (annotation_type filter)
-                {"annotation_type": "rapport",
-                 "turn_start": 20, "turn_end": 22,
-                 "annotator_id": "ann-A",
-                 "action_decomposed": ["The tutor expresses warmth."]},
-            ],
-        },
-    ])
+    _write_key_moments_jsonl(
+        src,
+        [
+            {
+                "conversation_id": "conv-1",
+                "num_turns": 100,
+                "key_moments": [
+                    # scaffolding moment we should pull in
+                    {
+                        "annotation_type": "scaffolding",
+                        "turn_start": 5,
+                        "turn_end": 7,
+                        "situation_label_agg": "scaffolding",
+                        "annotator_id": "ann-A",
+                        "action_decomposed": [
+                            "The tutor asks a guiding question.",
+                            "The tutor offers a hint.",
+                        ],
+                    },
+                    # rapport moment we should SKIP (annotation_type filter)
+                    {
+                        "annotation_type": "rapport",
+                        "turn_start": 20,
+                        "turn_end": 22,
+                        "annotator_id": "ann-A",
+                        "action_decomposed": ["The tutor expresses warmth."],
+                    },
+                ],
+            },
+        ],
+    )
     facets = list(tx.load_key_moments_jsonl(src))
     assert len(facets) == 2
     assert {f.statement for f in facets} == {
@@ -200,18 +231,26 @@ def test_load_tutorsim_results_reads_config_and_scenarios(tmp_path):
     # Stage a minimal tutorsim run-results directory + matching scenarios.jsonl.
     run_dir = tmp_path / "run-x"
     (run_dir / "scores").mkdir(parents=True)
-    (run_dir / "config.json").write_text(json.dumps({"tutor": "fake-model",
-                                                     "mode": "plain"}))
-    (run_dir / "scores" / "scen-1.json").write_text(json.dumps({
-        "scenario_id": "scen-1",
-        "annotation_type": "scaffolding",
-        "turn_start": 10, "turn_end": 14,
-        "action_decomposed": ["The tutor asks a guiding question."],
-        "action_label": "scaffolding",
-        "result_label": "pos",
-    }))
+    (run_dir / "config.json").write_text(
+        json.dumps({"tutor": "fake-model", "mode": "plain"})
+    )
+    (run_dir / "scores" / "scen-1.json").write_text(
+        json.dumps(
+            {
+                "scenario_id": "scen-1",
+                "annotation_type": "scaffolding",
+                "turn_start": 10,
+                "turn_end": 14,
+                "action_decomposed": ["The tutor asks a guiding question."],
+                "action_label": "scaffolding",
+                "result_label": "pos",
+            }
+        )
+    )
     scenarios = tmp_path / "scenarios.jsonl"
-    scenarios.write_text(json.dumps({"id": "scen-1", "dimension": "scaffolding"}) + "\n")
+    scenarios.write_text(
+        json.dumps({"id": "scen-1", "dimension": "scaffolding"}) + "\n"
+    )
 
     facets = list(tx.load_tutorsim_results(run_dir, scenarios))
     assert len(facets) == 1
@@ -225,6 +264,7 @@ def test_load_tutorsim_results_reads_config_and_scenarios(tmp_path):
 # ---------------------------------------------------------------------------
 # 5. Headline math (pure, no LLM)
 # ---------------------------------------------------------------------------
+
 
 def test_normal_ci_basic():
     mean, lo, hi = tx._normal_ci([0.5, 0.5, 0.5, 0.5])
@@ -250,7 +290,7 @@ def test_js_divergence_symmetric_and_self_zero():
 
 
 def test_macro_distribution_averages_per_moment(monkeypatch):
-    pd = pytest.importorskip("pandas")
+    pytest.importorskip("pandas")
     # two moments: m1 -> {A:2, B:0} (so A=100%); m2 -> {A:0, B:1} (so B=100%)
     # macro mean: A = (1.0 + 0.0)/2 = 0.5; B = (0.0 + 1.0)/2 = 0.5
     facets = [
@@ -270,6 +310,7 @@ def test_macro_distribution_averages_per_moment(monkeypatch):
 # 6. Classifier wiring + resume + json-error handling + total_tokens
 # ---------------------------------------------------------------------------
 
+
 class _FakeModelResponse:
     def __init__(self, text: str, usage: dict):
         self.text = text
@@ -287,8 +328,11 @@ class _FakeClient:
 
     def generate(self, prompt, **kwargs):
         self.calls.append({"prompt": prompt, **kwargs})
-        payload = (self._payloads.pop(0) if self._payloads
-                   else '{"assignments": [{"id":1,"category":"A"}]}')
+        payload = (
+            self._payloads.pop(0)
+            if self._payloads
+            else '{"assignments": [{"id":1,"category":"A"}]}'
+        )
         return _FakeModelResponse(
             payload,
             {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
@@ -315,8 +359,7 @@ def test_classifier_handles_unparseable_json(tmp_path, caplog):
     # Every response is junk -> retries exhausted -> statement forced to LAST_LETTER.
     client = _FakeClient(payloads=["not valid json"] * 8)
     with caplog.at_level("WARNING", logger="tutorsim.taxonomy"):
-        assignments = tx.classify_pool(
-            facets, tmp_path, client=client, max_batches=1)
+        assignments = tx.classify_pool(facets, tmp_path, client=client, max_batches=1)
     assert assignments[facets[0].statement.strip()] == tx.LAST_LETTER
     assert any("unparseable JSON" in rec.message for rec in caplog.records)
 
@@ -327,9 +370,11 @@ def test_classifier_resume_skips_completed_batches(tmp_path):
         _mk_facet("The tutor offers a hint.", moment_id="m2"),
     ]
     # First pass: both classified.
-    first = _FakeClient(payloads=[
-        '{"assignments":[{"id":1,"category":"A"},{"id":2,"category":"E"}]}',
-    ])
+    first = _FakeClient(
+        payloads=[
+            '{"assignments":[{"id":1,"category":"A"},{"id":2,"category":"E"}]}',
+        ]
+    )
     tx.classify_pool(facets, tmp_path, client=first, max_batches=1)
     assert len(first.calls) == 1
 
@@ -342,6 +387,7 @@ def test_classifier_resume_skips_completed_batches(tmp_path):
 # ---------------------------------------------------------------------------
 # 7. CLI extras guard
 # ---------------------------------------------------------------------------
+
 
 def test_require_analysis_extras_passes_when_pandas_present():
     pytest.importorskip("pandas")
@@ -374,9 +420,13 @@ from types import SimpleNamespace
 
 def _ann(**kw):
     base = dict(
-        scenario_id="c1__0_2", annotation_type="scaffolding",
+        scenario_id="c1__0_2",
+        annotation_type="scaffolding",
         action_decomposed=["The tutor asks a guiding question."],
-        turn_start=0, turn_end=2, action_label="scaffolding", result="ok",
+        turn_start=0,
+        turn_end=2,
+        action_label="scaffolding",
+        result="ok",
     )
     base.update(kw)
     return SimpleNamespace(**base)
@@ -387,37 +437,56 @@ def _moment(id="c1__0_2", dimension="scaffolding"):
 
 
 def test_facets_from_annotations_uses_moment_dimension():
-    facets = list(tx.facets_from_annotations(
-        [_ann()], [_moment(dimension="rigor")],
-        model="claude-sonnet-5", mode="plain",
-    ))
+    facets = list(
+        tx.facets_from_annotations(
+            [_ann()],
+            [_moment(dimension="rigor")],
+            model="claude-sonnet-5",
+            mode="plain",
+        )
+    )
     assert len(facets) == 1
     f = facets[0]
-    assert f.situation_label == "rigor"          # from Moment.dimension
-    assert f.result_label == "ok"                # from Annotation.result (not result_label)
+    assert f.situation_label == "rigor"  # from Moment.dimension
+    assert f.result_label == "ok"  # from Annotation.result (not result_label)
     assert f.model == "claude-sonnet-5" and f.prompt == "plain"
     assert f.annotation_type == "scaffolding"
 
 
 def test_facets_from_annotations_skips_non_scaffolding():
-    facets = list(tx.facets_from_annotations(
-        [_ann(annotation_type="rapport")], [_moment()], model="m", mode="plain",
-    ))
+    facets = list(
+        tx.facets_from_annotations(
+            [_ann(annotation_type="rapport")],
+            [_moment()],
+            model="m",
+            mode="plain",
+        )
+    )
     assert facets == []
 
 
 def test_classify_run_writes_classified_and_counts(tmp_path):
     anns = [
-        _ann(scenario_id="c1__0_2", action_decomposed=["The tutor asks a guiding question."]),
+        _ann(
+            scenario_id="c1__0_2",
+            action_decomposed=["The tutor asks a guiding question."],
+        ),
         _ann(scenario_id="c2__0_2", action_decomposed=["The tutor offers a hint."]),
     ]
     moments = [_moment(id="c1__0_2"), _moment(id="c2__0_2")]
-    client = _FakeClient(payloads=[
-        '{"assignments":[{"id":1,"category":"A"},{"id":2,"category":"E"}]}',
-    ])
+    client = _FakeClient(
+        payloads=[
+            '{"assignments":[{"id":1,"category":"A"},{"id":2,"category":"E"}]}',
+        ]
+    )
     out = tmp_path / "taxonomy"
     summary = tx.classify_run(
-        anns, moments, out, model="claude-sonnet-5", mode="plain", client=client,
+        anns,
+        moments,
+        out,
+        model="claude-sonnet-5",
+        mode="plain",
+        client=client,
     )
     assert (out / "classified.csv").exists()
     assert summary["scheme_version"] == tx.SCHEME_VERSION
@@ -430,6 +499,7 @@ def test_classify_run_writes_classified_and_counts(tmp_path):
 
 def test_taxonomy_spec_reads_config():
     from tutorsim import config as cfgmod
+
     cfgmod._reset_config_cache()
     spec = cfgmod.taxonomy_spec()
     assert spec["model"] == "claude-opus-4-8"
@@ -452,7 +522,13 @@ def test_read_paper_distribution_selects_series(tmp_path):
     human = tx.read_paper_distribution(csv, "human")
     assert human.loc["A", "mean_pct"] == pytest.approx(10.18)
     assert human.loc["A", "orientation"] == "scaffolding"
-    assert set(human.columns) >= {"name", "orientation", "mean_pct", "ci_low", "ci_high"}
+    assert set(human.columns) >= {
+        "name",
+        "orientation",
+        "mean_pct",
+        "ci_low",
+        "ci_high",
+    }
     # A model series selects its own column group
     model = tx.read_paper_distribution(csv, "claude_opus_4_8__plain")
     assert model.loc["A", "mean_pct"] == pytest.approx(20.27)

--- a/tests/tutorsim/test_tutor.py
+++ b/tests/tutorsim/test_tutor.py
@@ -1,10 +1,13 @@
 """Tests for tutorsim.tutor module."""
-import pytest
+
 import os
-from unittest.mock import patch, MagicMock
-from tutorsim.tutor import build_tutor_system_prompt, resolve_tutor
+from unittest.mock import patch
+
+import pytest
+
 from tutorsim import register_tutor
-from tutorsim.config import _reset_config_cache, _TUTOR_REGISTRY
+from tutorsim.config import _TUTOR_REGISTRY, _reset_config_cache
+from tutorsim.tutor import build_tutor_system_prompt, resolve_tutor
 
 
 def test_plain_mode_loads_and_substitutes():
@@ -35,9 +38,7 @@ def test_oracle_mode_substitutes_reference_transcript():
     context = "Grade 4, geometry"
     reference = "Tutor: Great job! Now let's try the next one."
     prompt = build_tutor_system_prompt(
-        "oracle",
-        student_context=context,
-        reference_transcript=reference
+        "oracle", student_context=context, reference_transcript=reference
     )
 
     assert context in prompt
@@ -51,10 +52,7 @@ def test_oracle_mode_substitutes_reference_transcript():
 def test_oracle_mode_requires_reference_transcript():
     """Test that oracle mode raises ValueError if reference_transcript is not provided."""
     with pytest.raises(ValueError, match="reference_transcript"):
-        build_tutor_system_prompt(
-            "oracle",
-            student_context="Grade 5"
-        )
+        build_tutor_system_prompt("oracle", student_context="Grade 5")
 
 
 def test_default_mode_with_none():
@@ -95,7 +93,7 @@ def test_student_context_can_be_empty():
 def test_resolve_tutor_hosted():
     """Test resolve_tutor for a hosted model."""
     # Patch the Anthropic SDK at the real import path
-    with patch("anthropic.Anthropic") as mock_anthropic:
+    with patch("anthropic.Anthropic"):
         # Set up the environment
         os.environ["ANTHROPIC_API_KEY"] = "test-key"
         try:

--- a/tests/tutorsim_build/test_build_moments.py
+++ b/tests/tutorsim_build/test_build_moments.py
@@ -14,6 +14,7 @@ conv-ddd: cluster (1,3), votes=[2]     -> JSONL-only conv; STUDENT turn -> cut s
 
 import json
 from pathlib import Path
+
 import pytest
 
 FIXTURE_DIR = Path("tests/tutorsim_build/fixtures/build_src")
@@ -31,14 +32,17 @@ def _ids_for(*conv_ts_te_pairs):
 # Import guard — fails loudly if build_scenarios isn't implemented yet
 # ---------------------------------------------------------------------------
 
+
 def _import_build():
     from tutorsim_build.moments_build import build_moments as build_scenarios
+
     return build_scenarios
 
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestBuildScenarios:
     """All tests are fully hermetic -- fixture dirs only, no real data."""
@@ -81,10 +85,26 @@ class TestBuildScenarios:
         s = scenarios[0]
         # conv-aaa cut=4 (STUDENT at 4, stays). Prefix: turns 1-4
         assert len(s.context) == 4
-        assert s.context[0] == {"turn_number": 1, "role": "tutor", "text": "What is half of 6?"}
-        assert s.context[1] == {"turn_number": 2, "role": "student", "text": "I think it might be 3?"}
-        assert s.context[2] == {"turn_number": 3, "role": "tutor", "text": "Can you explain how you got that?"}
-        assert s.context[3] == {"turn_number": 4, "role": "student", "text": "I split it into two groups"}
+        assert s.context[0] == {
+            "turn_number": 1,
+            "role": "tutor",
+            "text": "What is half of 6?",
+        }
+        assert s.context[1] == {
+            "turn_number": 2,
+            "role": "student",
+            "text": "I think it might be 3?",
+        }
+        assert s.context[2] == {
+            "turn_number": 3,
+            "role": "tutor",
+            "text": "Can you explain how you got that?",
+        }
+        assert s.context[3] == {
+            "turn_number": 4,
+            "role": "student",
+            "text": "I split it into two groups",
+        }
         # Roles must be lowercased
         for turn in s.context:
             assert turn["role"] in ("tutor", "student")
@@ -124,12 +144,12 @@ class TestBuildScenarios:
         scenarios = self._build(ids)
         p = scenarios[0].provenance
         assert p["conv_id"] == "conv-aaa"
-        assert p["cut_turn"] == 4           # final adjusted cut
+        assert p["cut_turn"] == 4  # final adjusted cut
         assert p["turn_start"] == 3
         assert p["turn_end"] == 5
         assert p["moment_id"] == "m-001"
         assert "annotator_id" in p
-        assert p["chosen_cut_turn"] == 4    # pre-adjustment modal vote
+        assert p["chosen_cut_turn"] == 4  # pre-adjustment modal vote
         assert "cut_votes" in p
         assert "cluster_size" in p
 
@@ -148,8 +168,8 @@ class TestBuildScenarios:
         scenarios = self._build(ids)
         assert len(scenarios) == 1
         s = scenarios[0]
-        assert s.provenance["chosen_cut_turn"] == 3   # modal before adjustment
-        assert s.provenance["cut_turn"] == 2           # after TUTOR decrement
+        assert s.provenance["chosen_cut_turn"] == 3  # modal before adjustment
+        assert s.provenance["cut_turn"] == 2  # after TUTOR decrement
         # context should be prefix up to cut=2 (turns 1,2)
         assert len(s.context) == 2
 
@@ -186,6 +206,7 @@ class TestBuildScenariosJsonl:
 
     def _build(self, ids, tutoring_provider_a_jsonl=None, set_name="test"):
         from tutorsim_build.moments_build import build_moments as build_scenarios
+
         return build_scenarios(
             set_name=set_name,
             ids=ids,
@@ -250,9 +271,18 @@ _STUB_TRAIT = {
 }
 
 
-def _reference_run_record(cell, scenario_id, conv_id, cut_turn, *, dimension="scaffolding",
-                          ts=3, te=5, situation="Ref-run situation text",
-                          student_trait=_STUB_TRAIT):
+def _reference_run_record(
+    cell,
+    scenario_id,
+    conv_id,
+    cut_turn,
+    *,
+    dimension="scaffolding",
+    ts=3,
+    te=5,
+    situation="Ref-run situation text",
+    student_trait=_STUB_TRAIT,
+):
     rec = {
         "cell": cell,
         "tutor_model": cell.split("__")[0],
@@ -301,15 +331,24 @@ class TestBuildMomentsFromReferenceRun:
         """One Moment per unique scenario_id, sorted by id, across many cells."""
         records = [
             _reference_run_record("m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4),
-            _reference_run_record("m1__scaffolding_rigor", "conv-aaa__hum_3_5", "conv-aaa", 4),
-            _reference_run_record("m2__plain", "conv-ddd__hum_1_3", "conv-ddd", 2, ts=1, te=3),
+            _reference_run_record(
+                "m1__scaffolding_rigor", "conv-aaa__hum_3_5", "conv-aaa", 4
+            ),
+            _reference_run_record(
+                "m2__plain", "conv-ddd__hum_1_3", "conv-ddd", 2, ts=1, te=3
+            ),
         ]
         moments = self._build(records, tmp_path)
-        assert [m.id for m in moments] == ["test:conv-aaa__hum_3_5", "test:conv-ddd__hum_1_3"]
+        assert [m.id for m in moments] == [
+            "test:conv-aaa__hum_3_5",
+            "test:conv-ddd__hum_1_3",
+        ]
 
     def test_detection_payload_becomes_moment_fields(self, tmp_path):
         """dimension/gold/hint/provenance come from the run's frozen detection."""
-        records = [_reference_run_record("m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4)]
+        records = [
+            _reference_run_record("m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4)
+        ]
         (m,) = self._build(records, tmp_path)
         assert m.dimension == "scaffolding"
         assert m.rubric["gold"] == "scaffolding"
@@ -326,10 +365,16 @@ class TestBuildMomentsFromReferenceRun:
 
     def test_context_and_reference_derived_from_transcript(self, tmp_path):
         """context = prefix turns <= cut_turn; reference = post-cut turns."""
-        records = [_reference_run_record("m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4)]
+        records = [
+            _reference_run_record("m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4)
+        ]
         (m,) = self._build(records, tmp_path)
         assert [t["turn_number"] for t in m.context] == [1, 2, 3, 4]
-        assert m.context[3] == {"turn_number": 4, "role": "student", "text": "I split it into two groups"}
+        assert m.context[3] == {
+            "turn_number": 4,
+            "role": "student",
+            "text": "I split it into two groups",
+        }
         ref = m.student["reference"]
         assert "Turn 5." in ref and "Turn 7." in ref and "Turn 4." not in ref
         assert m.student["mode"] == "oracle"
@@ -337,7 +382,11 @@ class TestBuildMomentsFromReferenceRun:
 
     def test_jsonl_only_conv_resolves(self, tmp_path):
         """A conv present only in the normalized JSONL transcript pool builds fine."""
-        records = [_reference_run_record("m1__plain", "conv-ddd__hum_1_3", "conv-ddd", 2, ts=1, te=3)]
+        records = [
+            _reference_run_record(
+                "m1__plain", "conv-ddd__hum_1_3", "conv-ddd", 2, ts=1, te=3
+            )
+        ]
         (m,) = self._build(records, tmp_path)
         assert m.id == "test:conv-ddd__hum_1_3"
         assert [t["turn_number"] for t in m.context] == [1, 2]
@@ -346,14 +395,18 @@ class TestBuildMomentsFromReferenceRun:
         """A scenario whose conv has no transcript is skipped, not fatal."""
         records = [
             _reference_run_record("m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4),
-            _reference_run_record("m1__plain", "conv-zzz__hum_1_2", "conv-zzz", 1, ts=1, te=2),
+            _reference_run_record(
+                "m1__plain", "conv-zzz__hum_1_2", "conv-zzz", 1, ts=1, te=2
+            ),
         ]
         moments = self._build(records, tmp_path)
         assert [m.id for m in moments] == ["test:conv-aaa__hum_3_5"]
 
     def test_student_trait_embedded_from_run(self, tmp_path):
         """The run record's frozen student_trait lands verbatim in student.trait."""
-        records = [_reference_run_record("m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4)]
+        records = [
+            _reference_run_record("m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4)
+        ]
         (m,) = self._build(records, tmp_path)
         assert m.student["trait"] == _STUB_TRAIT
 
@@ -361,8 +414,11 @@ class TestBuildMomentsFromReferenceRun:
         """A run record without student_trait must fail the build loudly:
         the release contract is that every moment carries the paper's frozen
         persona, and a silent skip would ship a non-reproducible set."""
-        records = [_reference_run_record("m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4,
-                                         student_trait=None)]
+        records = [
+            _reference_run_record(
+                "m1__plain", "conv-aaa__hum_3_5", "conv-aaa", 4, student_trait=None
+            )
+        ]
         with pytest.raises(ValueError, match="student_trait"):
             self._build(records, tmp_path)
 
@@ -377,11 +433,24 @@ def test_write_release_emits_flat_manifest_and_schema(tmp_path):
         id="t:c__hum_1_2",
         context=[{"turn_number": 1, "role": "tutor", "text": "Q"}],
         dimension="rigor",
-        student={"mode": "oracle", "reference": "", "context": "", "trait": dict(_STUB_TRAIT)},
+        student={
+            "mode": "oracle",
+            "reference": "",
+            "context": "",
+            "trait": dict(_STUB_TRAIT),
+        },
         rubric={"gold": "rigor", "hint": ""},
-        provenance={"conv_id": "c", "cut_turn": 1, "turn_start": 1, "turn_end": 2,
-                    "moment_id": None, "annotator_id": "a", "chosen_cut_turn": 1,
-                    "cut_votes": {"1": 1}, "cluster_size": 1},
+        provenance={
+            "conv_id": "c",
+            "cut_turn": 1,
+            "turn_start": 1,
+            "turn_end": 2,
+            "moment_id": None,
+            "annotator_id": "a",
+            "chosen_cut_turn": 1,
+            "cut_votes": {"1": 1},
+            "cluster_size": 1,
+        },
     )
     write_release([m], tmp_path, set_name="t", created="2026-07-02")
 
@@ -407,9 +476,17 @@ def test_write_release_refuses_traitless_moment(tmp_path):
         dimension="rigor",
         student={"mode": "oracle", "reference": "", "context": ""},
         rubric={"gold": "rigor", "hint": ""},
-        provenance={"conv_id": "c", "cut_turn": 1, "turn_start": 1, "turn_end": 2,
-                    "moment_id": None, "annotator_id": "a", "chosen_cut_turn": 1,
-                    "cut_votes": {"1": 1}, "cluster_size": 1},
+        provenance={
+            "conv_id": "c",
+            "cut_turn": 1,
+            "turn_start": 1,
+            "turn_end": 2,
+            "moment_id": None,
+            "annotator_id": "a",
+            "chosen_cut_turn": 1,
+            "cut_votes": {"1": 1},
+            "cluster_size": 1,
+        },
     )
     with pytest.raises(ValueError, match="trait"):
         write_release([m], tmp_path, set_name="t", created="2026-07-02")
@@ -425,17 +502,32 @@ def test_validate_dataset_requires_traits(tmp_path):
         id="t:c__hum_1_2",
         context=[{"turn_number": 1, "role": "tutor", "text": "Q"}],
         dimension="rigor",
-        student={"mode": "oracle", "reference": "", "context": "", "trait": dict(_STUB_TRAIT)},
+        student={
+            "mode": "oracle",
+            "reference": "",
+            "context": "",
+            "trait": dict(_STUB_TRAIT),
+        },
         rubric={"gold": "rigor", "hint": ""},
-        provenance={"conv_id": "c", "cut_turn": 1, "turn_start": 1, "turn_end": 2,
-                    "moment_id": None, "annotator_id": "a", "chosen_cut_turn": 1,
-                    "cut_votes": {"1": 1}, "cluster_size": 1},
+        provenance={
+            "conv_id": "c",
+            "cut_turn": 1,
+            "turn_start": 1,
+            "turn_end": 2,
+            "moment_id": None,
+            "annotator_id": "a",
+            "chosen_cut_turn": 1,
+            "cut_votes": {"1": 1},
+            "cluster_size": 1,
+        },
     )
     write_release([m], tmp_path, set_name="t", created="2026-07-02")
 
     # Strip the persona from the written record, rewrite manifest hashes to match.
     import json as _json
-    from tutorsim.moments import file_sha256, records_content_hash, _read_moments_jsonl
+
+    from tutorsim.moments import _read_moments_jsonl, file_sha256, records_content_hash
+
     rec = _json.loads((tmp_path / "moments.jsonl").read_text())
     rec["student"].pop("trait")
     (tmp_path / "moments.jsonl").write_text(_json.dumps(rec) + "\n", encoding="utf-8")
@@ -443,7 +535,9 @@ def test_validate_dataset_requires_traits(tmp_path):
     loaded = _read_moments_jsonl(tmp_path / "moments.jsonl")
     manifest["content_hash"] = records_content_hash([x.to_dict() for x in loaded])
     manifest["file_sha256"] = file_sha256(tmp_path / "moments.jsonl")
-    (tmp_path / "moments.manifest.json").write_text(_json.dumps(manifest), encoding="utf-8")
+    (tmp_path / "moments.manifest.json").write_text(
+        _json.dumps(manifest), encoding="utf-8"
+    )
 
     with pytest.raises(ValueError, match="trait"):
         validate_dataset(tmp_path)

--- a/tests/tutorsim_build/test_classify.py
+++ b/tests/tutorsim_build/test_classify.py
@@ -8,16 +8,16 @@ import pytest
 
 from tutorsim_build.classify import (
     JUNK_TEXTS,
-    VALID_SITUATION_LABELS,
     VALID_LABELS,
+    VALID_SITUATION_LABELS,
     _parse_situation_label,
     load_labeller_templates,
     load_situation_prompt,
     pick_template,
 )
 
-
 # --- _parse_situation_label -------------------------------------------------
+
 
 def test_parse_situation_label_valid_json():
     label, had_error = _parse_situation_label('{"scaffolding": "yes", "rigor": "no"}')
@@ -32,7 +32,9 @@ def test_parse_situation_label_unwraps_list():
 
 
 def test_parse_situation_label_coerces_unknown_value_to_unclear():
-    label, had_error = _parse_situation_label('{"scaffolding": "maybe", "rigor": "yes"}')
+    label, had_error = _parse_situation_label(
+        '{"scaffolding": "maybe", "rigor": "yes"}'
+    )
     assert label == {"scaffolding": "unclear", "rigor": "yes"}
     assert had_error is False
 
@@ -54,6 +56,7 @@ def test_valid_situation_labels_set():
 
 
 # --- load_labeller_templates / pick_template --------------------------------
+
 
 def test_load_labeller_templates_dict_routes_per_type():
     templates = load_labeller_templates(
@@ -94,6 +97,7 @@ def test_pick_template_raises_when_unmapped_and_no_fallback():
 
 
 # --- JUNK_TEXTS -------------------------------------------------------------
+
 
 def test_junk_texts_contains_known_placeholders():
     assert "" in JUNK_TEXTS

--- a/tests/tutorsim_build/test_cli.py
+++ b/tests/tutorsim_build/test_cli.py
@@ -21,16 +21,24 @@ def test_tutorsim_build_dispatches(tmp_path):
     out_dir = tmp_path / "release"
 
     with patch("tutorsim_build.moments_build._cli_build") as mock_build:
-        main([
-            "dataset",
-            "build",
-            "--set", "balanced_520",
-            "--ids", str(ids_file),
-            "--ground-truth", str(gt_dir),
-            "--transcripts", str(tx_dir),
-            "--out", str(out_dir),
-            "--created", "2026-06-26",
-        ])
+        main(
+            [
+                "dataset",
+                "build",
+                "--set",
+                "balanced_520",
+                "--ids",
+                str(ids_file),
+                "--ground-truth",
+                str(gt_dir),
+                "--transcripts",
+                str(tx_dir),
+                "--out",
+                str(out_dir),
+                "--created",
+                "2026-06-26",
+            ]
+        )
 
     mock_build.assert_called_once()
     call_args = mock_build.call_args[0][0]
@@ -46,11 +54,14 @@ def test_dataset_validate_cli(capsys):
     """main(['dataset', 'validate', ...]) validates the mini fixture release dir."""
     from tutorsim_build.cli import main
 
-    main([
-        "dataset",
-        "validate",
-        "--data_path", "tests/tutorsim/fixtures/mini_release",
-    ])
+    main(
+        [
+            "dataset",
+            "validate",
+            "--data_path",
+            "tests/tutorsim/fixtures/mini_release",
+        ]
+    )
 
     captured = capsys.readouterr()
     assert "Dataset valid: mini_set" in captured.out
@@ -65,15 +76,22 @@ def test_dataset_build_writes_build_log(tmp_path):
     out_dir = tmp_path / "release"
 
     with patch("tutorsim_build.moments_build._cli_build"):
-        main([
-            "dataset",
-            "build",
-            "--set", "balanced_520",
-            "--ids", str(ids_file),
-            "--ground-truth", str(tmp_path),
-            "--transcripts", str(tmp_path),
-            "--out", str(out_dir),
-        ])
+        main(
+            [
+                "dataset",
+                "build",
+                "--set",
+                "balanced_520",
+                "--ids",
+                str(ids_file),
+                "--ground-truth",
+                str(tmp_path),
+                "--transcripts",
+                str(tmp_path),
+                "--out",
+                str(out_dir),
+            ]
+        )
 
     content = (out_dir / "build.log").read_text(encoding="utf-8")
     assert "Command: tutorsim-build dataset build" in content
@@ -88,12 +106,17 @@ def test_build_ground_truth_dry_run_writes_nothing(tmp_path):
     out_dir = tmp_path / "gt"
 
     with patch("tutorsim_build.groundtruth.build_ground_truth"):
-        main([
-            "dataset", "build-ground-truth",
-            "--input", str(ann),
-            "--out-dir", str(out_dir),
-            "--dry-run",
-        ])
+        main(
+            [
+                "dataset",
+                "build-ground-truth",
+                "--input",
+                str(ann),
+                "--out-dir",
+                str(out_dir),
+                "--dry-run",
+            ]
+        )
 
     assert not out_dir.exists()
 
@@ -108,12 +131,16 @@ def test_build_cli_accepts_log_flags(tmp_path):
     root = logging.getLogger()
     old_handlers = root.handlers[:]
     try:
-        main([
-            "dataset",
-            "validate",
-            "--data_path", "tests/tutorsim/fixtures/mini_release",
-            "--log-file", str(log_file),
-        ])
+        main(
+            [
+                "dataset",
+                "validate",
+                "--data_path",
+                "tests/tutorsim/fixtures/mini_release",
+                "--log-file",
+                str(log_file),
+            ]
+        )
         for handler in root.handlers:
             handler.flush()
     finally:
@@ -128,6 +155,7 @@ def test_build_cli_accepts_log_flags(tmp_path):
 
 def test_tutorsim_build_ground_truth_help_parses():
     import pytest
+
     from tutorsim_build import cli as cli_mod
 
     parser = cli_mod._build_parser()
@@ -149,13 +177,20 @@ def test_tutorsim_build_ground_truth_dispatches_with_defaults(tmp_path):
         captured.update(kwargs)
         return {"dry_run": kwargs.get("dry_run")}
 
-    with patch("tutorsim_build.groundtruth.build_ground_truth", side_effect=_fake_build) as m:
-        cli_mod.main([
-            "dataset", "build-ground-truth",
-            "--input", str(ann),
-            "--out-dir", str(out),
-            "--dry-run",
-        ])
+    with patch(
+        "tutorsim_build.groundtruth.build_ground_truth", side_effect=_fake_build
+    ) as m:
+        cli_mod.main(
+            [
+                "dataset",
+                "build-ground-truth",
+                "--input",
+                str(ann),
+                "--out-dir",
+                str(out),
+                "--dry-run",
+            ]
+        )
     assert m.called
     assert captured["dry_run"] is True
     assert str(captured["input_path"]) == str(ann)
@@ -169,12 +204,19 @@ def test_tutorsim_build_ground_truth_default_out_dir_follows_labeller(tmp_path):
     ann = tmp_path / "ann.jsonl"
     ann.write_text("", encoding="utf-8")
     captured = {}
-    with patch("tutorsim_build.groundtruth.build_ground_truth",
-               side_effect=lambda **kw: captured.update(kw)):
-        cli_mod.main([
-            "dataset", "build-ground-truth",
-            "--input", str(ann),
-            "--labeller", "hybrid",
-            "--dry-run",
-        ])
+    with patch(
+        "tutorsim_build.groundtruth.build_ground_truth",
+        side_effect=lambda **kw: captured.update(kw),
+    ):
+        cli_mod.main(
+            [
+                "dataset",
+                "build-ground-truth",
+                "--input",
+                str(ann),
+                "--labeller",
+                "hybrid",
+                "--dry-run",
+            ]
+        )
     assert str(captured["out_dir"]).endswith("ground_truth_hybrid")

--- a/tests/tutorsim_build/test_ground_truth_agg.py
+++ b/tests/tutorsim_build/test_ground_truth_agg.py
@@ -10,8 +10,6 @@ its behavior.
 
 import json
 
-import pytest
-
 from tutorsim_build.groundtruth import (
     DEFAULT_RESULT_LABEL,
     _invalidate_agg_cache,
@@ -24,9 +22,16 @@ from tutorsim_build.groundtruth import (
 )
 
 
-def _moment(annotator_id, turn_start, turn_end, annotation_type="scaffolding",
-            action_decomposed=None, result_decomposed=None, situation_label=None,
-            result="r"):
+def _moment(
+    annotator_id,
+    turn_start,
+    turn_end,
+    annotation_type="scaffolding",
+    action_decomposed=None,
+    result_decomposed=None,
+    situation_label=None,
+    result="r",
+):
     m = {
         "annotator_id": annotator_id,
         "turn_start": turn_start,
@@ -43,6 +48,7 @@ def _moment(annotator_id, turn_start, turn_end, annotation_type="scaffolding",
 
 # --- _scaffolding_clusters -------------------------------------------------
 
+
 def test_scaffolding_clusters_ignores_rapport_moments():
     moments = [
         _moment("t1", 1, 5, annotation_type="rapport"),
@@ -58,11 +64,13 @@ def test_scaffolding_clusters_ignores_rapport_moments():
 def test_scaffolding_clusters_groups_overlapping_different_annotators():
     moments = [
         _moment("t1", 1, 10),
-        _moment("t2", 1, 10),   # identical range as t1 -- IoU == 1.0
+        _moment("t2", 1, 10),  # identical range as t1 -- IoU == 1.0
         _moment("t3", 50, 60),  # disjoint -- separate cluster
     ]
     clusters = _scaffolding_clusters(moments)
-    cluster_sets = sorted([frozenset(idxs) for idxs, _ in clusters], key=lambda s: min(s))
+    cluster_sets = sorted(
+        [frozenset(idxs) for idxs, _ in clusters], key=lambda s: min(s)
+    )
     assert cluster_sets == [frozenset({0, 1}), frozenset({2})]
 
 
@@ -78,6 +86,7 @@ def test_scaffolding_clusters_does_not_directly_link_same_annotator():
 
 
 # --- _unify_facets ----------------------------------------------------------
+
 
 def test_unify_facets_concatenates_across_annotators_in_order():
     cluster_moments = [
@@ -95,7 +104,13 @@ def test_unify_facets_keeps_only_first_occurrence_per_annotator():
     cluster_moments = [
         _moment("t1", 1, 10, action_decomposed=["a1"], result_decomposed=["r1"]),
         _moment("t2", 5, 14, action_decomposed=["b1"], result_decomposed=["r2"]),
-        _moment("t1", 9, 18, action_decomposed=["a2-should-be-dropped"], result_decomposed=["r2-dropped"]),
+        _moment(
+            "t1",
+            9,
+            18,
+            action_decomposed=["a2-should-be-dropped"],
+            result_decomposed=["r2-dropped"],
+        ),
     ]
     unified_action, unified_result = _unify_facets(cluster_moments)
     assert unified_action == ["a1", "b1"]
@@ -103,6 +118,7 @@ def test_unify_facets_keeps_only_first_occurrence_per_annotator():
 
 
 # --- compute_situation_label_agg (regression after refactor onto _scaffolding_clusters) ---
+
 
 def test_compute_situation_label_agg_majority_votes_overlapping_cluster():
     moments = [
@@ -118,14 +134,22 @@ def test_compute_situation_label_agg_majority_votes_overlapping_cluster():
 
 def test_compute_situation_label_agg_unknown_when_no_signal():
     moments = [
-        _moment("t1", 1, 10, situation_label={"scaffolding": "no_mention", "rigor": "unclear"}),
-        _moment("t2", 2, 10, situation_label={"scaffolding": None, "rigor": "no_mention"}),
+        _moment(
+            "t1",
+            1,
+            10,
+            situation_label={"scaffolding": "no_mention", "rigor": "unclear"},
+        ),
+        _moment(
+            "t2", 2, 10, situation_label={"scaffolding": None, "rigor": "no_mention"}
+        ),
     ]
     agg = compute_situation_label_agg(moments)
     assert agg == {0: "unknown", 1: "unknown"}
 
 
 # --- plan_action_result_agg --------------------------------------------------
+
 
 def _plan_for(moments, cached_agg=None):
     cached_agg = cached_agg or {}
@@ -213,6 +237,7 @@ def test_plan_reclassifies_when_unified_facets_changed():
 
 # --- _invalidate_agg_cache (selective --refresh-agg) -------------------------
 
+
 def _full_cache(moments):
     sig = frozenset(moment_key(m) for m in moments)
     return {
@@ -239,9 +264,9 @@ def test_invalidate_agg_cache_action_reclassifies_action_reuses_result():
     invalidated = _invalidate_agg_cache(_full_cache(moments), "action")
     plan, to_action, to_result = _plan_for(moments, invalidated)
     _, action_item, result_item = plan[0]
-    assert action_item[0] == "classify"          # action label cleared -> reclassify
+    assert action_item[0] == "classify"  # action label cleared -> reclassify
     assert to_action == [{"key": action_item[1], "facets": ["a1", "b1"]}]
-    assert result_item == ("reuse", "pos")        # result untouched -> still reused
+    assert result_item == ("reuse", "pos")  # result untouched -> still reused
     assert to_result == []
 
 
@@ -252,7 +277,7 @@ def test_invalidate_agg_cache_result_reclassifies_result_reuses_action():
     _, action_item, result_item = plan[0]
     assert action_item == ("reuse", "scaffolding")  # action untouched -> still reused
     assert to_action == []
-    assert result_item[0] == "classify"             # result label cleared -> reclassify
+    assert result_item[0] == "classify"  # result label cleared -> reclassify
     assert to_result == [{"key": result_item[1], "facets": ["r1", "r2"]}]
 
 
@@ -271,6 +296,7 @@ def test_invalidate_agg_cache_does_not_mutate_input():
 
 # --- load_existing_action_result_agg -----------------------------------------
 
+
 def test_load_existing_action_result_agg_reconstructs_cache(tmp_path):
     gt_dir = tmp_path / "ground_truth"
     gt_dir.mkdir()
@@ -286,7 +312,9 @@ def test_load_existing_action_result_agg_reconstructs_cache(tmp_path):
     moments[1]["student_outcome_agg"] = "pos"
 
     (gt_dir / "conv1.json").write_text(
-        json.dumps({"conversation_id": "conv1", "num_turns": 100, "key_moments": moments}),
+        json.dumps(
+            {"conversation_id": "conv1", "num_turns": 100, "key_moments": moments}
+        ),
         encoding="utf-8",
     )
 
@@ -307,7 +335,9 @@ def test_load_existing_action_result_agg_skips_clusters_without_agg_labels(tmp_p
 
     moments = [_moment("t1", 1, 10, action_decomposed=["a1"], result_decomposed=["r1"])]
     (gt_dir / "conv1.json").write_text(
-        json.dumps({"conversation_id": "conv1", "num_turns": 10, "key_moments": moments}),
+        json.dumps(
+            {"conversation_id": "conv1", "num_turns": 10, "key_moments": moments}
+        ),
         encoding="utf-8",
     )
 

--- a/tests/tutorsim_build/test_ground_truth_decomp.py
+++ b/tests/tutorsim_build/test_ground_truth_decomp.py
@@ -22,13 +22,17 @@ def _full_cache():
 def test_invalidate_decomp_cache_action_clears_action_keeps_result():
     invalidated = _invalidate_decomp_cache(_full_cache(), "action")
     assert invalidated["conv1"]["action"] == {}
-    assert invalidated["conv1"]["result"] == {("t1", 1, 10, "scaffolding", "def"): ["r1"]}
+    assert invalidated["conv1"]["result"] == {
+        ("t1", 1, 10, "scaffolding", "def"): ["r1"]
+    }
 
 
 def test_invalidate_decomp_cache_result_clears_result_keeps_action():
     invalidated = _invalidate_decomp_cache(_full_cache(), "result")
     assert invalidated["conv1"]["result"] == {}
-    assert invalidated["conv1"]["action"] == {("t1", 1, 10, "scaffolding", "abc"): ["a1"]}
+    assert invalidated["conv1"]["action"] == {
+        ("t1", 1, 10, "scaffolding", "abc"): ["a1"]
+    }
 
 
 def test_invalidate_decomp_cache_both_wipes_entire_cache():

--- a/tests/tutorsim_build/test_ground_truth_overscaffold.py
+++ b/tests/tutorsim_build/test_ground_truth_overscaffold.py
@@ -8,8 +8,8 @@ action). These tests pin that down.
 """
 
 from tutorsim_build.groundtruth import (
-    overscaffold_decompose_key,
     action_decompose_key,
+    overscaffold_decompose_key,
 )
 
 
@@ -28,7 +28,9 @@ def _moment(**extra):
 
 
 def test_identical_moments_share_a_key():
-    assert overscaffold_decompose_key(_moment()) == overscaffold_decompose_key(_moment())
+    assert overscaffold_decompose_key(_moment()) == overscaffold_decompose_key(
+        _moment()
+    )
 
 
 def test_changing_result_changes_the_key():

--- a/tests/tutorsim_build/test_ground_truth_scaffolding_only.py
+++ b/tests/tutorsim_build/test_ground_truth_scaffolding_only.py
@@ -21,26 +21,32 @@ def _record(transcript_id, annotation_type, annotator_id, turn_start, turn_end):
         "transcript_id": transcript_id,
         "annotation_type": annotation_type,
         "annotator_id": annotator_id,
-        "turn_annotations": [{
-            "turn_number_start": turn_start,
-            "turn_number_end": turn_end,
-            "situation": "s",
-            "action": "a",
-            "result": "r",
-            "annotation_timestamp": "2026-01-01",
-        }],
+        "turn_annotations": [
+            {
+                "turn_number_start": turn_start,
+                "turn_number_end": turn_end,
+                "situation": "s",
+                "action": "a",
+                "result": "r",
+                "annotation_timestamp": "2026-01-01",
+            }
+        ],
     }
 
 
 # --- load_from_jsonl annotation-type filter --------------------------------
 
+
 def test_load_from_jsonl_default_keeps_scaffolding_and_rapport(tmp_path):
     path = tmp_path / "ann.jsonl"
-    _write_jsonl(path, [
-        _record("c1", "scaffolding", "t1", 1, 5),
-        _record("c1", "rapport", "t2", 2, 6),
-        _record("c1", "caption", "t3", 0, 0),
-    ])
+    _write_jsonl(
+        path,
+        [
+            _record("c1", "scaffolding", "t1", 1, 5),
+            _record("c1", "rapport", "t2", 2, 6),
+            _record("c1", "caption", "t3", 0, 0),
+        ],
+    )
     convs = dict(load_from_jsonl(str(path)))
     types = {a["annotation_type"] for a in convs["c1"]["annotations"]}
     assert types == {"scaffolding", "rapport"}
@@ -48,10 +54,13 @@ def test_load_from_jsonl_default_keeps_scaffolding_and_rapport(tmp_path):
 
 def test_load_from_jsonl_scaffolding_only_drops_rapport(tmp_path):
     path = tmp_path / "ann.jsonl"
-    _write_jsonl(path, [
-        _record("c1", "scaffolding", "t1", 1, 5),
-        _record("c1", "rapport", "t2", 2, 6),
-    ])
+    _write_jsonl(
+        path,
+        [
+            _record("c1", "scaffolding", "t1", 1, 5),
+            _record("c1", "rapport", "t2", 2, 6),
+        ],
+    )
     convs = dict(load_from_jsonl(str(path), annotation_types=("scaffolding",)))
     types = {a["annotation_type"] for a in convs["c1"]["annotations"]}
     assert types == {"scaffolding"}
@@ -59,10 +68,13 @@ def test_load_from_jsonl_scaffolding_only_drops_rapport(tmp_path):
 
 def test_load_from_jsonl_scaffolding_only_omits_rapport_only_conversation(tmp_path):
     path = tmp_path / "ann.jsonl"
-    _write_jsonl(path, [
-        _record("c_rapport_only", "rapport", "t1", 1, 5),
-        _record("c_scaf", "scaffolding", "t2", 1, 5),
-    ])
+    _write_jsonl(
+        path,
+        [
+            _record("c_rapport_only", "rapport", "t1", 1, 5),
+            _record("c_scaf", "scaffolding", "t2", 1, 5),
+        ],
+    )
     convs = dict(load_from_jsonl(str(path), annotation_types=("scaffolding",)))
     assert "c_rapport_only" not in convs
     assert "c_scaf" in convs
@@ -70,10 +82,16 @@ def test_load_from_jsonl_scaffolding_only_omits_rapport_only_conversation(tmp_pa
 
 # --- _merge_scaffolding_only -----------------------------------------------
 
+
 def test_merge_preserves_existing_rapport_moments():
     new_scaf = [{"annotation_type": "scaffolding", "turn_start": 1, "turn_end": 5}]
     existing = [
-        {"annotation_type": "scaffolding", "turn_start": 1, "turn_end": 5, "stale": True},
+        {
+            "annotation_type": "scaffolding",
+            "turn_start": 1,
+            "turn_end": 5,
+            "stale": True,
+        },
         {"annotation_type": "rapport", "turn_start": 2, "turn_end": 8},
     ]
     merged = _merge_scaffolding_only(new_scaf, existing)

--- a/tests/tutorsim_build/test_groundtruth_reproducibility.py
+++ b/tests/tutorsim_build/test_groundtruth_reproducibility.py
@@ -50,20 +50,31 @@ class _FakeClient:
         self.model = model
 
 
-def _record(transcript_id, annotation_type, annotator_id, ts, te,
-            situation, action, result, timestamp):
+def _record(
+    transcript_id,
+    annotation_type,
+    annotator_id,
+    ts,
+    te,
+    situation,
+    action,
+    result,
+    timestamp,
+):
     return {
         "transcript_id": transcript_id,
         "annotation_type": annotation_type,
         "annotator_id": annotator_id,
-        "turn_annotations": [{
-            "turn_number_start": ts,
-            "turn_number_end": te,
-            "situation": situation,
-            "action": action,
-            "result": result,
-            "annotation_timestamp": timestamp,
-        }],
+        "turn_annotations": [
+            {
+                "turn_number_start": ts,
+                "turn_number_end": te,
+                "situation": situation,
+                "action": action,
+                "result": result,
+                "annotation_timestamp": timestamp,
+            }
+        ],
     }
 
 
@@ -72,15 +83,39 @@ def annotations_path(tmp_path):
     # Two scaffolding annotators on the SAME turn range (-> one IoU==1.0 cluster,
     # exercising the agg path) plus a rapport moment.
     records = [
-        _record("conv-A", "scaffolding", "ann1", 5, 9,
-                "student is stuck on factoring", "tutor gave a leading hint",
-                "student factored the next term", "2026-01-01T00:00:00"),
-        _record("conv-A", "scaffolding", "ann2", 5, 9,
-                "student stuck on the same step", "tutor asked a probing question",
-                "student made progress", "2026-01-01T00:00:01"),
-        _record("conv-A", "rapport", "ann3", 2, 4,
-                "student seems frustrated", "tutor acknowledged the difficulty",
-                "student relaxed", "2026-01-01T00:00:02"),
+        _record(
+            "conv-A",
+            "scaffolding",
+            "ann1",
+            5,
+            9,
+            "student is stuck on factoring",
+            "tutor gave a leading hint",
+            "student factored the next term",
+            "2026-01-01T00:00:00",
+        ),
+        _record(
+            "conv-A",
+            "scaffolding",
+            "ann2",
+            5,
+            9,
+            "student stuck on the same step",
+            "tutor asked a probing question",
+            "student made progress",
+            "2026-01-01T00:00:01",
+        ),
+        _record(
+            "conv-A",
+            "rapport",
+            "ann3",
+            2,
+            4,
+            "student seems frustrated",
+            "tutor acknowledged the difficulty",
+            "student relaxed",
+            "2026-01-01T00:00:02",
+        ),
     ]
     path = tmp_path / "ann.jsonl"
     with open(path, "w", encoding="utf-8") as f:
@@ -90,16 +125,22 @@ def annotations_path(tmp_path):
 
 
 def _read_all(out_dir):
-    return {p.name: p.read_text(encoding="utf-8") for p in sorted(out_dir.glob("*.json"))}
+    return {
+        p.name: p.read_text(encoding="utf-8") for p in sorted(out_dir.glob("*.json"))
+    }
 
 
-def test_warm_rebuild_is_byte_identical_and_makes_zero_llm_calls(annotations_path, tmp_path, monkeypatch):
+def test_warm_rebuild_is_byte_identical_and_makes_zero_llm_calls(
+    annotations_path, tmp_path, monkeypatch
+):
     out_dir = tmp_path / "gt_out"
 
     # --- cold build: stub the API with canned outputs ---
     monkeypatch.setattr("tutorsim.client.run_batch", _fake_run_batch)
     monkeypatch.setattr("tutorsim.client.ModelClient", _FakeClient)
-    summary1 = groundtruth.build_ground_truth(input_path=annotations_path, out_dir=out_dir)
+    summary1 = groundtruth.build_ground_truth(
+        input_path=annotations_path, out_dir=out_dir
+    )
     assert summary1["gt_written"] == 1
     cold = _read_all(out_dir)
     assert set(cold) == {"conv-A.json"}
@@ -109,20 +150,34 @@ def test_warm_rebuild_is_byte_identical_and_makes_zero_llm_calls(annotations_pat
     scaf = [m for m in conv["key_moments"] if m["annotation_type"] == "scaffolding"]
     assert scaf, "expected scaffolding moments"
     for m in scaf:
-        for k in ("strategy_label", "situation_label", "situation_label_agg",
-                  "action_decomposed", "result_decomposed", "overscaffold_decomposed",
-                  "action_direction_agg", "student_outcome_agg"):
+        for k in (
+            "strategy_label",
+            "situation_label",
+            "situation_label_agg",
+            "action_decomposed",
+            "result_decomposed",
+            "overscaffold_decomposed",
+            "action_direction_agg",
+            "student_outcome_agg",
+        ):
             assert k in m, f"missing {k} on scaffolding moment"
 
     # --- warm rebuild: any cache miss would call run_batch, which now RAISES ---
     def _boom(*a, **k):
-        raise AssertionError("warm rebuild made an LLM call -- cache was not fully warm")
+        raise AssertionError(
+            "warm rebuild made an LLM call -- cache was not fully warm"
+        )
 
     monkeypatch.setattr("tutorsim.client.run_batch", _boom)
-    monkeypatch.setattr("tutorsim.client.ModelClient",
-                        lambda *a, **k: (_ for _ in ()).throw(
-                            AssertionError("warm rebuild constructed a ModelClient")))
-    summary2 = groundtruth.build_ground_truth(input_path=annotations_path, out_dir=out_dir)
+    monkeypatch.setattr(
+        "tutorsim.client.ModelClient",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("warm rebuild constructed a ModelClient")
+        ),
+    )
+    summary2 = groundtruth.build_ground_truth(
+        input_path=annotations_path, out_dir=out_dir
+    )
     warm = _read_all(out_dir)
 
     assert warm == cold, "warm rebuild was not byte-identical to the cold build"
@@ -134,33 +189,44 @@ def test_warm_rebuild_is_byte_identical_and_makes_zero_llm_calls(annotations_pat
     assert summary2["classify_result_agg"] == 0
 
 
-def test_dry_run_makes_zero_llm_calls_and_writes_nothing(annotations_path, tmp_path, monkeypatch):
+def test_dry_run_makes_zero_llm_calls_and_writes_nothing(
+    annotations_path, tmp_path, monkeypatch
+):
     out_dir = tmp_path / "gt_out"
 
     def _boom(*a, **k):
         raise AssertionError("dry run made an LLM call")
 
     monkeypatch.setattr("tutorsim.client.run_batch", _boom)
-    monkeypatch.setattr("tutorsim.client.ModelClient",
-                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("dry run built a client")))
-    summary = groundtruth.build_ground_truth(input_path=annotations_path, out_dir=out_dir, dry_run=True)
+    monkeypatch.setattr(
+        "tutorsim.client.ModelClient",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("dry run built a client")),
+    )
+    summary = groundtruth.build_ground_truth(
+        input_path=annotations_path, out_dir=out_dir, dry_run=True
+    )
 
     assert summary["dry_run"] is True
     assert summary["total_moments"] == 3  # 2 scaffolding + 1 rapport
     assert not out_dir.exists(), "dry run must not write any files"
 
 
-def test_consolidate_writes_jsonl_matching_per_conversation_files(annotations_path, tmp_path, monkeypatch):
+def test_consolidate_writes_jsonl_matching_per_conversation_files(
+    annotations_path, tmp_path, monkeypatch
+):
     out_dir = tmp_path / "gt_out"
     monkeypatch.setattr("tutorsim.client.run_batch", _fake_run_batch)
     monkeypatch.setattr("tutorsim.client.ModelClient", _FakeClient)
 
     summary = groundtruth.build_ground_truth(
-        input_path=annotations_path, out_dir=out_dir, consolidate=True)
+        input_path=annotations_path, out_dir=out_dir, consolidate=True
+    )
 
     jsonl_path = out_dir.parent / f"{out_dir.name}.jsonl"
     assert jsonl_path.exists()
-    lines = [l for l in jsonl_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+    lines = [
+        l for l in jsonl_path.read_text(encoding="utf-8").splitlines() if l.strip()
+    ]
     assert len(lines) == summary["consolidated_count"] == 1
     # The consolidated record equals the per-conversation file's content.
     per_conv = json.loads((out_dir / "conv-A.json").read_text(encoding="utf-8"))

--- a/tests/tutorsim_build/test_publish_ground_truth_s3.py
+++ b/tests/tutorsim_build/test_publish_ground_truth_s3.py
@@ -13,7 +13,11 @@ boto3 = pytest.importorskip("boto3")
 moto = pytest.importorskip("moto")
 from moto import mock_aws
 
-_SCRIPT = Path(__file__).resolve().parents[2] / "tutorsim_build" / "publish_ground_truth_s3.py"
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "tutorsim_build"
+    / "publish_ground_truth_s3.py"
+)
 
 
 def _load_module():

--- a/tests/tutorsim_build/test_schema_conformance.py
+++ b/tests/tutorsim_build/test_schema_conformance.py
@@ -22,7 +22,10 @@ LOCAL_RELEASE = REPO / "data/balanced_520_release"
 
 def _shipped_schema() -> dict:
     from importlib.resources import files
-    return json.loads((files("tutorsim_build") / "moments.schema.json").read_text(encoding="utf-8"))
+
+    return json.loads(
+        (files("tutorsim_build") / "moments.schema.json").read_text(encoding="utf-8")
+    )
 
 
 def _validate_records(jsonl_path: Path):
@@ -44,14 +47,28 @@ def _full_moment(mid="t:c__hum_1_2"):
         context=[{"turn_number": 1, "role": "tutor", "text": "Q"}],
         dimension="rigor",
         student={
-            "mode": "oracle", "reference": "", "context": "",
-            "trait": {"persona": "The student hedges.", "trait_mode": "joined-3",
-                      "generator_model": "claude-opus-4-6", "generated_at": "2026-06-18T00:00:00"},
+            "mode": "oracle",
+            "reference": "",
+            "context": "",
+            "trait": {
+                "persona": "The student hedges.",
+                "trait_mode": "joined-3",
+                "generator_model": "claude-opus-4-6",
+                "generated_at": "2026-06-18T00:00:00",
+            },
         },
         rubric={"gold": "rigor", "hint": ""},
-        provenance={"conv_id": "c", "cut_turn": 1, "turn_start": 1, "turn_end": 2,
-                    "moment_id": None, "annotator_id": "a-1", "chosen_cut_turn": 1,
-                    "cut_votes": {"1": 1}, "cluster_size": 1},
+        provenance={
+            "conv_id": "c",
+            "cut_turn": 1,
+            "turn_start": 1,
+            "turn_end": 2,
+            "moment_id": None,
+            "annotator_id": "a-1",
+            "chosen_cut_turn": 1,
+            "cut_votes": {"1": 1},
+            "cluster_size": 1,
+        },
     )
 
 
@@ -65,7 +82,11 @@ def test_write_release_refuses_nonconforming_record(tmp_path):
     """A record violating the schema (provenance missing required fields)
     cannot be released, independent of the trait check."""
     m = _full_moment()
-    m.provenance = {"conv_id": "c", "cut_turn": 1, "cut_votes": {}}  # missing 6 required fields
+    m.provenance = {
+        "conv_id": "c",
+        "cut_turn": 1,
+        "cut_votes": {},
+    }  # missing 6 required fields
     with pytest.raises(ValueError, match="schema"):
         write_release([m], tmp_path, set_name="t", created="2026-07-03")
 
@@ -75,8 +96,10 @@ def test_mini_release_fixture_conforms():
     _validate_records(MINI_RELEASE / "moments.jsonl")
 
 
-@pytest.mark.skipif(not (LOCAL_RELEASE / "moments.jsonl").exists(),
-                    reason="local balanced_520 release not present")
+@pytest.mark.skipif(
+    not (LOCAL_RELEASE / "moments.jsonl").exists(),
+    reason="local balanced_520 release not present",
+)
 def test_local_balanced_520_release_conforms():
     """The real release dir (when present locally) satisfies the shipped schema."""
     _validate_records(LOCAL_RELEASE / "moments.jsonl")

--- a/tests/tutorsim_build/test_traits.py
+++ b/tests/tutorsim_build/test_traits.py
@@ -5,7 +5,6 @@ in the release (schema v2): the runtime only consumes student.trait; new
 moments sets get their personas at build time via generate_traits_for_moments.
 """
 
-import pytest
 from unittest.mock import MagicMock
 
 from tutorsim.moments import Moment
@@ -41,8 +40,9 @@ def _fake_client():
 
 def test_generate_traits_attaches_full_trait_object():
     m = _moment()
-    n = generate_traits_for_moments([m], model_client=_fake_client(),
-                                    model_name="claude-opus-4-6")
+    n = generate_traits_for_moments(
+        [m], model_client=_fake_client(), model_name="claude-opus-4-6"
+    )
     assert n == 1
     trait = m.student["trait"]
     assert trait["persona"]  # non-empty, parsed from DESCRIPTION:
@@ -64,23 +64,30 @@ def test_generate_traits_prefix_is_turn_formatted_context():
 
 
 def test_generate_traits_skips_moments_with_existing_trait():
-    frozen = {"persona": "frozen", "trait_mode": "joined-3",
-              "generator_model": "claude-opus-4-6", "generated_at": "2026-06-18T00:00:00"}
+    frozen = {
+        "persona": "frozen",
+        "trait_mode": "joined-3",
+        "generator_model": "claude-opus-4-6",
+        "generated_at": "2026-06-18T00:00:00",
+    }
     client = _fake_client()
     m = _moment(trait=frozen)
     n = generate_traits_for_moments([m], model_client=client, model_name="x")
     assert n == 0
-    assert m.student["trait"] == frozen        # untouched
-    assert client.generate.call_count == 0     # no LLM calls
+    assert m.student["trait"] == frozen  # untouched
+    assert client.generate.call_count == 0  # no LLM calls
 
 
 def test_trait_generator_prompts_ship_in_build_package():
     """system/user templates + dimension descriptions live in tutorsim_build,
     not the runtime package."""
     from tutorsim_build.resources import resource_text
+
     assert resource_text("prompts/trait_generator/system.txt").strip()
     assert resource_text("prompts/trait_generator/user.txt").strip()
-    assert resource_text("prompts/trait_generator/dimensions/misconceptions.txt").strip()
+    assert resource_text(
+        "prompts/trait_generator/dimensions/misconceptions.txt"
+    ).strip()
 
 
 # ---------------------------------------------------------------------------
@@ -108,7 +115,7 @@ class TestGenerateTrait:
 
         client = _make_client("Some thinking\nDESCRIPTION: A diligent student.")
         # We don't need the description content; just confirm the call goes through.
-        result = generate_trait("Turn 1. TUTOR: Hi", mode="joined-3", model_client=client)
+        generate_trait("Turn 1. TUTOR: Hi", mode="joined-3", model_client=client)
 
         # All 5 generate calls happened (one per dimension).
         assert client.generate.call_count == 5
@@ -125,7 +132,9 @@ class TestGenerateTrait:
         client = MagicMock()
         client.generate = MagicMock(side_effect=responses)
 
-        result = generate_trait("Turn 1. TUTOR: Hi", mode="joined-3", model_client=client)
+        result = generate_trait(
+            "Turn 1. TUTOR: Hi", mode="joined-3", model_client=client
+        )
 
         # Result is the sorted+joined descriptions.
         assert isinstance(result, str)
@@ -158,7 +167,6 @@ class TestGenerateTrait:
         # Check every generate call uses the right defaults.
         for call in client.generate.call_args_list:
             kwargs = call.kwargs if call.kwargs else {}
-            args = call.args if call.args else ()
             # max_tokens must be 1024 (adapter default when None passed by TraitGenerator)
             assert kwargs.get("max_tokens", 1024) == 1024, f"max_tokens wrong: {kwargs}"
             # json_mode must be False
@@ -178,7 +186,9 @@ class TestGenerateTrait:
         """Text before 'DESCRIPTION:' (thinking) is stripped; only post-marker text is kept."""
         from tutorsim_build.traits import generate_trait
 
-        client = _make_client("  lots of thinking\n\nDESCRIPTION:   Parsed description.  ")
+        client = _make_client(
+            "  lots of thinking\n\nDESCRIPTION:   Parsed description.  "
+        )
         result = generate_trait("prefix", mode="joined-3", model_client=client)
 
         # All 5 dimension results will be "Parsed description." (same stub for each)
@@ -196,7 +206,9 @@ class TestGenerateTrait:
         for call in client.generate.call_args_list:
             kwargs = call.kwargs if call.kwargs else {}
             # cacheable_prefix must be set (the system prompt) and non-empty
-            assert "cacheable_prefix" in kwargs, "cacheable_prefix missing from generate call"
+            assert "cacheable_prefix" in kwargs, (
+                "cacheable_prefix missing from generate call"
+            )
             assert kwargs["cacheable_prefix"], "cacheable_prefix is empty/None"
 
     def test_user_prompt_contains_conversation_text(self):
@@ -209,4 +221,6 @@ class TestGenerateTrait:
 
         for call in client.generate.call_args_list:
             user_text = call.args[0] if call.args else call.kwargs.get("prompt", "")
-            assert prefix in user_text, f"Prefix missing from user text: {user_text[:200]}"
+            assert prefix in user_text, (
+                f"Prefix missing from user text: {user_text[:200]}"
+            )

--- a/tests/tutorsim_build/test_validate_ground_truth.py
+++ b/tests/tutorsim_build/test_validate_ground_truth.py
@@ -12,9 +12,12 @@ import pytest
 from tutorsim_build.groundtruth import validate_ground_truth
 
 SCAFFOLDING = {
-    "annotation_type": "scaffolding", "strategy_label": "scaffold",
-    "situation_label_agg": "scaffolding", "action_direction_agg": "toward",
-    "student_outcome_agg": "pos", "turn_start": 1,
+    "annotation_type": "scaffolding",
+    "strategy_label": "scaffold",
+    "situation_label_agg": "scaffolding",
+    "action_direction_agg": "toward",
+    "student_outcome_agg": "pos",
+    "turn_start": 1,
 }
 RAPPORT = {"annotation_type": "rapport", "strategy_label": "warm", "turn_start": 4}
 
@@ -25,7 +28,11 @@ def _gt(*moments):
 
 EVAL_KW = dict(
     all_moments=("strategy_label",),
-    scaffolding_only=("situation_label_agg", "action_direction_agg", "student_outcome_agg"),
+    scaffolding_only=(
+        "situation_label_agg",
+        "action_direction_agg",
+        "student_outcome_agg",
+    ),
 )
 
 

--- a/tutorsim_build/classify.py
+++ b/tutorsim_build/classify.py
@@ -28,7 +28,9 @@ JUNK_TEXTS = {"", "n/a", "test", "sdf", "this is a test annotation"}
 # Situation classification
 # ===========================================================================
 
-_SITUATION_PROMPT_RESOURCE = "prompts/classify/situation_labeller/classify_scaffolding.md"
+_SITUATION_PROMPT_RESOURCE = (
+    "prompts/classify/situation_labeller/classify_scaffolding.md"
+)
 
 VALID_SITUATION_LABELS = {"yes", "no", "unclear", "no_mention"}
 
@@ -40,6 +42,7 @@ def _parse_situation_label(text: str) -> tuple[dict, bool]:
     Tries json.loads first; falls back to regex extraction field-by-field.
     A list-wrapped response (e.g. [{...}]) is unwrapped automatically.
     """
+
     def _coerce(val: str) -> str:
         v = val.strip().lower()
         return v if v in VALID_SITUATION_LABELS else "unclear"
@@ -98,7 +101,10 @@ def load_labeller_templates(labeller_cfg: "str | dict") -> "dict[str | None, str
     {"scaffolding": "classify_scaffolding", ...}), returns one entry per type.
     """
     if isinstance(labeller_cfg, dict):
-        return {ann_type: load_labeller_prompt(name) for ann_type, name in labeller_cfg.items()}
+        return {
+            ann_type: load_labeller_prompt(name)
+            for ann_type, name in labeller_cfg.items()
+        }
     return {None: load_labeller_prompt(labeller_cfg)}
 
 

--- a/tutorsim_build/cli.py
+++ b/tutorsim_build/cli.py
@@ -41,48 +41,102 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Build a release dir (moments.jsonl + manifest) from ground truth",
         parents=[log_parent],
     )
-    build_p.add_argument("--set", required=True, metavar="NAME",
-                         help="Set name, e.g. balanced_520")
-    build_p.add_argument("--ids", required=True, metavar="FILE",
-                         help="Path to JSON list of moment ids")
-    build_p.add_argument("--ground-truth", required=True, dest="ground_truth",
-                         metavar="DIR", help="Ground truth directory")
-    build_p.add_argument("--transcripts", required=True, metavar="DIR",
-                         help="Transcripts directory")
-    build_p.add_argument("--tutoring-provider-a-jsonl", default=None,
-                         dest="tutoring_provider_a_jsonl", metavar="FILE",
-                         help="Normalized JSONL transcript file (optional)")
-    build_p.add_argument("--out", required=True, metavar="DIR",
-                         help="Release directory to write moments.jsonl + moments.manifest.json")
-    build_p.add_argument("--created", default="", metavar="DATE",
-                         help="ISO date string for manifest (default: empty)")
-    build_p.add_argument("--version", default="0", metavar="VERSION",
-                         help="Dataset version string for manifest (default: 0)")
+    build_p.add_argument(
+        "--set", required=True, metavar="NAME", help="Set name, e.g. balanced_520"
+    )
+    build_p.add_argument(
+        "--ids", required=True, metavar="FILE", help="Path to JSON list of moment ids"
+    )
+    build_p.add_argument(
+        "--ground-truth",
+        required=True,
+        dest="ground_truth",
+        metavar="DIR",
+        help="Ground truth directory",
+    )
+    build_p.add_argument(
+        "--transcripts", required=True, metavar="DIR", help="Transcripts directory"
+    )
+    build_p.add_argument(
+        "--tutoring-provider-a-jsonl",
+        default=None,
+        dest="tutoring_provider_a_jsonl",
+        metavar="FILE",
+        help="Normalized JSONL transcript file (optional)",
+    )
+    build_p.add_argument(
+        "--out",
+        required=True,
+        metavar="DIR",
+        help="Release directory to write moments.jsonl + moments.manifest.json",
+    )
+    build_p.add_argument(
+        "--created",
+        default="",
+        metavar="DATE",
+        help="ISO date string for manifest (default: empty)",
+    )
+    build_p.add_argument(
+        "--version",
+        default="0",
+        metavar="VERSION",
+        help="Dataset version string for manifest (default: 0)",
+    )
 
     # -- dataset build-from-run --------------------------------------------------
     bfr_p = dataset_subs.add_parser(
         "build-from-run",
         help="Rebuild the frozen moments set from a published benchmark run "
-             "(the canonical record of the benchmark-time detections)",
+        "(the canonical record of the benchmark-time detections)",
         parents=[log_parent],
     )
-    bfr_p.add_argument("--set", required=True, metavar="NAME",
-                       help="Set name, e.g. balanced_520")
-    bfr_p.add_argument("--reference-run", required=True, dest="reference_run",
-                       metavar="FILE", help="Published run JSONL (one row per replay)")
-    bfr_p.add_argument("--transcripts", default=None, metavar="DIR",
-                       help="Transcripts directory (optional if JSONL given)")
-    bfr_p.add_argument("--tutoring-provider-a-jsonl", default=None,
-                       dest="tutoring_provider_a_jsonl", metavar="FILE",
-                       help="Normalized JSONL transcript file (optional)")
-    bfr_p.add_argument("--ids", default=None, metavar="FILE",
-                       help="Optional canonical id list to cross-check coverage against")
-    bfr_p.add_argument("--out", required=True, metavar="DIR",
-                       help="Release directory to write moments.jsonl + moments.manifest.json")
-    bfr_p.add_argument("--created", default="", metavar="DATE",
-                       help="ISO date string for manifest (default: empty)")
-    bfr_p.add_argument("--version", default="0", metavar="VERSION",
-                       help="Dataset version string for manifest (default: 0)")
+    bfr_p.add_argument(
+        "--set", required=True, metavar="NAME", help="Set name, e.g. balanced_520"
+    )
+    bfr_p.add_argument(
+        "--reference-run",
+        required=True,
+        dest="reference_run",
+        metavar="FILE",
+        help="Published run JSONL (one row per replay)",
+    )
+    bfr_p.add_argument(
+        "--transcripts",
+        default=None,
+        metavar="DIR",
+        help="Transcripts directory (optional if JSONL given)",
+    )
+    bfr_p.add_argument(
+        "--tutoring-provider-a-jsonl",
+        default=None,
+        dest="tutoring_provider_a_jsonl",
+        metavar="FILE",
+        help="Normalized JSONL transcript file (optional)",
+    )
+    bfr_p.add_argument(
+        "--ids",
+        default=None,
+        metavar="FILE",
+        help="Optional canonical id list to cross-check coverage against",
+    )
+    bfr_p.add_argument(
+        "--out",
+        required=True,
+        metavar="DIR",
+        help="Release directory to write moments.jsonl + moments.manifest.json",
+    )
+    bfr_p.add_argument(
+        "--created",
+        default="",
+        metavar="DATE",
+        help="ISO date string for manifest (default: empty)",
+    )
+    bfr_p.add_argument(
+        "--version",
+        default="0",
+        metavar="VERSION",
+        help="Dataset version string for manifest (default: 0)",
+    )
 
     # -- dataset validate ------------------------------------------------------
     val_p = dataset_subs.add_parser(
@@ -90,8 +144,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Validate a release dir's moments.jsonl against its manifest",
         parents=[log_parent],
     )
-    val_p.add_argument("--data_path", required=True, dest="data_path", metavar="DIR",
-                       help="Release directory containing moments.jsonl + moments.manifest.json")
+    val_p.add_argument(
+        "--data_path",
+        required=True,
+        dest="data_path",
+        metavar="DIR",
+        help="Release directory containing moments.jsonl + moments.manifest.json",
+    )
 
     # -- dataset build-ground-truth ---------------------------------------------
     gt_p = dataset_subs.add_parser(
@@ -99,26 +158,66 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Build ground truth from raw human annotations (LLM batch pipeline)",
         parents=[log_parent],
     )
-    gt_p.add_argument("--input", default=None, metavar="FILE",
-                      help="Annotations JSONL (default: packaged release path)")
-    gt_p.add_argument("--out-dir", default=None, dest="out_dir", metavar="DIR",
-                      help="Output directory (default: data/ground_truth_<labeller>)")
-    gt_p.add_argument("--labeller", default="hybrid", metavar="NAME",
-                      help="Labeller template name (default: hybrid)")
-    gt_p.add_argument("--dry-run", action="store_true", dest="dry_run",
-                      help="Plan only; no LLM calls or writes")
-    gt_p.add_argument("--scaffolding-only", action="store_true", dest="scaffolding_only",
-                      help="Restrict to scaffolding records (merge-preserve rapport)")
-    gt_p.add_argument("--refresh-agg", nargs="?", const="both", default=None,
-                      choices=["action", "result", "both"], dest="refresh_agg",
-                      help="Reclassify action/result aggregations")
-    gt_p.add_argument("--refresh-decomp", nargs="?", const="both", default=None,
-                      choices=["action", "result", "both"], dest="refresh_decomp",
-                      help="Re-decompose action/result facets (cache keys on text, not prompt)")
-    gt_p.add_argument("--refresh-overscaffold", action="store_true", dest="refresh_overscaffold",
-                      help="Re-decompose over-scaffolding for all scaffolding moments")
-    gt_p.add_argument("--consolidate", action="store_true",
-                      help="Also write a consolidated <out-dir>.jsonl after building")
+    gt_p.add_argument(
+        "--input",
+        default=None,
+        metavar="FILE",
+        help="Annotations JSONL (default: packaged release path)",
+    )
+    gt_p.add_argument(
+        "--out-dir",
+        default=None,
+        dest="out_dir",
+        metavar="DIR",
+        help="Output directory (default: data/ground_truth_<labeller>)",
+    )
+    gt_p.add_argument(
+        "--labeller",
+        default="hybrid",
+        metavar="NAME",
+        help="Labeller template name (default: hybrid)",
+    )
+    gt_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Plan only; no LLM calls or writes",
+    )
+    gt_p.add_argument(
+        "--scaffolding-only",
+        action="store_true",
+        dest="scaffolding_only",
+        help="Restrict to scaffolding records (merge-preserve rapport)",
+    )
+    gt_p.add_argument(
+        "--refresh-agg",
+        nargs="?",
+        const="both",
+        default=None,
+        choices=["action", "result", "both"],
+        dest="refresh_agg",
+        help="Reclassify action/result aggregations",
+    )
+    gt_p.add_argument(
+        "--refresh-decomp",
+        nargs="?",
+        const="both",
+        default=None,
+        choices=["action", "result", "both"],
+        dest="refresh_decomp",
+        help="Re-decompose action/result facets (cache keys on text, not prompt)",
+    )
+    gt_p.add_argument(
+        "--refresh-overscaffold",
+        action="store_true",
+        dest="refresh_overscaffold",
+        help="Re-decompose over-scaffolding for all scaffolding moments",
+    )
+    gt_p.add_argument(
+        "--consolidate",
+        action="store_true",
+        help="Also write a consolidated <out-dir>.jsonl after building",
+    )
 
     return parser
 
@@ -128,13 +227,18 @@ def _cmd_build_ground_truth(args, command_line: str) -> None:
     from contextlib import nullcontext
 
     from tutorsim_build import groundtruth
+
     input_path = args.input or groundtruth.ANNOTATIONS_JSONL
     out_dir = args.out_dir or groundtruth.default_out_dir(args.labeller)
     # --dry-run promises no writes, so it gets no build.log either.
-    log_ctx = nullcontext() if args.dry_run else per_run_log_file(
-        os.path.join(str(out_dir), "build.log"),
-        current_thread_only=False,
-        header=command_line,
+    log_ctx = (
+        nullcontext()
+        if args.dry_run
+        else per_run_log_file(
+            os.path.join(str(out_dir), "build.log"),
+            current_thread_only=False,
+            header=command_line,
+        )
     )
     with log_ctx:
         groundtruth.build_ground_truth(
@@ -165,15 +269,25 @@ def main(argv=None) -> None:
     )
     logger.info("%s", command_line)
 
-    from tutorsim_build.moments_build import _cli_build, _cli_build_from_run, _cli_validate
+    from tutorsim_build.moments_build import (
+        _cli_build,
+        _cli_build_from_run,
+        _cli_validate,
+    )
 
     if args.dataset_command == "build":
-        with per_run_log_file(os.path.join(args.out, "build.log"),
-                              current_thread_only=False, header=command_line):
+        with per_run_log_file(
+            os.path.join(args.out, "build.log"),
+            current_thread_only=False,
+            header=command_line,
+        ):
             _cli_build(args)
     elif args.dataset_command == "build-from-run":
-        with per_run_log_file(os.path.join(args.out, "build.log"),
-                              current_thread_only=False, header=command_line):
+        with per_run_log_file(
+            os.path.join(args.out, "build.log"),
+            current_thread_only=False,
+            header=command_line,
+        ):
             _cli_build_from_run(args)
     elif args.dataset_command == "validate":
         _cli_validate(args)

--- a/tutorsim_build/groundtruth.py
+++ b/tutorsim_build/groundtruth.py
@@ -30,32 +30,49 @@ decompose/structure helpers are reused from tutorsim.client / tutorsim.scoring; 
 situation/effectiveness helpers from tutorsim_build.classify. Model/params come from the
 `groundtruth` config block (tutorsim.config.get_groundtruth_phase_config).
 """
+
 import hashlib
 import json
 from collections import Counter, defaultdict
 from pathlib import Path
 
-from tutorsim_build.classify import (
-    JUNK_TEXTS,
-    VALID_LABELS,
-    load_labeller_templates,
-    load_labeller_prompt,
-    load_situation_prompt,
-    pick_template,
-    _parse_situation_label,
+from tutorsim.config import get_groundtruth_phase_config, get_labeller_config
+from tutorsim.scoring import (
+    DEFAULT_RESULT_LABEL,
 )
 from tutorsim.scoring import (
     JUNK_TEXTS as DECOMPOSE_JUNK_TEXTS,
-    DEFAULT_RESULT_LABEL,
-    load_decompose_prompt as _load_decompose_prompt,
-    parse_decomposed as _parse_decomposed,
+)
+from tutorsim.scoring import (
     build_overscaffold_prompt as _build_overscaffold_prompt,
-    load_structure_prompt as _load_structure_prompt,
+)
+from tutorsim.scoring import (
     format_facet_list as _format_facet_list,
+)
+from tutorsim.scoring import (
+    load_decompose_prompt as _load_decompose_prompt,
+)
+from tutorsim.scoring import (
+    load_structure_prompt as _load_structure_prompt,
+)
+from tutorsim.scoring import (
     parse_action_label as _parse_action_label,
+)
+from tutorsim.scoring import (
+    parse_decomposed as _parse_decomposed,
+)
+from tutorsim.scoring import (
     parse_result_label as _parse_result_label,
 )
-from tutorsim.config import get_groundtruth_phase_config, get_labeller_config
+from tutorsim_build.classify import (
+    JUNK_TEXTS,
+    VALID_LABELS,
+    _parse_situation_label,
+    load_labeller_prompt,
+    load_labeller_templates,
+    load_situation_prompt,
+    pick_template,
+)
 
 # tutorsim_build/groundtruth.py -> tutorsim_build -> <repo root>
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -63,7 +80,9 @@ DATA_DIR = REPO_ROOT / "data"
 
 # Default annotations input: the published HuggingFace release artifact (gitignored;
 # downloaded locally / from the release). Override with build_ground_truth(input_path=...).
-ANNOTATIONS_JSONL = DATA_DIR / "huggingface-release-20260630" / "tutoring_provider_a_annotations.jsonl"
+ANNOTATIONS_JSONL = (
+    DATA_DIR / "huggingface-release-20260630" / "tutoring_provider_a_annotations.jsonl"
+)
 
 # situate and decompose shared the same junk-text set as classify; alias for clarity.
 SIT_JUNK_TEXTS = JUNK_TEXTS
@@ -127,7 +146,10 @@ def load_from_jsonl(path, annotation_types=("scaffolding", "rapport")):
             annotator_id = record.get("annotator_id", "")
             annotation_type = record["annotation_type"]
             for ta in record.get("turn_annotations", []):
-                if ta.get("turn_number_start") is None or ta.get("turn_number_end") is None:
+                if (
+                    ta.get("turn_number_start") is None
+                    or ta.get("turn_number_end") is None
+                ):
                     continue
                 entry = {
                     "annotator_id": annotator_id,
@@ -150,7 +172,9 @@ def load_from_jsonl(path, annotation_types=("scaffolding", "rapport")):
         annotations.sort(key=lambda a: a["_timestamp"])
         for a in annotations:
             del a["_timestamp"]
-        num_turns = max((a["turn_end"] for a in annotations if a["turn_end"] is not None), default=0)
+        num_turns = max(
+            (a["turn_end"] for a in annotations if a["turn_end"] is not None), default=0
+        )
         result.append((conv_id, {"annotations": annotations, "num_turns": num_turns}))
     return result
 
@@ -239,11 +263,13 @@ def overscaffold_decompose_key(m):
     The over-scaffold prompt reads situation + action + result, so the cache key
     hashes all three (joined) -- a change to any of them re-decomposes.
     """
-    blob = "\x1f".join([
-        m.get("situation", "") or "",
-        m.get("action", "") or "",
-        m.get("result", "") or "",
-    ])
+    blob = "\x1f".join(
+        [
+            m.get("situation", "") or "",
+            m.get("action", "") or "",
+            m.get("result", "") or "",
+        ]
+    )
     return (
         m.get("annotator_id", ""),
         m.get("turn_start"),
@@ -270,7 +296,8 @@ def load_existing_overscaffold_decompositions(gt_dir):
         cache = {
             overscaffold_decompose_key(m): m["overscaffold_decomposed"]
             for m in d.get("key_moments", [])
-            if m.get("annotation_type") == "scaffolding" and "overscaffold_decomposed" in m
+            if m.get("annotation_type") == "scaffolding"
+            and "overscaffold_decomposed" in m
         }
         if cache:
             existing[f.stem] = cache
@@ -320,11 +347,25 @@ def load_existing_action_result_agg(gt_dir):
         with open(f, "r", encoding="utf-8") as fp:
             d = json.load(fp)
         cache = {}
-        for cluster_indices, cluster_moments in _scaffolding_clusters(d.get("key_moments", [])):
-            agg_a = next((m["action_direction_agg"] for m in cluster_moments
-                          if "action_direction_agg" in m), None)
-            agg_r = next((m["student_outcome_agg"] for m in cluster_moments
-                          if "student_outcome_agg" in m), None)
+        for cluster_indices, cluster_moments in _scaffolding_clusters(
+            d.get("key_moments", [])
+        ):
+            agg_a = next(
+                (
+                    m["action_direction_agg"]
+                    for m in cluster_moments
+                    if "action_direction_agg" in m
+                ),
+                None,
+            )
+            agg_r = next(
+                (
+                    m["student_outcome_agg"]
+                    for m in cluster_moments
+                    if "student_outcome_agg" in m
+                ),
+                None,
+            )
             if agg_a is None and agg_r is None:
                 continue
             unified_action, unified_result = _unify_facets(cluster_moments)
@@ -381,10 +422,7 @@ def _invalidate_decomp_cache(cache, field):
     if field == "both":
         return {}
     clear = "action" if field == "action" else "result"
-    return {
-        conv_id: {**sub, clear: {}}
-        for conv_id, sub in cache.items()
-    }
+    return {conv_id: {**sub, clear: {}} for conv_id, sub in cache.items()}
 
 
 def decompose_batch(items):
@@ -399,7 +437,7 @@ def decompose_batch(items):
     """
     if not items:
         return {}
-    from tutorsim.client import ModelClient, run_batch, build_batch_entry
+    from tutorsim.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
     client = ModelClient(cfg["model"])
@@ -413,12 +451,17 @@ def decompose_batch(items):
     for it in items:
         if it["field"] == "overscaffold":
             prompt = _build_overscaffold_prompt(
-                it.get("situation", ""), it.get("action", ""), it.get("result", ""),
-                overscaffold_template)
+                it.get("situation", ""),
+                it.get("action", ""),
+                it.get("result", ""),
+                overscaffold_template,
+            )
             if prompt is None:  # both action and result are junk -- nothing to analyze
                 results[it["key"]] = []
                 continue
-            entries.append(build_batch_entry(key=it["key"], prompt_text=prompt, json_mode=True))
+            entries.append(
+                build_batch_entry(key=it["key"], prompt_text=prompt, json_mode=True)
+            )
             continue
         text = (it["text"] or "").strip()
         if text.lower() in DECOMPOSE_JUNK_TEXTS:
@@ -427,19 +470,25 @@ def decompose_batch(items):
         if it["field"] == "action":
             prompt = action_template.replace("{action}", text)
         else:
-            prompt = (result_template
-                      .replace("{situation}", it.get("situation", ""))
-                      .replace("{action}", it.get("action", ""))
-                      .replace("{result}", text))
-        entries.append(build_batch_entry(key=it["key"], prompt_text=prompt, json_mode=True))
+            prompt = (
+                result_template.replace("{situation}", it.get("situation", ""))
+                .replace("{action}", it.get("action", ""))
+                .replace("{result}", text)
+            )
+        entries.append(
+            build_batch_entry(key=it["key"], prompt_text=prompt, json_mode=True)
+        )
 
     if not entries:
         return results
 
-    print(f"  Submitting {len(entries)} decomposition requests to batch API "
-          f"(model={cfg['model']})...")
+    print(
+        f"  Submitting {len(entries)} decomposition requests to batch API "
+        f"(model={cfg['model']})..."
+    )
     raw = run_batch(
-        client, entries,
+        client,
+        entries,
         json_mode=True,
         display_name="decomposition",
         poll_interval=cfg.get("poll_interval", 60),
@@ -455,7 +504,9 @@ def decompose_batch(items):
             continue
         facets, had_error = _parse_decomposed(result["text"])
         if had_error:
-            print(f"  WARNING: could not parse decomposition for {key}: {result['text'][:100]!r}")
+            print(
+                f"  WARNING: could not parse decomposition for {key}: {result['text'][:100]!r}"
+            )
         results[key] = facets
 
     return results
@@ -472,23 +523,30 @@ def action_direction_classify_batch(items):
     """
     if not items:
         return {}
-    from tutorsim.client import ModelClient, run_batch, build_batch_entry
+    from tutorsim.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
     client = ModelClient(cfg["model"])
     template = _load_structure_prompt("classify_action.md")
 
     entries = [
-        build_batch_entry(key=it["key"],
-                          prompt_text=template.replace("{action_list}", _format_facet_list(it["facets"])),
-                          json_mode=True)
+        build_batch_entry(
+            key=it["key"],
+            prompt_text=template.replace(
+                "{action_list}", _format_facet_list(it["facets"])
+            ),
+            json_mode=True,
+        )
         for it in items
     ]
 
-    print(f"  Submitting {len(entries)} action direction classifications to batch API "
-          f"(model={cfg['model']})...")
+    print(
+        f"  Submitting {len(entries)} action direction classifications to batch API "
+        f"(model={cfg['model']})..."
+    )
     results = run_batch(
-        client, entries,
+        client,
+        entries,
         json_mode=True,
         display_name="action_direction_agg_classification",
         poll_interval=cfg.get("poll_interval", 60),
@@ -505,7 +563,9 @@ def action_direction_classify_batch(items):
             continue
         label, had_error = _parse_action_label(result["text"])
         if had_error:
-            print(f"  WARNING: could not parse action direction label for {key}: {result['text'][:100]!r}")
+            print(
+                f"  WARNING: could not parse action direction label for {key}: {result['text'][:100]!r}"
+            )
         labels[key] = label
 
     return labels
@@ -522,23 +582,30 @@ def student_outcome_classify_batch(items):
     """
     if not items:
         return {}
-    from tutorsim.client import ModelClient, run_batch, build_batch_entry
+    from tutorsim.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
     client = ModelClient(cfg["model"])
     template = _load_structure_prompt("classify_student_result.md")
 
     entries = [
-        build_batch_entry(key=it["key"],
-                          prompt_text=template.replace("{student_list}", _format_facet_list(it["facets"])),
-                          json_mode=False)
+        build_batch_entry(
+            key=it["key"],
+            prompt_text=template.replace(
+                "{student_list}", _format_facet_list(it["facets"])
+            ),
+            json_mode=False,
+        )
         for it in items
     ]
 
-    print(f"  Submitting {len(entries)} student outcome classifications to batch API "
-          f"(model={cfg['model']})...")
+    print(
+        f"  Submitting {len(entries)} student outcome classifications to batch API "
+        f"(model={cfg['model']})..."
+    )
     results = run_batch(
-        client, entries,
+        client,
+        entries,
         json_mode=False,
         display_name="student_outcome_agg_classification",
         poll_interval=cfg.get("poll_interval", 60),
@@ -555,7 +622,9 @@ def student_outcome_classify_batch(items):
             continue
         result_label, had_error = _parse_result_label(result["text"])
         if had_error:
-            print(f"  WARNING: could not parse student outcome label for {key}: {result['text'][:100]!r}")
+            print(
+                f"  WARNING: could not parse student outcome label for {key}: {result['text'][:100]!r}"
+            )
         labels[key] = result_label
 
     return labels
@@ -568,7 +637,7 @@ def situation_classify_batch(items):
     """
     if not items:
         return {}
-    from tutorsim.client import ModelClient, run_batch, build_batch_entry
+    from tutorsim.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
     client = ModelClient(cfg["model"])
@@ -582,15 +651,20 @@ def situation_classify_batch(items):
             labels[it["key"]] = {"scaffolding": "unclear", "rigor": "unclear"}
             continue
         prompt = prompt_template.replace("{situation}", situation)
-        entries.append(build_batch_entry(key=it["key"], prompt_text=prompt, json_mode=True))
+        entries.append(
+            build_batch_entry(key=it["key"], prompt_text=prompt, json_mode=True)
+        )
 
     if not entries:
         return labels
 
-    print(f"  Submitting {len(entries)} situation classifications to batch API "
-          f"(model={cfg['model']})...")
+    print(
+        f"  Submitting {len(entries)} situation classifications to batch API "
+        f"(model={cfg['model']})..."
+    )
     results = run_batch(
-        client, entries,
+        client,
+        entries,
         json_mode=True,
         display_name="situation_classification",
         poll_interval=cfg.get("poll_interval", 60),
@@ -606,7 +680,9 @@ def situation_classify_batch(items):
             continue
         sit_label, had_error = _parse_situation_label(result["text"])
         if had_error:
-            print(f"  WARNING: could not parse situation label for {key}: {result['text'][:100]!r}")
+            print(
+                f"  WARNING: could not parse situation label for {key}: {result['text'][:100]!r}"
+            )
         labels[key] = sit_label
 
     return labels
@@ -622,7 +698,7 @@ def classify_batch(items, labeller="hybrid"):
     """
     if not items:
         return {}
-    from tutorsim.client import ModelClient, run_batch, build_batch_entry
+    from tutorsim.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
     client = ModelClient(cfg["model"])
@@ -642,24 +718,30 @@ def classify_batch(items, labeller="hybrid"):
             continue
         annotation_type = it.get("annotation_type", "unknown")
         template = pick_template(templates, annotation_type)
-        prompt = (template
-                  .replace("{annotation_type}", annotation_type)
-                  .replace("{situation}", it.get("situation", ""))
-                  .replace("{action}", it.get("action", ""))
-                  .replace("{result_text}", text))
-        entries.append(build_batch_entry(
-            key=it["key"],
-            prompt_text=prompt,
-            json_mode=False,
-        ))
+        prompt = (
+            template.replace("{annotation_type}", annotation_type)
+            .replace("{situation}", it.get("situation", ""))
+            .replace("{action}", it.get("action", ""))
+            .replace("{result_text}", text)
+        )
+        entries.append(
+            build_batch_entry(
+                key=it["key"],
+                prompt_text=prompt,
+                json_mode=False,
+            )
+        )
 
     if not entries:
         return labels
 
-    print(f"  Submitting {len(entries)} classifications to Anthropic batch API "
-          f"(model={cfg['model']})...")
+    print(
+        f"  Submitting {len(entries)} classifications to Anthropic batch API "
+        f"(model={cfg['model']})..."
+    )
     results = run_batch(
-        client, entries,
+        client,
+        entries,
         json_mode=False,
         display_name="effectiveness_classification_refresh",
         poll_interval=cfg.get("poll_interval", 60),
@@ -732,7 +814,9 @@ def _scaffolding_clusters(moments, threshold=1.0):
     are indices into `moments` and cluster_moments are the corresponding dicts
     (in the same order).
     """
-    scaf_idxs = [i for i, m in enumerate(moments) if m.get("annotation_type") == "scaffolding"]
+    scaf_idxs = [
+        i for i, m in enumerate(moments) if m.get("annotation_type") == "scaffolding"
+    ]
     if not scaf_idxs:
         return []
     scaf_moments = [moments[i] for i in scaf_idxs]
@@ -777,9 +861,9 @@ def _majority_vote_tuple(tuples):
 
 _TUPLE_TO_AGG = {
     ("yes", "yes"): "both",
-    ("yes", "no"):  "scaffolding",
-    ("no",  "yes"): "rigor",
-    ("no",  "no"):  "neither",
+    ("yes", "no"): "scaffolding",
+    ("no", "yes"): "rigor",
+    ("no", "no"): "neither",
 }
 
 
@@ -818,7 +902,9 @@ def compute_situation_label_agg(moments):
     return result
 
 
-def plan_action_result_agg(conv_id, moments, cached_agg, to_action_direction, to_student_outcome):
+def plan_action_result_agg(
+    conv_id, moments, cached_agg, to_action_direction, to_student_outcome
+):
     """Plan action_direction_agg / student_outcome_agg for one conversation's clusters.
 
     For each cluster of overlapping scaffolding moments (IoU >= 1.0), unifies the
@@ -839,8 +925,11 @@ def plan_action_result_agg(conv_id, moments, cached_agg, to_action_direction, to
         cached_entry = cached_convo.get(sig)
         tag = "_".join(str(i) for i in cluster_indices)
 
-        if (cached_entry and cached_entry["action_direction_agg"] is not None
-                and cached_entry["unified_action"] == unified_action):
+        if (
+            cached_entry
+            and cached_entry["action_direction_agg"] is not None
+            and cached_entry["unified_action"] == unified_action
+        ):
             action_item = ("reuse", cached_entry["action_direction_agg"])
         elif unified_action:
             akey = f"{conv_id}__{tag}__action_agg"
@@ -849,8 +938,11 @@ def plan_action_result_agg(conv_id, moments, cached_agg, to_action_direction, to
         else:
             action_item = ("default", "unknown")
 
-        if (cached_entry and cached_entry["student_outcome_agg"] is not None
-                and cached_entry["unified_result"] == unified_result):
+        if (
+            cached_entry
+            and cached_entry["student_outcome_agg"] is not None
+            and cached_entry["unified_result"] == unified_result
+        ):
             result_item = ("reuse", cached_entry["student_outcome_agg"])
         elif unified_result:
             rkey = f"{conv_id}__{tag}__result_agg"
@@ -873,7 +965,9 @@ def _merge_scaffolding_only(new_moments, existing_moments):
     moment whose annotation_type is not "scaffolding" is carried through unchanged.
     Returns new_moments followed by the preserved moments.
     """
-    preserved = [m for m in existing_moments if m.get("annotation_type") != "scaffolding"]
+    preserved = [
+        m for m in existing_moments if m.get("annotation_type") != "scaffolding"
+    ]
     return list(new_moments) + preserved
 
 
@@ -895,9 +989,9 @@ def build_moment(ann, label):
     return moment
 
 
-def validate_ground_truth(ground_truth: dict, *,
-                          all_moments: tuple = (),
-                          scaffolding_only: tuple = ()) -> None:
+def validate_ground_truth(
+    ground_truth: dict, *, all_moments: tuple = (), scaffolding_only: tuple = ()
+) -> None:
     """Assert required keys exist on ground-truth moments; raise if any are absent.
 
     A missing key here means the ground-truth input is corrupt for this run.
@@ -952,9 +1046,18 @@ def _consolidate_to_jsonl(out_dir: Path, jsonl_path: Path) -> int:
     return n
 
 
-def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
-                       scaffolding_only=False, refresh_agg=None, refresh_decomp=None,
-                       refresh_overscaffold=False, consolidate=False):
+def build_ground_truth(
+    *,
+    input_path,
+    out_dir,
+    labeller="hybrid",
+    dry_run=False,
+    scaffolding_only=False,
+    refresh_agg=None,
+    refresh_decomp=None,
+    refresh_overscaffold=False,
+    consolidate=False,
+):
     """Build ground-truth JSON from raw human annotations.
 
     Reads annotations from `input_path`, reuses cached enrichment from any existing
@@ -971,11 +1074,15 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
     if not input_path.exists():
         raise FileNotFoundError(f"input file not found: {input_path}")
 
-    annotation_types = ("scaffolding",) if scaffolding_only else ("scaffolding", "rapport")
+    annotation_types = (
+        ("scaffolding",) if scaffolding_only else ("scaffolding", "rapport")
+    )
     print(f"Loading annotations from {input_path}...")
     if scaffolding_only:
-        print("--scaffolding-only: skipping rapport records; existing rapport moments "
-              "will be preserved on write")
+        print(
+            "--scaffolding-only: skipping rapport records; existing rapport moments "
+            "will be preserved on write"
+        )
     conversations = load_from_jsonl(input_path, annotation_types=annotation_types)
     print(f"Loaded {len(conversations)} conversations")
 
@@ -983,40 +1090,66 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
     print(f"Loaded existing strategy labels for {len(existing_labels)} conversations")
     existing_situation_labels = load_existing_situation_labels(out_dir)
     sit_cache_total = sum(len(v) for v in existing_situation_labels.values())
-    print(f"Loaded existing situation labels for {len(existing_situation_labels)} conversations ({sit_cache_total} moments)")
+    print(
+        f"Loaded existing situation labels for {len(existing_situation_labels)} conversations ({sit_cache_total} moments)"
+    )
     existing_decompositions = load_existing_decompositions(out_dir)
-    decomp_action_total = sum(len(v.get("action", {})) for v in existing_decompositions.values())
-    decomp_result_total = sum(len(v.get("result", {})) for v in existing_decompositions.values())
-    print(f"Loaded existing decompositions: {decomp_action_total} action, {decomp_result_total} result")
+    decomp_action_total = sum(
+        len(v.get("action", {})) for v in existing_decompositions.values()
+    )
+    decomp_result_total = sum(
+        len(v.get("result", {})) for v in existing_decompositions.values()
+    )
+    print(
+        f"Loaded existing decompositions: {decomp_action_total} action, {decomp_result_total} result"
+    )
     if refresh_decomp:
-        existing_decompositions = _invalidate_decomp_cache(existing_decompositions, refresh_decomp)
-        decomp_field_desc = {"both": "action and result", "action": "action only",
-                             "result": "result only"}[refresh_decomp]
+        existing_decompositions = _invalidate_decomp_cache(
+            existing_decompositions, refresh_decomp
+        )
+        decomp_field_desc = {
+            "both": "action and result",
+            "action": "action only",
+            "result": "result only",
+        }[refresh_decomp]
         print(f"--refresh-decomp={refresh_decomp}: re-decomposing {decomp_field_desc}")
     existing_overscaffold = load_existing_overscaffold_decompositions(out_dir)
     overscaffold_cache_total = sum(len(v) for v in existing_overscaffold.values())
-    print(f"Loaded existing over-scaffold decompositions for {len(existing_overscaffold)} conversations ({overscaffold_cache_total} moments)")
+    print(
+        f"Loaded existing over-scaffold decompositions for {len(existing_overscaffold)} conversations ({overscaffold_cache_total} moments)"
+    )
     if refresh_overscaffold:
         existing_overscaffold = {}
-        print("--refresh-overscaffold: re-decomposing over-scaffolding for all scaffolding moments")
+        print(
+            "--refresh-overscaffold: re-decomposing over-scaffolding for all scaffolding moments"
+        )
     existing_action_result_agg = load_existing_action_result_agg(out_dir)
     if refresh_agg:
-        existing_action_result_agg = _invalidate_agg_cache(existing_action_result_agg, refresh_agg)
-        field_desc = {"both": "action and result", "action": "action only",
-                      "result": "result only"}[refresh_agg]
-        print(f"--refresh-agg={refresh_agg}: reclassifying {field_desc} "
-              f"aggregation(s) for scaffolding clusters")
+        existing_action_result_agg = _invalidate_agg_cache(
+            existing_action_result_agg, refresh_agg
+        )
+        field_desc = {
+            "both": "action and result",
+            "action": "action only",
+            "result": "result only",
+        }[refresh_agg]
+        print(
+            f"--refresh-agg={refresh_agg}: reclassifying {field_desc} "
+            f"aggregation(s) for scaffolding clusters"
+        )
     else:
         agg_cache_total = sum(len(v) for v in existing_action_result_agg.values())
-        print(f"Loaded existing action/result aggregations for {len(existing_action_result_agg)} conversations ({agg_cache_total} clusters)")
+        print(
+            f"Loaded existing action/result aggregations for {len(existing_action_result_agg)} conversations ({agg_cache_total} clusters)"
+        )
 
     # First pass: build per-conv plan (reuse vs classify) for both strategy and situation labels
     conv_plans = []
-    to_classify = []           # [{key, annotation_type, situation, action, result_text}]
+    to_classify = []  # [{key, annotation_type, situation, action, result_text}]
     to_situation_classify = []  # [{key, situation}] -- scaffolding moments only
-    to_decompose = []          # [{key, field, text}]
-    situation_plans = {}       # {conv_id: [s_item, ...]} parallel to plan
-    decompose_plans = {}       # {conv_id: [(action_item, result_item, overscaffold_item), ...]}
+    to_decompose = []  # [{key, field, text}]
+    situation_plans = {}  # {conv_id: [s_item, ...]} parallel to plan
+    decompose_plans = {}  # {conv_id: [(action_item, result_item, overscaffold_item), ...]}
     skipped_dup_count = 0
 
     for conv_id, conv_data in conversations:
@@ -1047,13 +1180,15 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
                 plan.append(("reuse", ann, known[k]))
             else:
                 ckey = f"{conv_id}__{idx}"
-                to_classify.append({
-                    "key": ckey,
-                    "annotation_type": ann.get("annotation_type", "unknown"),
-                    "situation": ann.get("situation", ""),
-                    "action": ann.get("action", ""),
-                    "result_text": ann.get("result", ""),
-                })
+                to_classify.append(
+                    {
+                        "key": ckey,
+                        "annotation_type": ann.get("annotation_type", "unknown"),
+                        "situation": ann.get("situation", ""),
+                        "action": ann.get("action", ""),
+                        "result_text": ann.get("result", ""),
+                    }
+                )
                 plan.append(("classify", ann, ckey))
 
             if ann.get("annotation_type") == "scaffolding":
@@ -1062,7 +1197,9 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
                     s_plan.append(("reuse", known_s[sk]))
                 else:
                     skey = f"{conv_id}__{idx}__sit"
-                    to_situation_classify.append({"key": skey, "situation": ann.get("situation", "")})
+                    to_situation_classify.append(
+                        {"key": skey, "situation": ann.get("situation", "")}
+                    )
                     s_plan.append(("classify", skey))
             else:
                 s_plan.append(None)
@@ -1072,7 +1209,9 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
                 action_item = ("reuse", known_action_decomp[ak])
             else:
                 dkey = f"{conv_id}__{idx}__action"
-                to_decompose.append({"key": dkey, "field": "action", "text": ann.get("action", "")})
+                to_decompose.append(
+                    {"key": dkey, "field": "action", "text": ann.get("action", "")}
+                )
                 action_item = ("classify", dkey)
 
             rk = result_decompose_key(ann)
@@ -1080,8 +1219,15 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
                 result_item = ("reuse", known_result_decomp[rk])
             else:
                 dkey = f"{conv_id}__{idx}__result"
-                to_decompose.append({"key": dkey, "field": "result", "text": ann.get("result", ""),
-                                     "situation": ann.get("situation", ""), "action": ann.get("action", "")})
+                to_decompose.append(
+                    {
+                        "key": dkey,
+                        "field": "result",
+                        "text": ann.get("result", ""),
+                        "situation": ann.get("situation", ""),
+                        "action": ann.get("action", ""),
+                    }
+                )
                 result_item = ("classify", dkey)
 
             # Over-scaffolding decomposition: scaffolding moments only.
@@ -1091,10 +1237,15 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
                     overscaffold_item = ("reuse", known_overscaffold_decomp[ok])
                 else:
                     okey = f"{conv_id}__{idx}__overscaffold"
-                    to_decompose.append({"key": okey, "field": "overscaffold",
-                                         "situation": ann.get("situation", ""),
-                                         "action": ann.get("action", ""),
-                                         "result": ann.get("result", "")})
+                    to_decompose.append(
+                        {
+                            "key": okey,
+                            "field": "overscaffold",
+                            "situation": ann.get("situation", ""),
+                            "action": ann.get("action", ""),
+                            "result": ann.get("result", ""),
+                        }
+                    )
                     overscaffold_item = ("classify", okey)
             else:
                 overscaffold_item = None
@@ -1109,11 +1260,24 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
     reused = sum(1 for _, _, p in conv_plans for kind, *_ in p if kind == "reuse")
     to_class = total_moments - reused
     new_convs = sum(1 for cid, _, _ in conv_plans if cid not in existing_labels)
-    sit_reused = sum(1 for sp in situation_plans.values() for item in sp if item and item[0] == "reuse")
-    decomp_action_reused = sum(1 for dp in decompose_plans.values() for a, _, _ in dp if a[0] == "reuse")
-    decomp_result_reused = sum(1 for dp in decompose_plans.values() for _, r, _ in dp if r[0] == "reuse")
+    sit_reused = sum(
+        1
+        for sp in situation_plans.values()
+        for item in sp
+        if item and item[0] == "reuse"
+    )
+    decomp_action_reused = sum(
+        1 for dp in decompose_plans.values() for a, _, _ in dp if a[0] == "reuse"
+    )
+    decomp_result_reused = sum(
+        1 for dp in decompose_plans.values() for _, r, _ in dp if r[0] == "reuse"
+    )
     decomp_overscaffold_reused = sum(
-        1 for dp in decompose_plans.values() for _, _, o in dp if o is not None and o[0] == "reuse")
+        1
+        for dp in decompose_plans.values()
+        for _, _, o in dp
+        if o is not None and o[0] == "reuse"
+    )
     new_overscaffold = sum(1 for it in to_decompose if it["field"] == "overscaffold")
 
     print(f"Plan: {len(conv_plans)} conversations, {total_moments} moments")
@@ -1125,8 +1289,10 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
     print(f"  Reuse existing action decomps:    {decomp_action_reused}")
     print(f"  Reuse existing result decomps:    {decomp_result_reused}")
     print(f"  Reuse existing overscaffold decomps: {decomp_overscaffold_reused}")
-    print(f"  New decompositions (action+result+overscaffold): {len(to_decompose)} "
-          f"({new_overscaffold} overscaffold)")
+    print(
+        f"  New decompositions (action+result+overscaffold): {len(to_decompose)} "
+        f"({new_overscaffold} overscaffold)"
+    )
     print(f"  Brand new conversations:          {new_convs}")
 
     summary = {
@@ -1161,7 +1327,9 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
             return None
         if s_item[0] == "reuse":
             return s_item[1]
-        return new_situation_labels.get(s_item[1], {"scaffolding": "unclear", "rigor": "unclear"})
+        return new_situation_labels.get(
+            s_item[1], {"scaffolding": "unclear", "rigor": "unclear"}
+        )
 
     # Third pass: build moments (everything except action_direction_agg / student_outcome_agg)
     conv_moments = {}  # {conv_id: (conv_data, moments)}
@@ -1169,23 +1337,30 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
         s_plan = situation_plans[conv_id]
         d_plan = decompose_plans[conv_id]
         moments = []
-        for (kind, ann, val), s_item, (action_item, result_item, overscaffold_item) in zip(plan, s_plan, d_plan):
+        for (kind, ann, val), s_item, (
+            action_item,
+            result_item,
+            overscaffold_item,
+        ) in zip(plan, s_plan, d_plan):
             label = val if kind == "reuse" else new_labels.get(val, "unclear")
             moment = build_moment(ann, label)
             sit = _resolve_situation(s_item)
             if sit is not None:
                 moment["situation_label"] = sit
             moment["action_decomposed"] = (
-                action_item[1] if action_item[0] == "reuse"
+                action_item[1]
+                if action_item[0] == "reuse"
                 else new_decompositions.get(action_item[1], [])
             )
             moment["result_decomposed"] = (
-                result_item[1] if result_item[0] == "reuse"
+                result_item[1]
+                if result_item[0] == "reuse"
                 else new_decompositions.get(result_item[1], [])
             )
             if overscaffold_item is not None:  # scaffolding moments only
                 moment["overscaffold_decomposed"] = (
-                    overscaffold_item[1] if overscaffold_item[0] == "reuse"
+                    overscaffold_item[1]
+                    if overscaffold_item[0] == "reuse"
                     else new_decompositions.get(overscaffold_item[1], [])
                 )
             moments.append(moment)
@@ -1196,10 +1371,15 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
 
     # Fourth pass: plan action_direction_agg / student_outcome_agg per scaffolding cluster
     to_action_direction = []  # [{key, facets}]
-    to_student_outcome = []   # [{key, facets}]
+    to_student_outcome = []  # [{key, facets}]
     agg_plans = {
-        conv_id: plan_action_result_agg(conv_id, moments, existing_action_result_agg,
-                                         to_action_direction, to_student_outcome)
+        conv_id: plan_action_result_agg(
+            conv_id,
+            moments,
+            existing_action_result_agg,
+            to_action_direction,
+            to_student_outcome,
+        )
         for conv_id, (_, moments) in conv_moments.items()
     }
     n_clusters = sum(len(ap) for ap in agg_plans.values())
@@ -1212,20 +1392,24 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
     print(f"  Reuse cached student outcome labels:    {result_kinds['reuse']}")
     print(f"  Default student outcome (no facets):    {result_kinds['default']}")
     print(f"  Classify new student outcome labels:    {result_kinds['classify']}")
-    summary.update({
-        "scaffolding_clusters": n_clusters,
-        "reuse_action_agg": action_kinds["reuse"],
-        "default_action_agg": action_kinds["default"],
-        "classify_action_agg": action_kinds["classify"],
-        "reuse_result_agg": result_kinds["reuse"],
-        "default_result_agg": result_kinds["default"],
-        "classify_result_agg": result_kinds["classify"],
-    })
+    summary.update(
+        {
+            "scaffolding_clusters": n_clusters,
+            "reuse_action_agg": action_kinds["reuse"],
+            "default_action_agg": action_kinds["default"],
+            "classify_action_agg": action_kinds["classify"],
+            "reuse_result_agg": result_kinds["reuse"],
+            "default_result_agg": result_kinds["default"],
+            "classify_result_agg": result_kinds["classify"],
+        }
+    )
     pending_ar = sum(1 for it in to_decompose if it["field"] in ("action", "result"))
     if dry_run and pending_ar:
-        print(f"  NOTE: {pending_ar} action/result decompositions are pending -- "
-              f"clusters touching them used placeholder (empty) facets above, so their "
-              f"reuse/classify counts are estimates and may change once decomposition runs")
+        print(
+            f"  NOTE: {pending_ar} action/result decompositions are pending -- "
+            f"clusters touching them used placeholder (empty) facets above, so their "
+            f"reuse/classify counts are estimates and may change once decomposition runs"
+        )
 
     if dry_run:
         print("\nDry run -- exiting without classifying or writing.")
@@ -1239,10 +1423,18 @@ def build_ground_truth(*, input_path, out_dir, labeller="hybrid", dry_run=False,
     gt_written = 0
     for conv_id, (conv_data, moments) in conv_moments.items():
         for cluster_indices, action_item, result_item in agg_plans[conv_id]:
-            action_label = (action_item[1] if action_item[0] != "classify"
-                            else new_action_direction_labels.get(action_item[1], "neither"))
-            result_label = (result_item[1] if result_item[0] != "classify"
-                            else new_student_outcome_labels.get(result_item[1], DEFAULT_RESULT_LABEL))
+            action_label = (
+                action_item[1]
+                if action_item[0] != "classify"
+                else new_action_direction_labels.get(action_item[1], "neither")
+            )
+            result_label = (
+                result_item[1]
+                if result_item[0] != "classify"
+                else new_student_outcome_labels.get(
+                    result_item[1], DEFAULT_RESULT_LABEL
+                )
+            )
             for idx in cluster_indices:
                 moments[idx]["action_direction_agg"] = action_label
                 moments[idx]["student_outcome_agg"] = result_label

--- a/tutorsim_build/moments_build.py
+++ b/tutorsim_build/moments_build.py
@@ -50,6 +50,7 @@ _CONV_ID_PREFIX_RE = re.compile(r"^\d{4}-t\d+_\d{4}-s\d+_")
 # Read from explicit directories; no S3.
 # ---------------------------------------------------------------------------
 
+
 def _conv_id_to_uuid(conv_id: str) -> str:
     """Extract the transcript-UUID component from a full conv_id.
 
@@ -96,6 +97,7 @@ def _load_transcripts(transcripts_dir: str) -> dict[str, dict]:
 # ---------------------------------------------------------------------------
 # JSONL transcript loader
 # ---------------------------------------------------------------------------
+
 
 def _transform_normalized_record(rec: dict) -> dict:
     """Transform an S3 normalized JSONL record to internal transcript format.
@@ -160,15 +162,17 @@ def _transform_normalized_record(rec: dict) -> dict:
         for e_entry in enrichments_by_turn.get(turn_num, []):
             final_turns.append({**e_entry, "turn_number": turn_num})
         ss = float(t.get("start_seconds", 0) or 0)
-        final_turns.append({
-            "turn_number": turn_num,
-            "role": t["role"].upper(),
-            "text": t["text"],
-            "type": "DIALOGUE",
-            "timestamp": f"{ss}s",
-            "start_seconds": ss,
-            "is_enrichment": False,
-        })
+        final_turns.append(
+            {
+                "turn_number": turn_num,
+                "role": t["role"].upper(),
+                "text": t["text"],
+                "type": "DIALOGUE",
+                "timestamp": f"{ss}s",
+                "start_seconds": ss,
+                "is_enrichment": False,
+            }
+        )
     for e_entry in trailing_enrichments:
         final_turns.append({**e_entry, "turn_number": max_dialogue_turn})
 
@@ -220,13 +224,16 @@ def _load_jsonl_index(path: str) -> dict[str, dict]:
             except Exception:
                 errors += 1
 
-    logger.info("Indexed %d transcripts from %s (%d parse errors)", len(index), path, errors)
+    logger.info(
+        "Indexed %d transcripts from %s (%d parse errors)", len(index), path, errors
+    )
     return index
 
 
 # ---------------------------------------------------------------------------
 # Cut/extraction helpers
 # ---------------------------------------------------------------------------
+
 
 def _pick_modal_cut(votes: list[int]) -> "int | None":
     """Return the most-voted cut. On tie, return the smallest.
@@ -269,7 +276,7 @@ def _pick_representative_member(members: list[dict], chosen_cut: int) -> dict:
     """
     matching = [m for m in members if m.get("cut_turn") == chosen_cut]
     pool = matching if matching else members
-    return min(pool, key=lambda m: (m.get("annotator_id") or ""))
+    return min(pool, key=lambda m: m.get("annotator_id") or "")
 
 
 def _resolve_cluster(
@@ -350,17 +357,20 @@ def _prefix_turns_to_context(conversation: dict, cut_turn: int) -> list[dict]:
     for turn in conversation["turns"]:
         if turn["turn_number"] > cut_turn:
             break
-        result.append({
-            "turn_number": turn["turn_number"],
-            "role": turn["role"].lower(),
-            "text": turn["text"],
-        })
+        result.append(
+            {
+                "turn_number": turn["turn_number"],
+                "role": turn["role"].lower(),
+                "text": turn["text"],
+            }
+        )
     return result
 
 
 # ---------------------------------------------------------------------------
 # Public API: build_moments
 # ---------------------------------------------------------------------------
+
 
 def build_moments(
     *,
@@ -513,6 +523,7 @@ def build_moments(
 # Public API: build_moments_from_reference_run
 # ---------------------------------------------------------------------------
 
+
 def build_moments_from_reference_run(
     *,
     set_name: str,
@@ -585,43 +596,46 @@ def build_moments_from_reference_run(
             )
 
         dimension = det["situation_label_agg"]
-        moments.append(Moment(
-            id=f"{set_name}:{scenario_id}",
-            context=context_turns,
-            dimension=dimension,
-            student={
-                "mode": "oracle",
-                "reference": _build_reference_transcript(conversation, cut_turn),
-                "context": _get_student_context(conversation),
-                "trait": {
-                    "persona": trait["persona"],
-                    "trait_mode": trait.get("trait_mode", "joined-3"),
-                    "generator_model": trait.get("generator_model", ""),
-                    "generated_at": trait.get("generated_at", ""),
+        moments.append(
+            Moment(
+                id=f"{set_name}:{scenario_id}",
+                context=context_turns,
+                dimension=dimension,
+                student={
+                    "mode": "oracle",
+                    "reference": _build_reference_transcript(conversation, cut_turn),
+                    "context": _get_student_context(conversation),
+                    "trait": {
+                        "persona": trait["persona"],
+                        "trait_mode": trait.get("trait_mode", "joined-3"),
+                        "generator_model": trait.get("generator_model", ""),
+                        "generated_at": trait.get("generated_at", ""),
+                    },
                 },
-            },
-            rubric={
-                "gold": dimension,
-                "hint": det.get("situation", ""),
-            },
-            provenance={
-                "conv_id": conv_id,
-                "cut_turn": cut_turn,
-                "turn_start": det["turn_start"],
-                "turn_end": det["turn_end"],
-                "moment_id": det.get("moment_id"),
-                "annotator_id": det.get("annotator_id"),
-                "chosen_cut_turn": det.get("chosen_cut_turn"),
-                "cut_votes": det.get("cut_votes") or {},
-                "cluster_size": det.get("cluster_size"),
-            },
-        ))
+                rubric={
+                    "gold": dimension,
+                    "hint": det.get("situation", ""),
+                },
+                provenance={
+                    "conv_id": conv_id,
+                    "cut_turn": cut_turn,
+                    "turn_start": det["turn_start"],
+                    "turn_end": det["turn_end"],
+                    "moment_id": det.get("moment_id"),
+                    "annotator_id": det.get("annotator_id"),
+                    "chosen_cut_turn": det.get("chosen_cut_turn"),
+                    "cut_votes": det.get("cut_votes") or {},
+                    "cluster_size": det.get("cluster_size"),
+                },
+            )
+        )
     return moments
 
 
 # ---------------------------------------------------------------------------
 # Release serialization
 # ---------------------------------------------------------------------------
+
 
 def _moment_to_release_dict(moment: Moment) -> dict:
     """Convert a Moment to the released (Arrow-friendly) record form.
@@ -648,8 +662,9 @@ def validate_records_against_schema(records: "list[dict]") -> None:
     (e.g. annotator_id's uuid) are annotations, not assertions — standard
     jsonschema semantics.
     """
-    import jsonschema
     from importlib.resources import files
+
+    import jsonschema
 
     schema = json.loads(
         (files("tutorsim_build") / SCHEMA_FILENAME).read_text(encoding="utf-8")
@@ -685,7 +700,9 @@ def write_release(
     from importlib.resources import files
 
     # Release contract: every moment carries the frozen student persona.
-    traitless = [m.id for m in moments if not (m.student.get("trait") or {}).get("persona")]
+    traitless = [
+        m.id for m in moments if not (m.student.get("trait") or {}).get("persona")
+    ]
     if traitless:
         raise ValueError(
             f"{len(traitless)} moment(s) have no student.trait persona "
@@ -725,7 +742,9 @@ def write_release(
         json.dump(manifest, f, indent=2, ensure_ascii=False)
 
     # Ship the record schema alongside the data (authoritative shape doc).
-    schema_text = (files("tutorsim_build") / SCHEMA_FILENAME).read_text(encoding="utf-8")
+    schema_text = (files("tutorsim_build") / SCHEMA_FILENAME).read_text(
+        encoding="utf-8"
+    )
     (out_dir / SCHEMA_FILENAME).write_text(schema_text, encoding="utf-8")
 
     return manifest
@@ -734,6 +753,7 @@ def write_release(
 # ---------------------------------------------------------------------------
 # CLI entry points (dispatched from tutorsim_build.cli)
 # ---------------------------------------------------------------------------
+
 
 def _cli_build(args: argparse.Namespace) -> None:
     """Build a release directory: <out>/{moments.jsonl, moments.manifest.json, moments.schema.json}."""
@@ -778,7 +798,9 @@ def _cli_build(args: argparse.Namespace) -> None:
             "source_tags": ["human_annotated", "hybrid_ground_truth"],
         },
     )
-    print(f"Wrote {manifest['record_count']} moments to {Path(args.out) / MOMENTS_FILENAME}")
+    print(
+        f"Wrote {manifest['record_count']} moments to {Path(args.out) / MOMENTS_FILENAME}"
+    )
     print(f"Wrote manifest to {Path(args.out) / MANIFEST_FILENAME}")
     print(f"  content_hash: {manifest['content_hash']}")
 
@@ -826,7 +848,9 @@ def _cli_build_from_run(args: argparse.Namespace) -> None:
             "source_tags": ["human_annotated", "reference_run"],
         },
     )
-    print(f"Wrote {manifest['record_count']} moments to {Path(args.out) / MOMENTS_FILENAME}")
+    print(
+        f"Wrote {manifest['record_count']} moments to {Path(args.out) / MOMENTS_FILENAME}"
+    )
     print(f"Wrote manifest to {Path(args.out) / MANIFEST_FILENAME}")
     print(f"  content_hash: {manifest['content_hash']}")
 

--- a/tutorsim_build/publish_ground_truth_s3.py
+++ b/tutorsim_build/publish_ground_truth_s3.py
@@ -15,6 +15,7 @@ Env fallbacks (CLI args take precedence):
     GROUND_TRUTH_S3_BUCKET   -- default bucket when --bucket is omitted
     GROUND_TRUTH_S3_PREFIX   -- default key prefix when --prefix is omitted
 """
+
 import argparse
 import os
 import sys
@@ -52,13 +53,20 @@ def publish(file_path, *, bucket, prefix):
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("file", help="Path to the ground-truth file to upload")
-    parser.add_argument("--bucket", default=None,
-                        help="Target S3 bucket (or set GROUND_TRUTH_S3_BUCKET)")
-    parser.add_argument("--prefix", default=None,
-                        help="Key prefix (or set GROUND_TRUTH_S3_PREFIX; default none)")
+    parser.add_argument(
+        "--bucket",
+        default=None,
+        help="Target S3 bucket (or set GROUND_TRUTH_S3_BUCKET)",
+    )
+    parser.add_argument(
+        "--prefix",
+        default=None,
+        help="Key prefix (or set GROUND_TRUTH_S3_PREFIX; default none)",
+    )
     args = parser.parse_args(argv)
 
     bucket = resolve_bucket(args.bucket)

--- a/tutorsim_build/traits.py
+++ b/tutorsim_build/traits.py
@@ -9,6 +9,7 @@ Public API:
     generate_trait(transcript_prefix, mode, *, model_client, ...) -> str
     generate_traits_for_moments(moments, *, model_client, model_name) -> int
 """
+
 import datetime
 import logging
 from typing import Optional
@@ -98,13 +99,15 @@ def get_dimension_description(persona_dimension: str) -> str:
 
     if persona_dimension == "all_engagement":
         texts = [
-            get_dimension_description(n) for n in sorted(ALL_ENGAGEMENT_DIMENSIONS.keys())
+            get_dimension_description(n)
+            for n in sorted(ALL_ENGAGEMENT_DIMENSIONS.keys())
         ]
         return "\n\n".join(f"{i + 1}. {t}" for i, t in enumerate(texts))
 
     if persona_dimension == "all_cognitive":
         texts = [
-            get_dimension_description(n) for n in sorted(ALL_COGNITIVE_DIMENSIONS.keys())
+            get_dimension_description(n)
+            for n in sorted(ALL_COGNITIVE_DIMENSIONS.keys())
         ]
         return "\n\n".join(f"{i + 1}. {t}" for i, t in enumerate(texts))
 
@@ -114,6 +117,7 @@ def get_dimension_description(persona_dimension: str) -> str:
 # ---------------------------------------------------------------------------
 # Adapter (wraps tutorsim.client.ModelClient)
 # ---------------------------------------------------------------------------
+
 
 class _ModelWrapperAdapter:
     """Thin shim around tutorsim ModelClient mimicking TraitGenerator's model interface.
@@ -155,6 +159,7 @@ class _ModelWrapperAdapter:
 # TraitGenerator (live path only)
 # ---------------------------------------------------------------------------
 
+
 class TraitGenerator:
     """Generate student traits from example conversations.
 
@@ -183,11 +188,9 @@ class TraitGenerator:
         else:
             suffix = " The description should be 1 sentence long."
 
-        return (
-            template
-            .replace("{dimension_description}", dimension_description)
-            .replace("{sentence_count_suffix}", suffix)
-        )
+        return template.replace(
+            "{dimension_description}", dimension_description
+        ).replace("{sentence_count_suffix}", suffix)
 
     def _get_user_prompt(
         self, conversation_text: str, num_sentences: Optional[int] = None
@@ -198,10 +201,8 @@ class TraitGenerator:
         {conversation_text} and {num_sentences}.
         """
         template = resource_text(f"{_TRAIT_GEN_DIR}/user.txt").rstrip("\n")
-        return (
-            template
-            .replace("{conversation_text}", conversation_text)
-            .replace("{num_sentences}", str(num_sentences))
+        return template.replace("{conversation_text}", conversation_text).replace(
+            "{num_sentences}", str(num_sentences)
         )
 
     def parse_trait_output(self, raw_output: str) -> tuple:
@@ -323,6 +324,7 @@ class TraitGenerator:
 # Module-level wrappers
 # ---------------------------------------------------------------------------
 
+
 def generate_trait(
     transcript_prefix: str,
     mode: str = DEFAULT_TRAIT_MODE,
@@ -349,8 +351,7 @@ def _format_transcript_prefix(context: list) -> str:
     personas were generated from this same rendering of the pre-cut turns.
     """
     return "\n".join(
-        f"Turn {t['turn_number']}. {t['role'].upper()}: {t['text']}"
-        for t in context
+        f"Turn {t['turn_number']}. {t['role'].upper()}: {t['text']}" for t in context
     )
 
 
@@ -379,8 +380,9 @@ def generate_traits_for_moments(
             "persona": persona.strip(),
             "trait_mode": trait_mode,
             "generator_model": model_name,
-            "generated_at": datetime.datetime.now(datetime.timezone.utc)
-                            .strftime("%Y-%m-%dT%H:%M:%S"),
+            "generated_at": datetime.datetime.now(datetime.timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%S"
+            ),
         }
         generated += 1
         logger.info("trait generated for %s (%d chars)", moment.id, len(persona))


### PR DESCRIPTION
## What

Adds continuous integration so PRs and pushes to `main` are gated by lint and the test suite. The repo had no `.github/` at all.

## Changes

- **`.github/workflows/ci.yml`** — two jobs on `pull_request` and `push` to `main` (Python 3.11, pip-cached, concurrency cancels superseded runs):
  - `lint`: `ruff check .` + `ruff format --check .`
  - `test`: `pip install -e ".[dev,build-dev,analysis]"` then `pytest tests -q`
  - No secrets needed — the suite makes no real API calls, so it's safe for fork PRs.
- **`pyproject.toml`** — adds `ruff` to the `dev` extra and a `[tool.ruff]` config: `select = ["E4","E7","E9","F","I"]`, `ignore = ["E402","E741"]`, notebooks + markdown excluded, line-length 88 (formatter target; E501 intentionally not gated).
- **One-time `ruff` normalization** — `ruff format` + `ruff check --fix` across all Python sources, plus manual removal of unused locals (F841) with no safe autofix. Behavior-preserving.
- **Flaky-test fix** — `test_per_run_log_file_registered_worker_thread_captured` had a thread-id-reuse race (registered/unregistered threads ran sequentially; a recycled id let the unregistered thread pass the filter, ~50% failure). Now keeps both threads alive via a barrier so ids are distinct. Verified 50/50.
- **`.gitignore`** — add `.ruff_cache/`.

## Verification

On a clean Python 3.11 env matching the workflow:
- `ruff check .` and `ruff format --check .` clean.
- `pytest tests -q` → **479 passed, 13 skipped** (the 13 skips are dataset-release tests that self-skip when the gitignored `balanced_520` release is absent — expected in CI).

## Note on ordering

This overlaps with #29 (tutorsim → tutormoments rename), which touches nearly every `.py` file. Whichever lands second needs a rebase. Suggest landing this first so #29 gets CI coverage for its sweeping change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)