### PR TITLE
Support the HF release and default to allenai/tutormoments-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ benchmark runtime. Everything a run depends on ships inside the package:
 
 ## Running
 
-TODO: Update the dataset path
-Point the runner at the released Hugging Face dataset and provide an API key to
-run the benchmark.
+Provide an API key and run the benchmark; the dataset source defaults to the
+released Hugging Face dataset (see `--dataset` below).
 
 ```bash
 export ANTHROPIC_API_KEY=...   # or the provider's key
@@ -37,8 +36,7 @@ export ANTHROPIC_API_KEY=...   # or the provider's key
 tutormoments run \
   --tutors claude-opus-4-8 \
   --modes plain scaffolding_rigor \
-  --sample 10 \
-  --dataset <org>/tutormoments-transcripts-preview
+  --sample 10
 ```
 
 Useful run options:
@@ -47,7 +45,7 @@ Useful run options:
 |---|---|
 | `--tutors MODEL_ID ...` | Tutor model IDs or registered custom tutor names to evaluate. |
 | `--modes MODE ...` | Tutor prompt modes. Defaults to `plain scaffolding_rigor`. |
-| `--dataset HF_ID` | Hugging Face dataset id (default: `dataset.id` from config). |
+| `--dataset HF_ID` | Hugging Face dataset id. Defaults to [`allenai/tutormoments-preview`](https://huggingface.co/datasets/allenai/tutormoments-preview) (`dataset.id` in config). |
 | `--data_path DIR` | Run from a local data dir; wins over `--dataset`. |
 | `--dataset-revision REV` | Pin a HF dataset revision for reproducibility. |
 | `--sample N` | Use the first `N` moments from the dataset. |

--- a/src/tutormoments/default_config.yaml
+++ b/src/tutormoments/default_config.yaml
@@ -1,9 +1,9 @@
-# Released benchmark dataset. `id` is the Hugging Face dataset id (null until
-# the release is published — pass --dataset or --data_path meanwhile);
-# `revision` pins a dataset commit/tag for reproducibility; `config` names the
-# dataset config that holds the runnable moments set.
+# Released benchmark dataset. `id` is the Hugging Face dataset id (override with
+# --dataset, or --data_path for a local release dir); `revision` pins a dataset
+# commit/tag for reproducibility; `config` names the dataset config that holds
+# the runnable moments set.
 dataset:
-  id: null
+  id: allenai/tutormoments-preview
   revision: null
   config: moments
 

--- a/src/tutormoments/moments.py
+++ b/src/tutormoments/moments.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import logging
 from dataclasses import asdict, dataclass
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -143,6 +144,28 @@ def _read_moments_jsonl(path: str | Path) -> list[Moment]:
     return moments
 
 
+def _normalize_hf_row(value: Any) -> Any:
+    """Recursively convert Arrow-deserialized datetimes to ISO strings.
+
+    The released dataset stores timestamp fields (e.g.
+    student.trait.generated_at) as Arrow ``timestamp`` columns, so
+    ``datasets.load_dataset`` hands them back as Python ``datetime`` objects.
+    The released jsonl carries the same fields as ISO strings, so normalize the
+    HF rows here to keep both load paths byte-identical (this also keeps the
+    records JSON-serializable for records_content_hash). Mirrors the Arrow
+    round-trip handled for cut_votes in _normalize_cut_votes.
+    """
+    if isinstance(value, datetime):  # check before date: datetime is a date
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: _normalize_hf_row(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_normalize_hf_row(v) for v in value]
+    return value
+
+
 def load_manifest(release_dir: str | Path) -> dict | None:
     """Load a release directory's moments.manifest.json if present."""
     path = Path(release_dir) / MANIFEST_FILENAME
@@ -190,7 +213,7 @@ def load_moments(
         from datasets import load_dataset  # heavy import; only on the HF path
 
         ds = load_dataset(dataset, name=config, revision=revision, split="train")
-        moments = [Moment.from_dict(dict(row)) for row in ds]
+        moments = [Moment.from_dict(_normalize_hf_row(dict(row))) for row in ds]
         source_meta = {
             "dataset_id": dataset,
             "revision": revision,

--- a/tests/tutormoments/test_config.py
+++ b/tests/tutormoments/test_config.py
@@ -121,9 +121,9 @@ def test_scorer_and_student_specs():
 def test_build_run_config_defaults():
     rc = cfgmod.build_run_config(tutors=["claude-opus-4-8"])
     assert rc.modes == ["plain", "scaffolding_rigor"]
-    # No dataset is pinned in the default config until the release is published;
-    # the runnable set defaults to the "moments" config within a dataset.
-    assert rc.dataset is None
+    # The default config pins the released HF dataset; the runnable set defaults
+    # to the "moments" config within it.
+    assert rc.dataset == "allenai/tutormoments-preview"
     assert rc.data_path is None
     assert rc.dataset_config == "moments"
     assert rc.max_turns == 5 and rc.trials == 1

--- a/tests/tutormoments/test_moments.py
+++ b/tests/tutormoments/test_moments.py
@@ -101,6 +101,58 @@ def test_load_moments_no_source_raises():
         load_moments()
 
 
+def test_load_moments_hf_path_normalizes_datetimes(monkeypatch):
+    """HF loading normalizes Arrow datetime fields to ISO strings.
+
+    datasets.load_dataset returns timestamp columns (student.trait.generated_at)
+    as datetime objects. The runtime must normalize them so records stay
+    JSON-serializable for records_content_hash and hash identically to the
+    equivalent jsonl (string) form.
+    """
+    import datasets
+
+    from datetime import datetime
+
+    trait = {
+        "persona": "curious",
+        "trait_mode": "frozen",
+        "generator_model": "claude-opus-4-6",
+        "generated_at": datetime(2026, 6, 18, 6, 28, 40),
+    }
+    row = {
+        "id": "s:c__hum_1_2",
+        "context": [{"turn_number": 1, "role": "tutor", "text": "Q"}],
+        "dimension": "rigor",
+        "student": {"mode": "oracle", "reference": "", "context": "", "trait": trait},
+        "rubric": {"gold": "rigor", "hint": ""},
+        "provenance": {"conv_id": "c", "cut_turn": 27},
+    }
+
+    def fake_load_dataset(dataset, name=None, revision=None, split=None):
+        assert dataset == "org/ds"
+        assert name == "moments"
+        assert split == "train"
+        return [row]
+
+    monkeypatch.setattr(datasets, "load_dataset", fake_load_dataset)
+
+    moments, source = load_moments(dataset="org/ds")
+
+    assert len(moments) == 1
+    gen = moments[0].to_dict()["student"]["trait"]["generated_at"]
+    assert gen == "2026-06-18T06:28:40"  # datetime -> ISO string, not a datetime
+    assert source["dataset_id"] == "org/ds"
+
+    # Hash parity: the HF (datetime) form hashes identically to the jsonl form
+    # that carries the same timestamp as an ISO string.
+    string_trait = dict(trait, generated_at="2026-06-18T06:28:40")
+    string_row = dict(
+        row, student=dict(row["student"], trait=string_trait)
+    )
+    expected = records_content_hash([Moment.from_dict(string_row).to_dict()])
+    assert source["content_hash"] == expected
+
+
 def test_validate_dataset_reads_manifest_and_hashes_fixture():
     report = validate_dataset(_FIXTURE_RELEASE)
     assert report["record_count"] == 2

--- a/tests/tutormoments/test_moments.py
+++ b/tests/tutormoments/test_moments.py
@@ -109,9 +109,9 @@ def test_load_moments_hf_path_normalizes_datetimes(monkeypatch):
     JSON-serializable for records_content_hash and hash identically to the
     equivalent jsonl (string) form.
     """
-    import datasets
-
     from datetime import datetime
+
+    import datasets
 
     trait = {
         "persona": "curious",
@@ -146,9 +146,7 @@ def test_load_moments_hf_path_normalizes_datetimes(monkeypatch):
     # Hash parity: the HF (datetime) form hashes identically to the jsonl form
     # that carries the same timestamp as an ISO string.
     string_trait = dict(trait, generated_at="2026-06-18T06:28:40")
-    string_row = dict(
-        row, student=dict(row["student"], trait=string_trait)
-    )
+    string_row = dict(row, student=dict(row["student"], trait=string_trait))
     expected = records_content_hash([Moment.from_dict(string_row).to_dict()])
     assert source["content_hash"] == expected
 


### PR DESCRIPTION
## Summary

Makes `tutormoments run` work against the released Hugging Face dataset and sets it as the default source. Verified end-to-end against `allenai/tutormoments-preview` (520 records load; no LLM calls needed to reproduce).

## Changes

- **Fix HF load crash** (`src/tutormoments/moments.py`): the dataset stores `student.trait.generated_at` as an Arrow `timestamp[s]` column, so `datasets.load_dataset` returns a Python `datetime` and `records_content_hash` failed with `TypeError: Object of type datetime is not JSON serializable`. Added `_normalize_hf_row` to recursively convert Arrow-deserialized `datetime`/`date` back to ISO strings on the HF branch (mirroring the existing `_normalize_cut_votes` round-trip). Using `.isoformat()` keeps values byte-identical to the jsonl form, so `content_hash` matches across the HF and local `--data_path` paths.
- **Default to the released dataset** (`src/tutormoments/default_config.yaml`): `dataset.id` -> `allenai/tutormoments-preview`, so a run works without an explicit `--dataset`.
- **README**: quickstart no longer needs `--dataset`; the default is documented in the `--dataset` options row.
- **Tests**: added `test_load_moments_hf_path_normalizes_datetimes` (mocks `datasets.load_dataset`, stays offline) asserting datetime normalization and hash parity; updated `test_build_run_config_defaults` for the new default.

## Verification

- Live load of `allenai/tutormoments-preview`: 520 records, `generated_at` normalized to `'2026-06-18T06:28:40'`, HF `content_hash` equal to the raw `moments.jsonl` hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)