### PR TITLE
Measure the roster's TTFT and publish it on the leaderboard and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,13 @@ reportable number, run the serial probe:
 tutormoments latency --tutor claude-sonnet-5 --mode scaffolding_rigor
 ```
 
-This writes `results/<run_id>/latency.json`. See [docs/latency.md](docs/latency.md) for what
-the metrics mean, why warm and cold cache states are reported separately, and the caveats
-that apply before quoting a number.
+This writes `results/<run_id>/latency.json`. `tutormoments report` then joins that onto the
+leaderboard as `ttft_p50` (with `ttft_cold_p50` / `ttft_warm_p50` where a provider's cache
+states can be trusted), matching on tutor model and prompt mode; a cell with no probe run
+shows `-` rather than the concurrency-distorted figure from its benchmark run.
+
+See [docs/latency.md](docs/latency.md) for what the metrics mean, why warm and cold cache
+states are reported separately, and the caveats that apply before quoting a number.
 
 ## Reports And Viewers
 
@@ -108,7 +112,9 @@ Aggregate completed run summaries into leaderboard files:
 tutormoments report --results-root results --out leaderboard
 ```
 
-This writes `leaderboard.md` and `leaderboard.csv`.
+This writes `leaderboard.md` and `leaderboard.csv`. Columns are the paper's three metrics,
+then TTFT from any serial [latency](#latency) probe in the same results root, then the run's
+own end-to-end tutor latency and token totals.
 
 Build a self-contained HTML viewer:
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ tutormoments latency --tutor claude-sonnet-5 --mode scaffolding_rigor
 ```
 
 This writes `results/<run_id>/latency.json`. `tutormoments report` then joins that onto the
-leaderboard as `ttft_p50` (with `ttft_cold_p50` / `ttft_warm_p50` where a provider's cache
-states can be trusted), matching on tutor model and prompt mode; a cell with no probe run
-shows `-` rather than the concurrency-distorted figure from its benchmark run.
+leaderboard as `ttft_p50`, split into `ttft_first_p50` / `ttft_later_p50` (the first message
+of a session against turns 3 and 5), matching on tutor model and prompt mode; a cell with no
+probe run shows `-` rather than the concurrency-distorted figure from its benchmark run.
 
 See [docs/latency.md](docs/latency.md) for what the metrics mean, why warm and cold cache
 states are reported separately, and the caveats that apply before quoting a number.

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -98,15 +98,15 @@ see [Concurrency impacts latency](#concurrency-impacts-latency).
 Probe results live in their own run directory, which nothing else reads, so two consumers
 join them in ([`probe_runs`](../src/tutormoments/latency.py)):
 
-- **`tutormoments report`** — the leaderboard gains `ttft_p50`, `ttft_cold_p50` and
-  `ttft_warm_p50`, joined onto each run summary by `(tutor_model, mode)`. A cell with no probe
+- **`tutormoments report`** — the leaderboard gains `ttft_p50`, `ttft_first_p50` and
+  `ttft_later_p50`, joined onto each run summary by `(tutor_model, mode)`. A cell with no probe
   shows `-`; it never borrows the TTFT its benchmark run recorded under concurrency. The
   run-based `tutor_lat_p50` / `tutor_lat_p95` columns stay where they were, and are still
   end-to-end wall clock that compares a model against its own history rather than against
   another model.
 - **The website's latency chart** — `website/scripts/refresh-data.py` reads the same figures
-  into `static/data/latency.json` as `ttft_s` and `ttlt_s` (plus `ttft_cold_s` /
-  `ttft_warm_s` where the split is publishable) and plots TTFT on the x-axis, with TTLT in
+  into `static/data/latency.json` as `ttft_s` and `ttlt_s` plus the same first/later split
+  (`ttft_first_s` / `ttft_later_s`), and plots TTFT on the x-axis with TTLT and the split in
   the tooltip. That script imports this module rather
   than restating its rules; an earlier version restated them and gated on cache hit *rate*,
   which is the one thing this code deliberately refuses to do.
@@ -122,18 +122,21 @@ run directory — which is how the 40-moment pilot stopped being published the m
 samples would each pass it; both consumers therefore check that the selected probes agree on
 `subsample_id` and warn when they do not.
 
-**The pooled figure is the headline, not the cold one.** Cold is the more natural
-"first message of a session" number, but it does not exist on every provider: Gemini reports
-no cache tokens, so it has no cold bucket, and on Together the bucket exists but its labels
-mean something else (above). Pooled TTFT is measured identically on all four providers, so it
-is the only figure that can rank the whole roster, and dropping two models off a chart for a
-provider-reporting reason is worse than the alternative. What that costs: at a fixed
-`max_turns` the mix is structurally 1 cold to 2 warm per moment, but the *realised* hit rate
-varies (0.45–0.67 on Anthropic, since a moment whose head falls under the model's minimum
-prefix fails to cache silently), so a pooled figure carries a small mix effect on top of the
-model's speed. With the warm gain at ~1–3.6s that is worth well under a second — smaller than
-the cold/warm gap it replaces, and far smaller than the p5–p95 spread within any one model.
-The split is published beside it wherever it can be trusted, so nothing is hidden.
+**The published split keys on turn position, not cache state.** "First message" is the 112
+turn-1 calls; "later" is the 224 on turns 3 and 5. The probe recorded every call's turn
+itself, so this split is ground truth on all four providers and needs no publishability gate.
+A cache-state split is the natural first idea and is wrong twice over: it does not exist on
+Gemini (no cache tokens reported), and where automatic caching exists it mislabels — a "cold"
+bucket holds every call whose cache missed, which on `gpt-5.5` included 27 later-turn calls
+whose prefix silently failed to cache, diluting its "first message" figure from 7.53s to
+6.91s, and on Together tracks run warmup rather than session position entirely. The
+cache-state aggregates stay in `latency.json` (fidelity-gated, see
+[caching fidelity](#caching-fidelity--the-biggest-caveat)) as the diagnostic for what
+*caching* does; the turn split is what a student's first and later messages actually cost.
+
+**The pooled figure is the ranking number.** One number per model, over an identical sample —
+112 first + 224 later for every model in a full run. The mix is fixed by run structure, not by
+provider behavior, so pooling is fair; the split is published beside it so nothing is hidden.
 
 ## Analysis
 
@@ -148,21 +151,31 @@ because every probe's simulated student is `claude-opus-4-6` on the same account
 
 | model | TTFT p50 | p5 / p95 | first message | later | TTLT p50 | thinking share of TTFT |
 |---|---|---|---|---|---|---|
-| `gpt-5.4-mini-2026-03-17` | **3.16** | 1.77 / 7.16 | 3.72 | 2.71 | 3.47 | not streamed |
-| `gemini-3.5-flash` | **5.51** | 3.62 / 10.50 | – | – | 5.72 | 3.75s of 5.51 |
-| `gpt-5.5-2026-04-23` | **6.38** | 3.40 / 9.65 | 6.91 | 5.92 | 7.28 | not streamed |
+| `gpt-5.4-mini-2026-03-17` | **3.16** | 1.77 / 7.16 | 3.76 | 2.71 | 3.47 | not streamed |
+| `gemini-3.5-flash` | **5.51** | 3.62 / 10.50 | 6.11 | 5.21 | 5.72 | 3.75s of 5.51 |
+| `gpt-5.5-2026-04-23` | **6.38** | 3.40 / 9.65 | 7.53 | 5.89 | 7.28 | not streamed |
 | `claude-sonnet-4-6` | **8.47** | 3.12 / 21.09 | 9.62 | 7.63 | 8.73 | 7.13s of 8.47 |
 | `claude-opus-4-8` | **9.04** | 4.34 / 27.90 | 13.22 | 7.99 | 10.52 | 7.86s of 9.04 |
-| `deepseek-ai/DeepSeek-V4-Pro` | **11.09** | 4.42 / 36.43 | – | – | 11.86 | 10.35s of 11.09 |
-| `gemini-2.5-pro` | **14.08** | 9.13 / 24.34 | – | – | 14.15 | 11.59s of 14.08 |
+| `deepseek-ai/DeepSeek-V4-Pro` | **11.09** | 4.42 / 36.43 | 12.91 | 9.97 | 11.86 | 10.35s of 11.09 |
+| `gemini-2.5-pro` | **14.08** | 9.13 / 24.34 | 14.74 | 13.68 | 14.15 | 11.59s of 14.08 |
 
 TTFT p50 is pooled over all 336 calls, which is what the leaderboard and the website rank on.
-"First message" / "later" are the cold and warm halves, shown only where the provider's cache
-labels can be carried (see [caching fidelity](#caching-fidelity--the-biggest-caveat)) — so
-Gemini has none, and DeepSeek's are withheld rather than published. The thinking column
+"First message" / "later" split it **by turn position** — the 112 turn-1 calls against the 224
+on turns 3 and 5. Turn position is the probe's own record, so the split exists for every
+provider identically; it does not depend on what a provider reports about caching, which is
+why Gemini and DeepSeek have figures here despite having no usable cache split (see
+[caching fidelity](#caching-fidelity--the-biggest-caveat)). On Anthropic it coincides with
+the cache split to a hundredth of a second (turn 1 is always the miss); on `gpt-5.5` it
+corrects it — the cache-based "cold" was 6.91 because 27 later-turn calls silently failed to
+cache and diluted the bucket, while the actual first-message p50 is 7.53. The thinking column
 subtracts the `ttfc` p50 from the `ttft` p50; the
 [decomposition below](#caching-does-not-systematically-improve-latency) takes the p50 of the
 per-call difference instead, which is why its figures differ by a tenth of a second or so.
+
+The split is also where the roster's other pattern shows: every model adapts its effort to
+position. Even Gemini 2.5 Pro, with no session cache in this harness at all, is 1.06s faster
+on later turns — pure thinking adaptation. DeepSeek's 2.94s and Opus 4.8's 5.22s gaps say the
+first message of a session is where reasoning models spend their budget.
 
 The order is not the score order: the two strongest tutors in the benchmark sit 8.5–9.0s from
 first token, and the fastest model on the roster is the weakest. That trade-off is the finding
@@ -291,9 +304,12 @@ thinking, and thinking falls monotonically with turn index (11.75s, then 6.96s, 
 the model reasons hardest when it first meets the problem and less on each continuation.
 Sonnet 4.6 does show a real prefill saving, and it is 0.53s.
 
-So the split is honestly read as **"first message of a session" vs "a later message"**, which
-is how the website labels it — a position-in-conversation effect that caching contributes a
-fraction of a second to. On the OpenAI path the decomposition is unavailable (reasoning is not
+So the split is honestly read as **"first message of a session" vs "a later message"** — a
+position-in-conversation effect that caching contributes a fraction of a second to. That
+reading is now literal: the split the leaderboard and website publish keys on turn position
+directly, so it exists for every provider and measures the position effect wherever thinking
+adapts — including Gemini 2.5 Pro, 1.06s faster on later turns with no session cache in this
+harness at all. On the OpenAI path the decomposition is unavailable (reasoning is not
 streamed, so `ttfc` ≈ `ttft`) and the whole ~1.0s gain lands in prefill by construction; that
 is an upper bound on its caching effect, not a measurement of one.
 
@@ -348,20 +364,24 @@ comparable within the Anthropic and OpenAI paths, and absent elsewhere.** Wiring
 Gemini/Together cache remains follow-up work; the gate is what keeps its absence honest in the
 meantime.
 
-**A withheld split withholds the cold figure too.** The natural reading is that this gate
-guards the warm number alone, but its conditions establish that a provider's hit/miss labels
-mean session warmth *at all* — and labels that cannot be trusted for the hits cannot be
-trusted for their complement. Together is the concrete case: its misses are the calls its
-automatic prefix cache happened not to serve, which cluster at run start rather than at
-session start. On the roster that put its "cold" p50 at 12.86s and its "warm" at 10.86s, a
-2.0s gap that reads exactly like the session effect the Anthropic models show and is nothing
-of the kind — the 72 calls in that bucket are the ones Together's cache happened to miss, not
-the 112 first messages.
-Publishing that as "the first message of a session" would be wrong in exactly the way
-publishing its warm figure would be. `probe_figures` therefore returns the split as a unit or
-not at all. The probe's own terminal summary is looser on purpose — it prints the cold figure
-with a NOTE naming what was withheld and why, because there it is a diagnostic read by
-whoever just ran the probe, not a number lifted into a table.
+**What the gate guards — and what routed around it.** A withheld warm figure withholds the
+cold one too: the gate's conditions establish that a provider's hit/miss labels mean session
+warmth *at all*, and labels that cannot be trusted for the hits cannot be trusted for their
+complement. Together is the concrete case: its misses are the calls its automatic prefix
+cache happened not to serve, which cluster at run start rather than at session start. On the
+roster that put its "cold" p50 at 12.86s and its "warm" at 10.86s — a 2.0s gap that reads
+exactly like the session effect the Anthropic models show and is nothing of the kind. The 72
+calls in that bucket are the ones Together's cache happened to miss, not the 112 first
+messages.
+
+This is why the *published* first/later split keys on turn position instead
+(`probe_figures`): turn index is the probe's own record, needs no gate, and answers the
+product question directly. The cache split this section describes remains in `latency.json`
+and the probe's terminal summary as the caching diagnostic — the summary prints the cold
+figure with a NOTE naming what was withheld and why, because there it is read by whoever just
+ran the probe, not lifted into a table. Where both splits exist they nearly agree on
+Anthropic (turn 1 ≡ miss, to a hundredth of a second) and diverge exactly where the cache
+labels lie, which is itself a useful check.
 
 ### What is not modelled
 

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -105,8 +105,9 @@ join them in ([`probe_runs`](../src/tutormoments/latency.py)):
   end-to-end wall clock that compares a model against its own history rather than against
   another model.
 - **The website's latency chart** — `website/scripts/refresh-data.py` reads the same figures
-  into `static/data/latency.json` as `ttft_s` (plus `ttft_cold_s` / `ttft_warm_s` where the
-  split is publishable) and plots TTFT on the x-axis. That script imports this module rather
+  into `static/data/latency.json` as `ttft_s` and `ttlt_s` (plus `ttft_cold_s` /
+  `ttft_warm_s` where the split is publishable) and plots TTFT on the x-axis, with TTLT in
+  the tooltip. That script imports this module rather
   than restating its rules; an earlier version restated them and gated on cache hit *rate*,
   which is the one thing this code deliberately refuses to do.
 

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -11,7 +11,7 @@ the whole exchange.
 **TTFT is the headline; TTLT is reported beside it.** Both are real, but they are not
 interchangeable, and TTLT should not be the number a model is ranked on:
 
-- TTLT = TTFT + the time to stream the answer out. That window is 0–11% of TTLT across the
+- TTLT = TTFT + the time to stream the answer out. That window is 0–12% of TTLT across the
   roster, so the two rank models almost identically — headlining TTFT gives up very little.
 - What the window *does* carry is generation length × throughput. Length is a content
   property this benchmark already evaluates: a model that over-explains is penalised by
@@ -93,17 +93,90 @@ for a check that comes free with every run.
 `tutormoments run` also records TTFT/TTLT on every transcript, but those are diagnostics —
 see [Concurrency impacts latency](#concurrency-impacts-latency).
 
+### Where the figures surface
+
+Probe results live in their own run directory, which nothing else reads, so two consumers
+join them in ([`probe_runs`](../src/tutormoments/latency.py)):
+
+- **`tutormoments report`** — the leaderboard gains `ttft_p50`, `ttft_cold_p50` and
+  `ttft_warm_p50`, joined onto each run summary by `(tutor_model, mode)`. A cell with no probe
+  shows `-`; it never borrows the TTFT its benchmark run recorded under concurrency. The
+  run-based `tutor_lat_p50` / `tutor_lat_p95` columns stay where they were, and are still
+  end-to-end wall clock that compares a model against its own history rather than against
+  another model.
+- **The website's latency chart** — `website/scripts/refresh-data.py` reads the same figures
+  into `static/data/latency.json` as `ttft_s` (plus `ttft_cold_s` / `ttft_warm_s` where the
+  split is publishable) and plots TTFT on the x-axis. That script imports this module rather
+  than restating its rules; an earlier version restated them and gated on cache hit *rate*,
+  which is the one thing this code deliberately refuses to do.
+
+Two rules keep the join from quietly comparing unlike things:
+
+**Only frozen, complete subsamples are eligible.** A derived sample spans no particular
+prompt-length distribution, and an incomplete one dropped ids, so neither is the same
+measurement as the run before it. Among eligible probes for one cell the newest `measured_at`
+wins, so re-measuring a model supersedes its earlier figure without anyone deleting the old
+run directory — which is how the 40-moment pilot stopped being published the moment the
+112-moment sweep landed beside it. Eligibility is per-probe, though, so two *different* frozen
+samples would each pass it; both consumers therefore check that the selected probes agree on
+`subsample_id` and warn when they do not.
+
+**The pooled figure is the headline, not the cold one.** Cold is the more natural
+"first message of a session" number, but it does not exist on every provider: Gemini reports
+no cache tokens, so it has no cold bucket, and on Together the bucket exists but its labels
+mean something else (above). Pooled TTFT is measured identically on all four providers, so it
+is the only figure that can rank the whole roster, and dropping two models off a chart for a
+provider-reporting reason is worse than the alternative. What that costs: at a fixed
+`max_turns` the mix is structurally 1 cold to 2 warm per moment, but the *realised* hit rate
+varies (0.45–0.67 on Anthropic, since a moment whose head falls under the model's minimum
+prefix fails to cache silently), so a pooled figure carries a small mix effect on top of the
+model's speed. With the warm gain at ~1–3.6s that is worth well under a second — smaller than
+the cold/warm gap it replaces, and far smaller than the p5–p95 spread within any one model.
+The split is published beside it wherever it can be trusted, so nothing is hidden.
+
 ## Analysis
 
-> **The per-model numbers quoted below are provisional.** They were measured on
-> 2026-08-17 over a 40-moment pilot subsample (`subsample_id` `84b4ad5615876a3e`, 80 tutor
-> calls per model), which predates the current frozen list (`589e8acf8ac761f2`, 112 moments,
-> 336 calls). The pilot took each conversation's median moment, so it under-covered short and
-> long prompts — see [the latency subsample](#the-latency-subsample). The *shape* of the
-> findings (TTFT ≫ generation window, caching barely moves TTFT, warm/cold fidelity differing
-> by provider) is what these figures are cited for and is not sensitive to that; the specific
-> seconds are, and no figure here should be published before the roster is re-measured
-> against the current list.
+### The roster, measured
+
+Seven models, `scaffolding_rigor`, the frozen 112-moment subsample
+(`subsample_id` `589e8acf8ac761f2`) at the default `max_turns` of 5 — 336 tutor calls each,
+2,352 in total. Measured 2026-08-18, 10:27–15:31 local, on one unlabelled machine
+(`location` null): **these seconds are comparable to each other and to nothing else.**
+Non-Anthropic lanes ran concurrently with each other; the two Anthropic tutors ran alone,
+because every probe's simulated student is `claude-opus-4-6` on the same account.
+
+| model | TTFT p50 | p5 / p95 | first message | later | TTLT p50 | thinking share of TTFT |
+|---|---|---|---|---|---|---|
+| `gpt-5.4-mini-2026-03-17` | **3.16** | 1.77 / 7.16 | 3.72 | 2.71 | 3.47 | not streamed |
+| `gemini-3.5-flash` | **5.51** | 3.62 / 10.50 | – | – | 5.72 | 3.75s of 5.51 |
+| `gpt-5.5-2026-04-23` | **6.38** | 3.40 / 9.65 | 6.91 | 5.92 | 7.28 | not streamed |
+| `claude-sonnet-4-6` | **8.47** | 3.12 / 21.09 | 9.62 | 7.63 | 8.73 | 7.13s of 8.47 |
+| `claude-opus-4-8` | **9.04** | 4.34 / 27.90 | 13.22 | 7.99 | 10.52 | 7.86s of 9.04 |
+| `deepseek-ai/DeepSeek-V4-Pro` | **11.09** | 4.42 / 36.43 | – | – | 11.86 | 10.35s of 11.09 |
+| `gemini-2.5-pro` | **14.08** | 9.13 / 24.34 | – | – | 14.15 | 11.59s of 14.08 |
+
+TTFT p50 is pooled over all 336 calls, which is what the leaderboard and the website rank on.
+"First message" / "later" are the cold and warm halves, shown only where the provider's cache
+labels can be carried (see [caching fidelity](#caching-fidelity--the-biggest-caveat)) — so
+Gemini has none, and DeepSeek's are withheld rather than published. The thinking column
+subtracts the `ttfc` p50 from the `ttft` p50; the
+[decomposition below](#caching-does-not-systematically-improve-latency) takes the p50 of the
+per-call difference instead, which is why its figures differ by a tenth of a second or so.
+
+The order is not the score order: the two strongest tutors in the benchmark sit 8.5–9.0s from
+first token, and the fastest model on the roster is the weakest. That trade-off is the finding
+the website chart plots.
+
+Sanity checks (see [interpreting a result](#interpreting-a-result)) all hold: `ttfc ≤ ttft ≤
+ttlt` on every one of the 2,352 calls, no failed moments, and every frozen id resolved on
+every model. One exception, on one call: `deepseek-ai/DeepSeek-V4-Pro` recorded
+`n_no_visible_output` 1 of 336 (0.3%), so its percentiles are conditional on 335. That call
+emitted 572 output tokens and never produced a visible one. The probe keeps timings rather
+than text, so the mechanism is not directly observable here, but an unterminated
+`<think>` block produces exactly this on the Together path: TTFT is held until the closing
+tag, and a tag that never arrives leaves nothing ever counted as visible. In a benchmark run
+that turn is recorded as `"..."` and scored as if the tutor said it, which is why this counter
+exists — and why a non-zero value is worth chasing rather than rounding away.
 
 ### Two departures from Artificial Analysis
 
@@ -139,19 +212,33 @@ on OpenAI). A long response streams as hundreds of them, which is what produces 
 token-by-token typing effect. **A tutor turn does not: it is short enough to arrive in one or two deltas.**
 
 A direct instrumented call counted exactly **2 text deltas** for both `claude-sonnet-4-6`
-and `claude-opus-4-8`, carrying answers of 72 and 157 characters. Across the 40-moment
-pilot sample, `claude-sonnet-4-6` delivered its whole visible answer inside a 5ms window on
-44 of 80 calls. Median generation window (TTFT → TTLT): 0.00s for Sonnet 4.6, 0.05s for
-Gemini 2.5 Pro, 1.16s for Opus 4.8.
+and `claude-opus-4-8`, carrying answers of 72 and 157 characters. Median generation window
+(TTFT → TTLT) across the roster:
+
+| model | window p50 | share of TTLT |
+|---|---|---|
+| `claude-sonnet-4-6` | 0.00s | 0.0% |
+| `gemini-2.5-pro` | 0.06s | 0.4% |
+| `gemini-3.5-flash` | 0.15s | 2.6% |
+| `gpt-5.4-mini-2026-03-17` | 0.30s | 8.6% |
+| `deepseek-ai/DeepSeek-V4-Pro` | 0.69s | 5.8% |
+| `gpt-5.5-2026-04-23` | 0.84s | 11.6% |
+| `claude-opus-4-8` | 1.23s | 11.7% |
+
+Sonnet 4.6's median window is **0.00s**: the whole visible answer lands inside one
+millisecond-scale window, in one or two deltas.
 
 The practical consequence: streaming buys a tutoring product almost no progressive
 rendering. The student waits, then the message appears essentially at once. **TTFT is the
-metric; TTLT is TTFT plus about a second; throughput is noise.** Streaming is still
+metric; TTLT is TTFT plus at most about a second; throughput is noise.** Streaming is still
 required — it is the only way to observe TTFT at all — but not for the usual reason.
 
-A corollary for reading `output_tps`: on thinking models most `output_tokens` are thinking
-tokens (Opus 4.8: ~500 of 551 on one measured call), so tokens/sec largely describes
-reasoning speed, not how fast text reaches the student.
+Two corollaries for reading `output_tps`. On models that stream reasoning, most
+`output_tokens` are thinking tokens (Opus 4.8: ~500 of 551 on one measured call), so
+tokens/sec largely describes reasoning speed rather than how fast text reaches the student.
+On the OpenAI path it is not even that: reasoning is finished before `ttfc`, so the window
+`ttlt − ttfc` covers only the visible text while `output_tokens` still counts the reasoning,
+which is how `gpt-5.4-mini` posts a nominal 1,518 tokens/sec. Diagnostic only, as labelled.
 
 ### Caching does not systematically improve latency
 
@@ -168,8 +255,14 @@ experiences:
 - **miss** ≈ the first message of a session
 - **hit** ≈ every later message in that session
 
-They are reported separately. Pooling them would make the figure drift with how many turns
-each conversation happened to run, since `[END]` truncates some conversations early.
+They are reported separately, and the pooled figure is reported too — the pooled one is what
+ranks the roster, because Gemini has no cache states to split on at all (see
+[where the figures surface](#where-the-figures-surface)). The reason to keep the split beside
+it is that pooling can drift with how many turns each conversation happened to run: `[END]`
+truncates some conversations early, and a model that ends more of them shifts its own cold/warm
+mix. Worth checking rather than assuming — on the 2026-08-18 sweep it did not happen at all.
+Every model returned exactly 112 first turns and 224 later ones, so the pooled figures there
+differ only in the models, not in their mix.
 
 **Cache state is read off `cache_read_input_tokens`, never inferred from turn position.**
 Turn index is a bad proxy for two reasons. The minimum cacheable prefix is model-dependent
@@ -179,6 +272,34 @@ cache **silently**. So the same short-transcript moment can cache on one roster 
 not another. And providers that report no cache tokens are recorded as `unknown` rather than
 guessed at.
 
+**Measured, the cold/warm gap is mostly not a caching effect.** Every model with a usable
+split is faster warm — 1.0s on both OpenAI models, 2.0s on Sonnet 4.6, and 5.2s on Opus 4.8.
+That last number looks like a strong case for caching until the gap is decomposed. Splitting
+TTFT into prefill (`ttfc`, first chunk of any kind) and thinking (`ttft − ttfc`) at p50:
+
+| model | | prefill | thinking | TTFT |
+|---|---|---|---|---|
+| `claude-opus-4-8` | first message | 1.18 | 11.75 | 13.22 |
+| | later | 1.18 | 6.14 | 7.99 |
+| `claude-sonnet-4-6` | first message | 1.76 | 7.27 | 9.62 |
+| | later | 1.23 | 6.17 | 7.63 |
+
+Caching can only touch prefill, and on Opus 4.8 prefill does not move *at all* — 1.18s cold,
+1.18s warm, on a cache reading back a median 9,390 tokens. The entire 5.2s belongs to
+thinking, and thinking falls monotonically with turn index (11.75s, then 6.96s, then 6.00s):
+the model reasons hardest when it first meets the problem and less on each continuation.
+Sonnet 4.6 does show a real prefill saving, and it is 0.53s.
+
+So the split is honestly read as **"first message of a session" vs "a later message"**, which
+is how the website labels it — a position-in-conversation effect that caching contributes a
+fraction of a second to. On the OpenAI path the decomposition is unavailable (reasoning is not
+streamed, so `ttfc` ≈ `ttft`) and the whole ~1.0s gain lands in prefill by construction; that
+is an upper bound on its caching effect, not a measurement of one.
+
+None of this weakens the case for caching, which is a cost argument — a ~90% cut on the
+dominant term. It just means **caching is not a latency lever**, and a product that wants a
+faster first token has to spend elsewhere.
+
 ### Caching fidelity — the biggest caveat
 
 **Only the Anthropic path sends a real cache breakpoint.** Gemini
@@ -186,12 +307,13 @@ guessed at.
 into the prompt instead, so neither caches *this conversation's* transcript.
 
 That does not mean they report no cache hits. Together reports `cached_tokens` from its own
-automatic prefix caching, and measured on `deepseek-ai/DeepSeek-V4-Pro` it returns a **0.91
-hit rate** — higher than Anthropic's structural 0.50. The hits are not what they look like:
+automatic prefix caching, and measured on `deepseek-ai/DeepSeek-V4-Pro` it returns a **0.786
+hit rate** — *above* the 0.667 ceiling the run structure allows for a real session cache, which
+is the tell. The hits are not what they look like:
 
 | | hit/miss by turn | median tokens read back |
 |---|---|---|
-| Anthropic, explicit breakpoint | perfect `miss, hit` alternation | **7,400–10,000** |
+| Anthropic, explicit breakpoint | perfect `miss, hit, hit` per moment | **6,767–9,390** |
 | Together, automatic prefix cache | misses cluster at *run start*, unrelated to turn | **256** |
 
 Together is caching one quantised block of the system prompt every moment shares — run
@@ -208,11 +330,37 @@ a real conversation head. The sample gate is a count rather than a hit *rate* de
 the rate is fixed by `max_turns` (exactly 0.5 at `--max-turns 3`, 0.67 at 5), so a rate
 threshold would let a run knob decide whether a model gets a published figure. In practice
 one `claude-sonnet-4-6` run came in at 0.49 because a single turn missed; under a rate gate
-its warm figure would have vanished over one stray call.
+its warm figure would have vanished over one stray call. The roster bears this out from the
+other side: `gpt-5.5-2026-04-23` lands at 0.586 against the 0.667 ceiling — 24 calls that
+should have hit did not — while reading back 5,888 tokens a time, which is a real conversation
+head by any measure.
 
 Every latency block publishes `cache_hit_rate` and `cache_read_p50_on_hits` alongside the
-numbers. **Until real prefix caching is wired for Gemini, Together and OpenAI, the warm column
-is only comparable within the Anthropic-hosted models.** That is tracked as follow-up work.
+numbers.
+
+Note what the gate is and is not testing. It asks what the hits actually read back, not who
+sent a breakpoint — so it is not a list of Anthropic models. Measured on the roster, the
+OpenAI path passes it: `chat.completions` caches automatically and reads back a median of
+5,888 tokens, which is a real conversation head rather than a shared block of system prompt.
+Together fails it at 256 tokens, and Gemini reports nothing to judge. **So the warm column is
+comparable within the Anthropic and OpenAI paths, and absent elsewhere.** Wiring an explicit
+Gemini/Together cache remains follow-up work; the gate is what keeps its absence honest in the
+meantime.
+
+**A withheld split withholds the cold figure too.** The natural reading is that this gate
+guards the warm number alone, but its conditions establish that a provider's hit/miss labels
+mean session warmth *at all* — and labels that cannot be trusted for the hits cannot be
+trusted for their complement. Together is the concrete case: its misses are the calls its
+automatic prefix cache happened not to serve, which cluster at run start rather than at
+session start. On the roster that put its "cold" p50 at 12.86s and its "warm" at 10.86s, a
+2.0s gap that reads exactly like the session effect the Anthropic models show and is nothing
+of the kind — the 72 calls in that bucket are the ones Together's cache happened to miss, not
+the 112 first messages.
+Publishing that as "the first message of a session" would be wrong in exactly the way
+publishing its warm figure would be. `probe_figures` therefore returns the split as a unit or
+not at all. The probe's own terminal summary is looser on purpose — it prints the cold figure
+with a NOTE naming what was withheld and why, because there it is a diagnostic read by
+whoever just ran the probe, not a number lifted into a table.
 
 ### What is not modelled
 
@@ -238,10 +386,8 @@ concurrency distorts latency by a **model-dependent** amount:
 
 The probe runs strictly serially, so its numbers mean the same thing for every model. Run
 figures are stamped `"source": "run"` with the concurrency they were gathered at, so a
-reader can tell the two apart. The leaderboard carries no TTFT column: `tutormoments
-latency` writes its own `latency.json`, and nothing joins that onto a run summary yet, so
-the probe figure is read from `latency.json` directly. Wiring that join — for the
-leaderboard and for the website chart — is tracked as follow-up work.
+reader can tell the two apart. Only probe figures are published — see
+[where the figures surface](#where-the-figures-surface).
 
 Conversations also share one `ModelClient` per model
 ([`get_client`](../src/tutormoments/client.py)). Previously each moment built its own,
@@ -267,10 +413,19 @@ block across runs before trusting a cross-model comparison: if its median moves 
 to the tutor differences you are claiming, those differences may be the network or the hour
 of day rather than the models.
 
-Measured on the seven-model sweep of 2026-08-17 (14:50→16:20): student TTFT p50 ranged
-2.29–2.50s, a spread of **0.21s**, against a within-run p5–p95 spread of ~1.5s. Drift
-between runs was far smaller than noise inside them, so the tutor spread over that sweep
-(3.4s to 14.9s) is not an artifact of the environment changing.
+Measured on the seven-model sweep of 2026-08-18 (10:27→15:31): student TTFT p50 ranged
+2.44–2.76s, a spread of **0.32s**, against a within-run p5–p95 spread of ~1.5s and a tutor
+spread of 3.2s to 14.1s. Drift was an order of magnitude smaller than the differences being
+claimed, so the roster figures are not an artifact of the environment changing over five
+hours.
+
+The control also picked up the one thing it was pointed at. The three slowest student medians
+(2.69–2.76s) are all runs from the first phase of the sweep, when three provider lanes ran
+concurrently and each was making student calls against the same Anthropic account; the two
+runs that had that account to themselves came in at 2.46–2.48s. That is contention showing up
+exactly where the [concurrency](#concurrency-impacts-latency) argument says it should — and it
+is the reason the two Anthropic *tutors* were measured alone rather than in a lane beside the
+others.
 
 ## The latency subsample
 
@@ -365,11 +520,10 @@ another day and compare the two files if you need that.
 ## Interpreting a result
 
 **A p50 gap is not evidence that one model is faster.** TTFT spread is wide — Opus 4.8 runs
-p5 4.62 / p50 9.45 / p95 28.34 — so two close models can differ at p50 while being tied.
+p5 4.34 / p50 9.04 / p95 27.90 — so two close models can differ at p50 while being tied.
 
 Compare them **paired by (moment, turn)** instead, which cancels the moment-to-moment
-variation that dominates the raw spread. Opus 4.8 and Sonnet 4.6 differ by 0.55s at p50, but
-paired, Opus is faster on 39 of 80 calls — 48.7%, a coin flip.
+variation that dominates the raw spread.
 
 Sample size sets what you can resolve. The 95% CI half-width on a paired win rate near 50%
 is `0.98 / sqrt(n)`:
@@ -380,11 +534,25 @@ is `0.98 / sqrt(n)`:
 | 224 | ±6.5 pts | warm figure at default `max_turns` 5 |
 | 336 | ±5.3 pts | all samples pooled, default run |
 
-So a default run separates models differing by roughly 7 points or more on the warm figure,
-and places everything else in a tier. It cannot rank close neighbours, and no run option
-changes that — the sample is already every conversation in the release. An earlier
-40-moment run put Opus 4.8 and Sonnet 4.6 0.55s apart at p50 while paired they split
-39/80: 48.7%, CI [37.8%, 59.7%].
+So a default run separates models differing by roughly 6 points or more, and places everything
+else in a tier. It cannot rank arbitrarily close neighbours, and no run option changes that —
+the sample is already every conversation in the release.
+
+On the 2026-08-18 roster the full sample resolves every adjacent pair, including the two
+closest:
+
+| pair | p50 gap | paired win rate | verdict |
+|---|---|---|---|
+| `gemini-3.5-flash` vs `gpt-5.5` | 0.87s | flash faster on 57.1% ±5.3 | separated, barely |
+| `claude-sonnet-4-6` vs `claude-opus-4-8` | 0.57s | Sonnet faster on 60.4% ±5.3 | separated |
+| `gpt-5.4-mini` vs `gpt-5.5` | 3.22s | mini faster on 91.7% ±5.3 | separated |
+
+The middle row is the one to keep in mind. A 0.57s p50 gap between two models whose p5–p95
+spans are 18–24 seconds wide looks like noise, and on the 40-moment pilot it was: Opus came
+out ahead on 48.7% of pairs, CI [37.8%, 59.7%], a coin flip. At 336 samples the same pairing
+lands at 60.4% ±5.3 for Sonnet — the ranking was real, the pilot simply could not see it. The
+first row is now the limiting case: 57.1% ±5.3 clears 50% with 1.8 points to spare, so a pair
+this close is at the edge of what this benchmark can resolve, not comfortably inside it.
 
 Reporting one model as faster than another means checking the paired win rate, not the p50
 gap, and treating an interval that straddles 50% as a tie.
@@ -400,16 +568,22 @@ Sanity checks that should hold on any live run:
   4,096-token minimum that `claude-opus-4-6` and `claude-haiku-4-5` impose (1% below the
   1,024-token one). So ~0.45 at `max_turns` 5 is normal on those two models and ~0.67 on the
   rest. A rate *above* the ceiling, or far below it on a model with a low minimum, means the
-  cache is behaving differently than assumed.
+  cache is behaving differently than assumed. Observed on the roster: 0.667 and 0.661 on the
+  two Anthropic models (the ceiling, as expected), 0.649 and 0.586 on OpenAI, and **0.786 on
+  DeepSeek — above the ceiling**, which is the automatic-prefix-cache signature rather than a
+  session cache.
 - `ttfc` well below `ttft` on thinking models, and near-equal on the OpenAI path, where
   reasoning is not streamed. Reported in the same cache-state split as the headline
-  metrics, so this reads straight off the block.
+  metrics, so this reads straight off the block. Observed: thinking is 2.1× to 14.1× `ttfc` on
+  the five models that stream it, and `ttft − ttfc` is 0.02s or less on both OpenAI models.
 
-**Do not expect warm to be much faster than cold.** Measured across the roster, the warm
-TTFT gain is ~1–3.6s on Anthropic and *negative* on `gpt-5.5` (6.57 warm vs 6.39 cold).
-Prompt caching skips prefill, and prefill is not the bottleneck: `ttfc` moves by ~0.04s
-between cold and warm on Opus 4.8. On thinking models TTFT is dominated by thinking time by
-roughly 7×. Caching remains a ~90% cost lever; it is close to irrelevant for latency.
+**Do not read the warm figure as the effect of caching.** Measured across the roster the warm
+gain is 1.0–5.2s, but on Opus 4.8 — the largest of them — prefill (`ttfc`) is identical cold
+and warm to within a millisecond, and the whole gap is the model thinking less on a
+continuation than on a fresh problem. See
+[caching does not systematically improve latency](#caching-does-not-systematically-improve-latency)
+for the decomposition. Caching remains a ~90% cost lever; as a latency lever it is worth
+fractions of a second.
 
 One note when comparing against the June 2026 Preview paper: its figures use
 `tutor_latencies`, which is end-to-end wall-clock seconds per call and is **unchanged** by

--- a/src/tutormoments/cli.py
+++ b/src/tutormoments/cli.py
@@ -1106,23 +1106,52 @@ def _cmd_report(args) -> None:
         if summary is None:
             logger.warning("No summary.json for run %s -- skipping", run_id)
             continue
-        # Inject run_id-derived fields if not already present
-        if "tutor_model" not in summary or not summary.get("tutor_model"):
-            # Best-effort: parse tutor from run_id prefix
+        # Identify the cell. Runs from before the summary carried these fields
+        # need them recovered, and the recovery has to be exact: (tutor_model,
+        # mode) is the key the TTFT probe figures join on, and it is also what
+        # the mode column prints.
+        if not summary.get("tutor_model") or not summary.get("mode"):
+            # config.json records both verbatim, so prefer it over the run id.
+            cfg_json = results.read_config(run_id, results_root=args.results_root) or {}
+            # Last resort: split the run id. Lossy -- make_run_id joins
+            # {tutor}_{mode}_{dataset}_{date} with underscores that also occur
+            # inside a tutor id ("deepseek-ai/DeepSeek-V4-Pro" becomes
+            # "deepseek-ai_DeepSeek-V4-Pro") and inside a mode
+            # ("scaffolding_rigor"), so this can only be trusted to find a
+            # first field. A mode read this way is a prefix of the real one,
+            # which is why it must not be the first choice: it silently misses
+            # the probe join and mislabels the row.
             parts = run_id.split("_")
             summary = dict(summary)
-            summary.setdefault("tutor_model", parts[0] if parts else run_id)
-        if "mode" not in summary or not summary.get("mode"):
-            parts = run_id.split("_")
-            summary = dict(summary)
-            summary.setdefault("mode", parts[1] if len(parts) > 1 else "")
+            if not summary.get("tutor_model"):
+                summary["tutor_model"] = cfg_json.get("tutor") or (
+                    parts[0] if parts else run_id
+                )
+            if not summary.get("mode"):
+                summary["mode"] = cfg_json.get("mode") or (
+                    parts[1] if len(parts) > 1 else ""
+                )
         summaries.append(summary)
 
     if not summaries:
         print("No run summaries found in: " + args.results_root)
         return
 
-    markdown, csv_str = report.leaderboard(summaries)
+    # Join the serial-probe TTFT figures onto the run summaries. Probes write
+    # their own run directories under the same results root; nothing else
+    # reads them.
+    probes = latency.probe_runs(args.results_root)
+    sample_ids = {i for i in latency.probe_subsample_ids(probes) if i}
+    if len(sample_ids) > 1:
+        logger.warning(
+            "TTFT columns mix %d latency subsamples (%s); those figures were "
+            "measured over different prompts and are not comparable to each "
+            "other -- re-measure the roster against one subsample",
+            len(sample_ids),
+            ", ".join(sorted(sample_ids)),
+        )
+
+    markdown, csv_str = report.leaderboard(summaries, probes)
 
     out_stem = args.out
     md_path = Path(out_stem + ".md")

--- a/src/tutormoments/latency.py
+++ b/src/tutormoments/latency.py
@@ -206,6 +206,111 @@ def warm_figure_is_publishable(block: dict) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Reading probe results back (leaderboard + website join)
+# ---------------------------------------------------------------------------
+
+
+def probe_figures(block: dict) -> dict:
+    """The publishable TTFT/TTLT p50s from one probe's ``latency.json``.
+
+    Returns ``ttft_p50`` / ``ttlt_p50`` (pooled over all samples) plus the
+    cold and warm halves, which are ``None`` unless the cache split can be
+    trusted.
+
+    Pooled is always populated: it is measured identically on every provider,
+    whatever that provider reports about caching, so it is the only figure
+    that ranks the whole roster. The split refines it where cache state is
+    knowable.
+
+    **The split is published as a unit or not at all.** The obvious reading is
+    that `warm_figure_is_publishable` guards only the warm number, but its
+    three conditions establish that this provider's hit/miss labels mean
+    session warmth at all -- and a label that cannot be trusted for the hits
+    cannot be trusted for their complement either. Concretely: Together's
+    "misses" are the calls its automatic prefix cache happened not to serve,
+    which cluster at run start rather than at session start, and on the pilot
+    that put its cold p50 at 15.03s against a pooled 7.94s. Publishing that as
+    "first message of a session" would be wrong in the same way publishing its
+    warm figure would be.
+
+    The probe's own terminal summary is deliberately looser -- it prints the
+    cold figure with a NOTE explaining why warm was withheld, because there it
+    is a diagnostic read by whoever just ran the probe. These figures go into
+    the leaderboard and onto the website, where they are read without that
+    context.
+    """
+    ttft = block.get("ttft") or {}
+    ttlt = block.get("ttlt") or {}
+
+    def _p50(metric: dict, state: str):
+        return (metric.get(state) or {}).get("p50_seconds")
+
+    split_ok = warm_figure_is_publishable(block)
+    return {
+        "ttft_p50": _p50(ttft, "all"),
+        "ttlt_p50": _p50(ttlt, "all"),
+        "ttft_cold_p50": _p50(ttft, "miss") if split_ok else None,
+        "ttft_warm_p50": _p50(ttft, "hit") if split_ok else None,
+    }
+
+
+def probe_runs(results_root: str = "results") -> dict:
+    """Latest comparable probe result per ``(tutor_model, mode)``.
+
+    Scans *results_root* for run directories carrying a ``latency.json`` and
+    returns ``{(tutor_model, mode): block}``. This is the join the leaderboard
+    and the website both need: a probe writes its own run directory, which
+    nothing else reads.
+
+    Only probes that measured a **frozen** subsample **in full** are eligible.
+    A derived sample spans no particular prompt-length distribution and is
+    comparable to nothing; an incomplete one dropped ids, so it is not the
+    same sample as the run before it. Neither belongs in a table that invites
+    cross-model comparison.
+
+    Among eligible probes for one cell the newest by ``measured_at`` wins, so
+    re-measuring a model supersedes its earlier figure without anyone having
+    to delete the old run. Callers that publish several cells should check the
+    selected blocks agree on ``subsample_id``: eligibility is per-probe, and
+    two frozen-but-different samples would each pass it (see
+    `probe_subsample_ids`).
+    """
+    out: dict[tuple[str, str], dict] = {}
+    best_key: dict[tuple[str, str], tuple] = {}
+
+    for run_id in results.list_runs(results_root):
+        block = results.read_latency(run_id, results_root=results_root)
+        if not block:
+            continue
+        sub = block.get("subsample") or {}
+        if not str(sub.get("subsample_source", "")).startswith("frozen"):
+            continue
+        if not sub.get("subsample_complete", False):
+            continue
+        cell = (block.get("tutor_model", ""), block.get("mode", ""))
+        env = block.get("measurement_environment") or {}
+        # measured_at then run_id: a run directory written without a timestamp
+        # still orders deterministically instead of depending on scan order.
+        rank = (env.get("measured_at") or "", run_id)
+        if cell not in best_key or rank > best_key[cell]:
+            best_key[cell] = rank
+            out[cell] = block
+    return out
+
+
+def probe_subsample_ids(probes: dict) -> set:
+    """The distinct ``subsample_id`` values across selected probe blocks.
+
+    More than one means the figures were measured over different prompt sets
+    and must not be printed in one table -- the point of the id is that this
+    is visible rather than quietly averaged.
+    """
+    return {
+        (block.get("subsample") or {}).get("subsample_id") for block in probes.values()
+    }
+
+
+# ---------------------------------------------------------------------------
 # Subsample resolution
 # ---------------------------------------------------------------------------
 

--- a/src/tutormoments/latency.py
+++ b/src/tutormoments/latency.py
@@ -213,44 +213,54 @@ def warm_figure_is_publishable(block: dict) -> bool:
 def probe_figures(block: dict) -> dict:
     """The publishable TTFT/TTLT p50s from one probe's ``latency.json``.
 
-    Returns ``ttft_p50`` / ``ttlt_p50`` (pooled over all samples) plus the
-    cold and warm halves, which are ``None`` unless the cache split can be
-    trusted.
+    Takes the whole latency.json dict. Returns ``ttft_p50`` / ``ttlt_p50``
+    (pooled over all samples) plus ``ttft_first_p50`` / ``ttft_later_p50`` —
+    the first message of a session (turn 1) against the later ones (turns 3
+    and 5).
 
-    Pooled is always populated: it is measured identically on every provider,
-    whatever that provider reports about caching, so it is the only figure
-    that ranks the whole roster. The split refines it where cache state is
-    knowable.
+    Pooled is the ranking figure: one number per model, measured identically
+    on every provider. The first/later split refines it, and it keys on
+    **turn position, not cache state**. Turn position is ground truth the
+    probe itself recorded, so the split exists for every provider — including
+    the ones that report no cache tokens — and needs no publishability gate.
+    A cache-state split would need one (`warm_figure_is_publishable`), and
+    even where it passes it answers a subtly different question: a "cold"
+    bucket holds every call whose cache missed, which on a provider with
+    silent cache failures includes later-turn calls. Measured on `gpt-5.5`,
+    that diluted the cache-based cold p50 to 6.91s when the actual
+    first-message p50 was 7.53s.
 
-    **The split is published as a unit or not at all.** The obvious reading is
-    that `warm_figure_is_publishable` guards only the warm number, but its
-    three conditions establish that this provider's hit/miss labels mean
-    session warmth at all -- and a label that cannot be trusted for the hits
-    cannot be trusted for their complement either. Concretely: Together's
-    "misses" are the calls its automatic prefix cache happened not to serve,
-    which cluster at run start rather than at session start, and on the pilot
-    that put its cold p50 at 15.03s against a pooled 7.94s. Publishing that as
-    "first message of a session" would be wrong in the same way publishing its
-    warm figure would be.
+    What the split measures is the position effect — mostly the model
+    thinking less on a continuation than on a fresh problem, plus whatever
+    caching contributes where the harness caches (see docs/latency.md). The
+    cache-state aggregates stay in the block for that diagnostic.
 
-    The probe's own terminal summary is deliberately looser -- it prints the
-    cold figure with a NOTE explaining why warm was withheld, because there it
-    is a diagnostic read by whoever just ran the probe. These figures go into
-    the leaderboard and onto the website, where they are read without that
-    context.
+    Computed from ``samples`` rather than a stored aggregate so any probe's
+    latency.json can be read back, including ones written before this split
+    existed. Samples that produced no visible token have no TTFT and are
+    excluded, same as everywhere else.
     """
-    ttft = block.get("ttft") or {}
-    ttlt = block.get("ttlt") or {}
+    tutor = block.get("tutor") or {}
+    ttft = tutor.get("ttft") or {}
+    ttlt = tutor.get("ttlt") or {}
 
-    def _p50(metric: dict, state: str):
-        return (metric.get(state) or {}).get("p50_seconds")
+    def _p50(metric: dict) -> float | None:
+        return (metric.get("all") or {}).get("p50_seconds")
 
-    split_ok = warm_figure_is_publishable(block)
+    def _turn_p50(pred) -> float | None:
+        vals = [
+            s["ttft_seconds"]
+            for s in block.get("samples") or []
+            if s.get("ttft_seconds") is not None and pred(s.get("turn_index"))
+        ]
+        stats = latency_stats(vals)
+        return stats["p50_seconds"] if stats else None
+
     return {
-        "ttft_p50": _p50(ttft, "all"),
-        "ttlt_p50": _p50(ttlt, "all"),
-        "ttft_cold_p50": _p50(ttft, "miss") if split_ok else None,
-        "ttft_warm_p50": _p50(ttft, "hit") if split_ok else None,
+        "ttft_p50": _p50(ttft),
+        "ttlt_p50": _p50(ttlt),
+        "ttft_first_p50": _turn_p50(lambda t: t == 0),
+        "ttft_later_p50": _turn_p50(lambda t: isinstance(t, int) and t > 0),
     }
 
 

--- a/src/tutormoments/report.py
+++ b/src/tutormoments/report.py
@@ -192,14 +192,29 @@ _LEADERBOARD_COLS = [
     ("appropriate_scaffolding", "appropriate_scaffolding"),
     ("appropriate_rigor", "appropriate_rigor"),
     ("avoids_overscaffold", "avoids_overscaffold"),
+    # From `tutormoments latency` (serial probe), joined on (tutor_model,
+    # mode). ttft_p50 is the headline: pooled over all samples, the only
+    # figure measured identically on every provider. The cold/warm split is
+    # dashed unless the provider's cache labels mean session warmth.
+    ("ttft_p50", "ttft_p50"),
+    ("ttft_cold_p50", "ttft_cold_p50"),
+    ("ttft_warm_p50", "ttft_warm_p50"),
+    # From the benchmark run: end-to-end wall clock under --concurrency, so
+    # comparable within a model over time but not across models.
     ("tutor_lat_p50", "tutor_lat_p50"),
     ("tutor_lat_p95", "tutor_lat_p95"),
     ("tokens_total", "tokens_total"),
 ]
 
 
-def _extract_row(summary: dict) -> dict:
-    """Pull the leaderboard-column values out of a run summary dict."""
+def _extract_row(summary: dict, probes: dict | None = None) -> dict:
+    """Pull the leaderboard-column values out of a run summary dict.
+
+    *probes* is ``{(tutor_model, mode): latency.json block}`` from
+    `tutormoments.latency.probe_runs`; a cell with no probe gets ``None`` TTFT
+    columns rather than a figure borrowed from the run, which was gathered
+    under concurrency and means something else.
+    """
     cal_s = summary.get("scaffold_calibrated") or {}
     cal_r = summary.get("rigor_calibrated") or {}
     over = summary.get("overscaffold") or {}
@@ -209,13 +224,28 @@ def _extract_row(summary: dict) -> dict:
     over_rate = over.get("rate")
     avoids = (1.0 - over_rate) if isinstance(over_rate, (int, float)) else None
 
+    tutor_model = summary.get("tutor_model", "")
+    mode = summary.get("mode", "")
+    # Lazy: this module keeps no module-level SDK imports, and the latency
+    # module reaches the provider clients.
+    from tutormoments.latency import probe_figures  # noqa: PLC0415
+
+    probe = (probes or {}).get((tutor_model, mode))
+    ttft = probe_figures((probe or {}).get("tutor") or {})
+
     return {
-        "tutor_model": summary.get("tutor_model", ""),
-        "mode": summary.get("mode", ""),
+        "tutor_model": tutor_model,
+        "mode": mode,
         "n": summary.get("n_scenarios", 0),
         "appropriate_scaffolding": cal_s.get("score"),
         "appropriate_rigor": cal_r.get("score"),
         "avoids_overscaffold": avoids,
+        # Absent unless this cell has a probe run: a benchmark run records
+        # TTFT too, but under --concurrency, which distorts it by a
+        # model-dependent amount. See docs/latency.md.
+        "ttft_p50": ttft["ttft_p50"],
+        "ttft_cold_p50": ttft["ttft_cold_p50"],
+        "ttft_warm_p50": ttft["ttft_warm_p50"],
         # End-to-end wall-clock seconds per tutor turn; unaffected by
         # streaming, so historical and new runs stay comparable.
         "tutor_lat_p50": lat.get("p50_seconds"),
@@ -244,33 +274,44 @@ def _fmt_csv(v) -> str:
     return str(v)
 
 
-def leaderboard(runs: list) -> tuple:
+def leaderboard(runs: list, probes: dict | None = None) -> tuple:
     """Build a leaderboard Markdown table and CSV from a list of run summaries.
 
     Args:
         runs: list of run summary dicts (as returned by aggregate / read from
               summary.json).  Each dict must contain the standard keys written
               by the benchmark pipeline.
+        probes: optional ``{(tutor_model, mode): latency.json block}`` from
+              `tutormoments.latency.probe_runs`, supplying the TTFT columns.
+              Cells with no probe show "-".
 
     Returns:
         (markdown_table: str, csv_str: str)
 
     Columns (the paper's three metrics under the paper's names, plus
-    identity and latency/token diagnostics):
+    identity, TTFT, and latency/token diagnostics):
         tutor_model, mode, n, appropriate_scaffolding, appropriate_rigor,
-        avoids_overscaffold, tutor_lat_p50, tutor_lat_p95, tokens_total
+        avoids_overscaffold, ttft_p50, ttft_cold_p50, ttft_warm_p50,
+        tutor_lat_p50, tutor_lat_p95, tokens_total
 
-    Latency here is end-to-end wall-clock seconds per tutor call, gathered
-    under `--concurrency` and therefore not comparable across models. TTFT is
-    deliberately absent: the comparable figure comes from `tutormoments
-    latency`, which writes its own latency.json that nothing joins onto these
-    summaries yet. See docs/latency.md.
+    Two different latency measurements sit side by side here, deliberately:
+
+    - ``ttft_p50`` and its cold/warm split come from `tutormoments latency`,
+      which runs strictly serially. These are the cross-model-comparable
+      figures, and they are joined in from a probe's own run directory rather
+      than read off the benchmark run.
+    - ``tutor_lat_p50`` / ``tutor_lat_p95`` are end-to-end wall clock per
+      tutor call from the benchmark run itself, gathered under
+      ``--concurrency``, so they compare a model against its own history but
+      not against another model.
+
+    See docs/latency.md.
 
     Rows sorted descending by appropriate_scaffolding (None last).
     avoids_overscaffold = 1 - overscaffold["rate"]  (higher is better).
     Floats formatted to 3 decimal places; None -> "-" (md) / "" (csv).
     """
-    rows = [_extract_row(s) for s in runs]
+    rows = [_extract_row(s, probes) for s in runs]
 
     def _sort_key(r):
         v = r.get("appropriate_scaffolding")

--- a/src/tutormoments/report.py
+++ b/src/tutormoments/report.py
@@ -193,12 +193,13 @@ _LEADERBOARD_COLS = [
     ("appropriate_rigor", "appropriate_rigor"),
     ("avoids_overscaffold", "avoids_overscaffold"),
     # From `tutormoments latency` (serial probe), joined on (tutor_model,
-    # mode). ttft_p50 is the headline: pooled over all samples, the only
-    # figure measured identically on every provider. The cold/warm split is
-    # dashed unless the provider's cache labels mean session warmth.
+    # mode). ttft_p50 is the headline: pooled over all samples, one number per
+    # model. first/later split on turn position -- the first message of a
+    # session against turns 3 and 5 -- which is ground truth on every
+    # provider, unlike cache state.
     ("ttft_p50", "ttft_p50"),
-    ("ttft_cold_p50", "ttft_cold_p50"),
-    ("ttft_warm_p50", "ttft_warm_p50"),
+    ("ttft_first_p50", "ttft_first_p50"),
+    ("ttft_later_p50", "ttft_later_p50"),
     # From the benchmark run: end-to-end wall clock under --concurrency, so
     # comparable within a model over time but not across models.
     ("tutor_lat_p50", "tutor_lat_p50"),
@@ -230,8 +231,7 @@ def _extract_row(summary: dict, probes: dict | None = None) -> dict:
     # module reaches the provider clients.
     from tutormoments.latency import probe_figures  # noqa: PLC0415
 
-    probe = (probes or {}).get((tutor_model, mode))
-    ttft = probe_figures((probe or {}).get("tutor") or {})
+    ttft = probe_figures((probes or {}).get((tutor_model, mode)) or {})
 
     return {
         "tutor_model": tutor_model,
@@ -244,8 +244,8 @@ def _extract_row(summary: dict, probes: dict | None = None) -> dict:
         # TTFT too, but under --concurrency, which distorts it by a
         # model-dependent amount. See docs/latency.md.
         "ttft_p50": ttft["ttft_p50"],
-        "ttft_cold_p50": ttft["ttft_cold_p50"],
-        "ttft_warm_p50": ttft["ttft_warm_p50"],
+        "ttft_first_p50": ttft["ttft_first_p50"],
+        "ttft_later_p50": ttft["ttft_later_p50"],
         # End-to-end wall-clock seconds per tutor turn; unaffected by
         # streaming, so historical and new runs stay comparable.
         "tutor_lat_p50": lat.get("p50_seconds"),
@@ -291,15 +291,15 @@ def leaderboard(runs: list, probes: dict | None = None) -> tuple:
     Columns (the paper's three metrics under the paper's names, plus
     identity, TTFT, and latency/token diagnostics):
         tutor_model, mode, n, appropriate_scaffolding, appropriate_rigor,
-        avoids_overscaffold, ttft_p50, ttft_cold_p50, ttft_warm_p50,
+        avoids_overscaffold, ttft_p50, ttft_first_p50, ttft_later_p50,
         tutor_lat_p50, tutor_lat_p95, tokens_total
 
     Two different latency measurements sit side by side here, deliberately:
 
-    - ``ttft_p50`` and its cold/warm split come from `tutormoments latency`,
-      which runs strictly serially. These are the cross-model-comparable
-      figures, and they are joined in from a probe's own run directory rather
-      than read off the benchmark run.
+    - ``ttft_p50`` and its first/later-message split come from `tutormoments
+      latency`, which runs strictly serially. These are the
+      cross-model-comparable figures, and they are joined in from a probe's
+      own run directory rather than read off the benchmark run.
     - ``tutor_lat_p50`` / ``tutor_lat_p95`` are end-to-end wall clock per
       tutor call from the benchmark run itself, gathered under
       ``--concurrency``, so they compare a model against its own history but

--- a/tests/tutormoments/test_cli.py
+++ b/tests/tutormoments/test_cli.py
@@ -829,6 +829,154 @@ def test_report_writes_leaderboard_md_and_csv(tmp_path):
     assert len(csv_lines) == 3, f"Expected header + 2 rows, got: {csv_lines}"
 
 
+def _make_probe_run(root: Path, run_id: str, tutor_model: str, mode: str) -> None:
+    """Write a minimal `tutormoments latency` result inside root/run_id/."""
+    run_dir = root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "latency.json").write_text(
+        json.dumps(
+            {
+                "source": "probe",
+                "tutor_model": tutor_model,
+                "mode": mode,
+                "tutor": {
+                    "cache_hit_rate": 0.667,
+                    "cache_read_p50_on_hits": 9390,
+                    "ttft": {
+                        "all": {"n": 336, "p50_seconds": 9.043},
+                        "miss": {"n": 112, "p50_seconds": 13.217},
+                        "hit": {"n": 224, "p50_seconds": 7.993},
+                    },
+                    "ttlt": {"all": {"n": 336, "p50_seconds": 10.52}},
+                },
+                "subsample": {
+                    "subsample_source": "frozen_packaged",
+                    "subsample_id": "589e8acf8ac761f2",
+                    "subsample_complete": True,
+                },
+                "measurement_environment": {"measured_at": "2026-08-18T14:21:39"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_report_joins_probe_ttft_onto_the_matching_run(tmp_path):
+    """End to end: a probe run sitting beside a benchmark run in the same
+    results root fills that cell's TTFT columns, and only that cell's."""
+    from tutormoments.cli import main
+
+    results_root = tmp_path / "results"
+    _make_fake_run(
+        results_root,
+        "model-alpha_scaffolding_rigor_ds_20260818",
+        "model-alpha",
+        "scaffolding_rigor",
+    )
+    _make_fake_run(
+        results_root, "model-alpha_plain_ds_20260818", "model-alpha", "plain"
+    )
+    _make_probe_run(
+        results_root,
+        "model-alpha_scaffolding_rigor_latency_20260818",
+        "model-alpha",
+        "scaffolding_rigor",
+    )
+
+    out_stem = str(tmp_path / "leaderboard")
+    main(["report", "--results-root", str(results_root), "--out", out_stem])
+
+    rows = {
+        line.split("|")[2].strip(): line
+        for line in (tmp_path / "leaderboard.md").read_text("utf-8").splitlines()
+        if line.startswith("| model-alpha")
+    }
+    assert "9.043" in rows["scaffolding_rigor"]
+    assert "13.217" in rows["scaffolding_rigor"]
+    assert "9.043" not in rows["plain"]
+
+
+def test_report_recovers_the_cell_from_config_not_the_run_id(tmp_path):
+    """Runs predating tutor_model/mode in summary.json must still join. The run
+    id cannot supply the mode: make_run_id joins fields with underscores that
+    occur inside a mode too, so splitting it yields "scaffolding" for
+    "scaffolding_rigor" -- which would silently miss the probe."""
+    from tutormoments.cli import main
+
+    results_root = tmp_path / "results"
+    run_id = "claude-opus-4-8_scaffolding_rigor_tutormoments-preview_20260807"
+    _make_fake_run(results_root, run_id, "claude-opus-4-8", "scaffolding_rigor")
+    summary_path = results_root / run_id / "summary.json"
+    summary = json.loads(summary_path.read_text("utf-8"))
+    del summary["tutor_model"]
+    del summary["mode"]
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    (results_root / run_id / "config.json").write_text(
+        json.dumps({"tutor": "claude-opus-4-8", "mode": "scaffolding_rigor"}),
+        encoding="utf-8",
+    )
+    _make_probe_run(
+        results_root,
+        "claude-opus-4-8_scaffolding_rigor_latency_20260818",
+        "claude-opus-4-8",
+        "scaffolding_rigor",
+    )
+
+    out_stem = str(tmp_path / "leaderboard")
+    main(["report", "--results-root", str(results_root), "--out", out_stem])
+
+    row = next(
+        line
+        for line in (tmp_path / "leaderboard.md").read_text("utf-8").splitlines()
+        if line.startswith("| claude-opus-4-8")
+    )
+    assert "| scaffolding_rigor |" in row
+    assert "9.043" in row
+
+
+def test_report_warns_when_probes_mix_subsamples(tmp_path, caplog):
+    """Two frozen-but-different samples each pass per-probe eligibility, so the
+    table would compare figures measured over different prompts."""
+    from tutormoments.cli import main
+
+    results_root = tmp_path / "results"
+    _make_fake_run(
+        results_root,
+        "model-alpha_scaffolding_rigor_ds_20260818",
+        "model-alpha",
+        "scaffolding_rigor",
+    )
+    _make_probe_run(
+        results_root,
+        "model-alpha_scaffolding_rigor_latency_20260818",
+        "model-alpha",
+        "scaffolding_rigor",
+    )
+    _make_probe_run(
+        results_root,
+        "model-beta_scaffolding_rigor_latency_20260817",
+        "model-beta",
+        "scaffolding_rigor",
+    )
+    stale = results_root / "model-beta_scaffolding_rigor_latency_20260817"
+    block = json.loads((stale / "latency.json").read_text("utf-8"))
+    block["subsample"]["subsample_id"] = "84b4ad5615876a3e"
+    (stale / "latency.json").write_text(json.dumps(block), encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        main(
+            [
+                "report",
+                "--results-root",
+                str(results_root),
+                "--out",
+                str(tmp_path / "leaderboard"),
+            ]
+        )
+
+    assert "mix 2 latency subsamples" in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # Test 8: view subcommand writes non-empty HTML
 # ---------------------------------------------------------------------------

--- a/tests/tutormoments/test_cli.py
+++ b/tests/tutormoments/test_cli.py
@@ -840,15 +840,15 @@ def _make_probe_run(root: Path, run_id: str, tutor_model: str, mode: str) -> Non
                 "tutor_model": tutor_model,
                 "mode": mode,
                 "tutor": {
-                    "cache_hit_rate": 0.667,
-                    "cache_read_p50_on_hits": 9390,
-                    "ttft": {
-                        "all": {"n": 336, "p50_seconds": 9.043},
-                        "miss": {"n": 112, "p50_seconds": 13.217},
-                        "hit": {"n": 224, "p50_seconds": 7.993},
-                    },
+                    "ttft": {"all": {"n": 336, "p50_seconds": 9.043}},
                     "ttlt": {"all": {"n": 336, "p50_seconds": 10.52}},
                 },
+                "samples": [
+                    {"ttft_seconds": 13.217, "turn_index": 0},
+                    {"ttft_seconds": 7.9, "turn_index": 1},
+                    {"ttft_seconds": 7.993, "turn_index": 1},
+                    {"ttft_seconds": 8.1, "turn_index": 2},
+                ],
                 "subsample": {
                     "subsample_source": "frozen_packaged",
                     "subsample_id": "589e8acf8ac761f2",

--- a/tests/tutormoments/test_latency.py
+++ b/tests/tutormoments/test_latency.py
@@ -687,6 +687,21 @@ def _probe_tutor_block(
     }
 
 
+def _probe_samples(first=(12.0, 13.0, 14.0), later=(7.0, 8.0, 9.0)):
+    """Tutor samples spanning both turn positions."""
+    rows = [{"ttft_seconds": v, "turn_index": 0} for v in first]
+    rows += [{"ttft_seconds": v, "turn_index": 1 + i % 2} for i, v in enumerate(later)]
+    return rows
+
+
+def _probe_block(tutor_block=None, samples=None):
+    """A whole latency.json dict, as probe_figures takes it."""
+    return {
+        "tutor": tutor_block or _probe_tutor_block(),
+        "samples": _probe_samples() if samples is None else samples,
+    }
+
+
 def _write_probe(
     root: Path,
     run_id: str,
@@ -708,6 +723,7 @@ def _write_probe(
                 "tutor_model": tutor,
                 "mode": mode,
                 "tutor": tutor_block or _probe_tutor_block(),
+                "samples": _probe_samples(),
                 "subsample": {
                     "subsample_source": source,
                     "subsample_id": sub_id,
@@ -724,34 +740,57 @@ def _write_probe(
 def test_probe_figures_always_publishes_the_pooled_number():
     """Pooled TTFT is measured identically on every provider, so it is the one
     figure that can rank the whole roster."""
-    figs = probe_figures(_probe_tutor_block(cache_hit_rate=None, cache_read=None))
+    figs = probe_figures(
+        _probe_block(_probe_tutor_block(cache_hit_rate=None, cache_read=None))
+    )
     assert figs["ttft_p50"] == 9.0
     assert figs["ttlt_p50"] == 10.0
 
 
-def test_probe_figures_publishes_the_split_when_the_cache_is_real():
-    figs = probe_figures(_probe_tutor_block())
-    assert figs["ttft_cold_p50"] == 12.0
-    assert figs["ttft_warm_p50"] == 8.0
+def test_probe_figures_splits_on_turn_position_not_cache_state():
+    """First/later keys on turn_index, which the probe recorded itself. A
+    cache-state split needs a publishability gate and, even where it passes,
+    dilutes the first-message bucket with later-turn calls whose cache
+    silently missed (measured on gpt-5.5: cache-based cold p50 6.91s against
+    an actual first-message p50 of 7.53s)."""
+    figs = probe_figures(_probe_block())
+    assert figs["ttft_first_p50"] == 13.0  # p50 of (12, 13, 14) -- turn 0
+    assert figs["ttft_later_p50"] == 8.0  # p50 of (7, 8, 9) -- turns 1 and 2
 
 
-def test_probe_figures_withholds_cold_as_well_as_warm():
-    """The gate establishes that hit/miss labels mean session warmth at all.
-    Together's misses are the calls its automatic prefix cache happened not to
-    serve -- clustered at run start, not session start -- so publishing them as
-    a cold figure is wrong in the same way publishing its warm figure is."""
-    figs = probe_figures(_probe_tutor_block(cache_read=256))
-    assert figs["ttft_p50"] == 9.0
-    assert figs["ttft_cold_p50"] is None
-    assert figs["ttft_warm_p50"] is None
+def test_probe_figures_splits_for_a_provider_reporting_no_cache_tokens():
+    """The point of the turn split: Gemini reports no cache tokens, so a
+    cache-state split cannot exist for it -- but its first/later figures are
+    as real as anyone's."""
+    figs = probe_figures(
+        _probe_block(_probe_tutor_block(cache_hit_rate=None, cache_read=None))
+    )
+    assert figs["ttft_first_p50"] == 13.0
+    assert figs["ttft_later_p50"] == 8.0
+
+
+def test_probe_figures_excludes_samples_with_no_visible_output():
+    """A call that produced no visible token has no TTFT and must not enter a
+    position bucket."""
+    samples = _probe_samples() + [{"ttft_seconds": None, "turn_index": 0}]
+    figs = probe_figures(_probe_block(samples=samples))
+    assert figs["ttft_first_p50"] == 13.0
+
+
+def test_probe_figures_reads_old_files_without_a_stored_split():
+    """The split is computed from `samples`, which every probe has always
+    written -- a latency.json from before the split existed still yields one."""
+    block = _probe_block()
+    assert "ttft_first_p50" not in json.dumps(block)  # nothing precomputed
+    assert probe_figures(block)["ttft_first_p50"] == 13.0
 
 
 def test_probe_figures_tolerates_an_absent_probe():
     assert probe_figures({}) == {
         "ttft_p50": None,
         "ttlt_p50": None,
-        "ttft_cold_p50": None,
-        "ttft_warm_p50": None,
+        "ttft_first_p50": None,
+        "ttft_later_p50": None,
     }
 
 

--- a/tests/tutormoments/test_latency.py
+++ b/tests/tutormoments/test_latency.py
@@ -18,6 +18,9 @@ from tutormoments.latency import (
     aggregate_timings,
     format_probe_summary,
     latency_stats,
+    probe_figures,
+    probe_runs,
+    probe_subsample_ids,
     resolve_subsample,
     run_probe,
     warm_figure_is_publishable,
@@ -656,3 +659,171 @@ def test_withheld_reason_follows_the_gate_order():
         ]
     )
     assert "incidental shared prefix" in withheld_reason(incidental)
+
+
+# ---------------------------------------------------------------------------
+# Reading probe results back: probe_figures / probe_runs
+# ---------------------------------------------------------------------------
+
+
+def _probe_tutor_block(
+    *,
+    p50_all=9.0,
+    p50_miss=12.0,
+    p50_hit=8.0,
+    cache_hit_rate=0.5,
+    cache_read=8000,
+    n_hits=40,
+):
+    return {
+        "cache_hit_rate": cache_hit_rate,
+        "cache_read_p50_on_hits": cache_read,
+        "ttft": {
+            "all": {"n": 112, "p50_seconds": p50_all},
+            "miss": {"n": 40, "p50_seconds": p50_miss},
+            "hit": {"n": n_hits, "p50_seconds": p50_hit},
+        },
+        "ttlt": {"all": {"n": 112, "p50_seconds": p50_all + 1.0}},
+    }
+
+
+def _write_probe(
+    root: Path,
+    run_id: str,
+    *,
+    tutor="model-a",
+    mode="scaffolding_rigor",
+    measured_at="2026-08-18T10:00:00",
+    source="frozen_packaged",
+    complete=True,
+    sub_id="589e8acf8ac761f2",
+    tutor_block=None,
+):
+    run = root / run_id
+    run.mkdir(parents=True)
+    (run / "latency.json").write_text(
+        json.dumps(
+            {
+                "source": "probe",
+                "tutor_model": tutor,
+                "mode": mode,
+                "tutor": tutor_block or _probe_tutor_block(),
+                "subsample": {
+                    "subsample_source": source,
+                    "subsample_id": sub_id,
+                    "subsample_complete": complete,
+                },
+                "measurement_environment": {"measured_at": measured_at},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return run
+
+
+def test_probe_figures_always_publishes_the_pooled_number():
+    """Pooled TTFT is measured identically on every provider, so it is the one
+    figure that can rank the whole roster."""
+    figs = probe_figures(_probe_tutor_block(cache_hit_rate=None, cache_read=None))
+    assert figs["ttft_p50"] == 9.0
+    assert figs["ttlt_p50"] == 10.0
+
+
+def test_probe_figures_publishes_the_split_when_the_cache_is_real():
+    figs = probe_figures(_probe_tutor_block())
+    assert figs["ttft_cold_p50"] == 12.0
+    assert figs["ttft_warm_p50"] == 8.0
+
+
+def test_probe_figures_withholds_cold_as_well_as_warm():
+    """The gate establishes that hit/miss labels mean session warmth at all.
+    Together's misses are the calls its automatic prefix cache happened not to
+    serve -- clustered at run start, not session start -- so publishing them as
+    a cold figure is wrong in the same way publishing its warm figure is."""
+    figs = probe_figures(_probe_tutor_block(cache_read=256))
+    assert figs["ttft_p50"] == 9.0
+    assert figs["ttft_cold_p50"] is None
+    assert figs["ttft_warm_p50"] is None
+
+
+def test_probe_figures_tolerates_an_absent_probe():
+    assert probe_figures({}) == {
+        "ttft_p50": None,
+        "ttlt_p50": None,
+        "ttft_cold_p50": None,
+        "ttft_warm_p50": None,
+    }
+
+
+def test_probe_runs_keys_by_model_and_mode(tmp_path):
+    _write_probe(tmp_path, "model-a_scaffolding_rigor_latency_20260818")
+    _write_probe(
+        tmp_path, "model-b_plain_latency_20260818", tutor="model-b", mode="plain"
+    )
+    found = probe_runs(str(tmp_path))
+    assert set(found) == {("model-a", "scaffolding_rigor"), ("model-b", "plain")}
+
+
+def test_probe_runs_prefers_the_newest_measurement(tmp_path):
+    """Re-measuring a model supersedes its earlier figure without anyone
+    having to delete the old run directory."""
+    _write_probe(
+        tmp_path,
+        "model-a_scaffolding_rigor_latency_20260817",
+        measured_at="2026-08-17T14:50:00",
+        tutor_block=_probe_tutor_block(p50_all=99.0),
+    )
+    _write_probe(
+        tmp_path,
+        "model-a_scaffolding_rigor_latency_20260818",
+        measured_at="2026-08-18T10:00:00",
+        tutor_block=_probe_tutor_block(p50_all=9.0),
+    )
+    block = probe_runs(str(tmp_path))[("model-a", "scaffolding_rigor")]
+    assert block["tutor"]["ttft"]["all"]["p50_seconds"] == 9.0
+
+
+def test_probe_runs_ignores_a_derived_subsample(tmp_path):
+    """A derived sample spans no particular prompt-length distribution, so it
+    is comparable to nothing -- least of all to another model's frozen run."""
+    _write_probe(
+        tmp_path, "model-a_scaffolding_rigor_latency_20260818", source="derived"
+    )
+    assert probe_runs(str(tmp_path)) == {}
+
+
+def test_probe_runs_ignores_an_incomplete_frozen_subsample(tmp_path):
+    """Dropped ids mean this is not the same sample as the run before it."""
+    _write_probe(tmp_path, "model-a_scaffolding_rigor_latency_20260818", complete=False)
+    assert probe_runs(str(tmp_path)) == {}
+
+
+def test_probe_runs_ignores_benchmark_run_directories(tmp_path):
+    """Benchmark runs write summary.json, not latency.json, and their latency
+    was gathered under --concurrency."""
+    (tmp_path / "model-a_scaffolding_rigor_tutormoments-preview_20260807").mkdir()
+    assert probe_runs(str(tmp_path)) == {}
+
+
+def test_probe_runs_on_a_missing_results_root(tmp_path):
+    assert probe_runs(str(tmp_path / "nope")) == {}
+
+
+def test_probe_subsample_ids_exposes_a_mixed_set(tmp_path):
+    """Eligibility is per-probe, so two frozen-but-different samples each pass
+    it. Callers publishing several cells need to see that."""
+    _write_probe(
+        tmp_path,
+        "model-a_scaffolding_rigor_latency_20260818",
+        sub_id="589e8acf8ac761f2",
+    )
+    _write_probe(
+        tmp_path,
+        "model-b_scaffolding_rigor_latency_20260817",
+        tutor="model-b",
+        sub_id="84b4ad5615876a3e",
+    )
+    assert probe_subsample_ids(probe_runs(str(tmp_path))) == {
+        "589e8acf8ac761f2",
+        "84b4ad5615876a3e",
+    }

--- a/tests/tutormoments/test_report.py
+++ b/tests/tutormoments/test_report.py
@@ -333,36 +333,32 @@ EXPECTED_COLUMNS = [
     "appropriate_rigor",
     "avoids_overscaffold",
     "ttft_p50",
-    "ttft_cold_p50",
-    "ttft_warm_p50",
+    "ttft_first_p50",
+    "ttft_later_p50",
     "tutor_lat_p50",
     "tutor_lat_p95",
     "tokens_total",
 ]
 
 
-def _probe_block(
-    *,
-    p50_all: float,
-    p50_miss: float | None = None,
-    p50_hit: float | None = None,
-    cache_hit_rate: float | None = 0.5,
-    cache_read: int | None = 8000,
-    n_hits: int = 40,
-) -> dict:
-    """One `tutormoments latency` result, shaped as the probe writes it."""
+def _probe_block(*, p50_all: float, first: tuple = (), later: tuple = ()) -> dict:
+    """One `tutormoments latency` result, shaped as the probe writes it.
+
+    `first`/`later` are per-call TTFTs for turn 0 and turns 1-2; the split the
+    leaderboard prints is computed from these samples, not from the cache
+    aggregates.
+    """
+    samples = [{"ttft_seconds": v, "turn_index": 0} for v in first]
+    samples += [
+        {"ttft_seconds": v, "turn_index": 1 + i % 2} for i, v in enumerate(later)
+    ]
     return {
         "tutor": {
-            "n_samples": 112,
-            "cache_hit_rate": cache_hit_rate,
-            "cache_read_p50_on_hits": cache_read,
-            "ttft": {
-                "all": {"n": 112, "p50_seconds": p50_all},
-                "miss": {"n": 40, "p50_seconds": p50_miss} if p50_miss else None,
-                "hit": {"n": n_hits, "p50_seconds": p50_hit} if p50_hit else None,
-            },
-            "ttlt": {"all": {"n": 112, "p50_seconds": p50_all + 1.0}},
-        }
+            "n_samples": 336,
+            "ttft": {"all": {"n": 336, "p50_seconds": p50_all}},
+            "ttlt": {"all": {"n": 336, "p50_seconds": p50_all + 1.0}},
+        },
+        "samples": samples,
     }
 
 
@@ -666,14 +662,14 @@ def test_leaderboard_joins_probe_ttft_onto_the_matching_cell():
     two meet. Join key is (tutor_model, mode) -- the cell the probe measured."""
     probes = {
         ("model-alpha", "scaffolding_rigor"): _probe_block(
-            p50_all=9.446, p50_miss=12.377, p50_hit=8.794
+            p50_all=9.043, first=(13.0, 13.2, 13.4), later=(7.9, 8.0, 8.1)
         )
     }
     md, csv_str = leaderboard([SUMMARY_A], probes)
-    assert "9.446" in md
-    assert "12.377" in md
-    assert "8.794" in md
-    assert "9.446" in csv_str
+    assert "9.043" in md
+    assert "13.200" in md  # ttft_first_p50
+    assert "8.000" in md  # ttft_later_p50
+    assert "9.043" in csv_str
 
 
 def test_leaderboard_dashes_ttft_for_a_cell_with_no_probe():
@@ -706,36 +702,30 @@ def test_leaderboard_ttft_join_is_per_mode():
     assert "9.446" not in rows["plain"]
 
 
-def test_leaderboard_publishes_pooled_ttft_when_the_provider_reports_no_cache():
-    """Gemini reports no cache tokens at all, so it has neither a cold nor a
-    warm bucket -- but its pooled figure is measured exactly like everyone
-    else's and is what ranks the roster. Withholding it would drop the model
-    off the table for a provider-reporting reason."""
+def test_leaderboard_splits_by_turn_for_a_provider_with_no_cache_reporting():
+    """Gemini reports no cache tokens, so a cache-state split cannot exist for
+    it -- but turn position is the probe's own record, so its first/later
+    figures publish like everyone else's."""
     probes = {
         ("model-alpha", "scaffolding_rigor"): _probe_block(
-            p50_all=14.94, cache_hit_rate=None, cache_read=None
+            p50_all=14.08, first=(14.6, 14.7, 14.8), later=(13.6, 13.7, 13.8)
         )
     }
     md, _ = leaderboard([SUMMARY_A], probes)
     row = next(line for line in md.splitlines() if line.startswith("| model-alpha"))
     cells = [c.strip() for c in row.split("|")]
-    assert cells[7] == "14.940"  # ttft_p50
-    assert cells[8] == "-"  # ttft_cold_p50
-    assert cells[9] == "-"  # ttft_warm_p50
+    assert cells[7] == "14.080"  # ttft_p50
+    assert cells[8] == "14.700"  # ttft_first_p50
+    assert cells[9] == "13.700"  # ttft_later_p50
 
 
-def test_leaderboard_withholds_the_whole_split_on_an_incidental_cache():
-    """Together's hits read back one quantised block of shared system prompt,
-    so its hit/miss labels track run warmup rather than session warmth. That
-    invalidates the cold half as much as the warm half: on the pilot its
-    "cold" p50 was 15.03s against a pooled 7.94s, because the misses were the
-    calls at run start."""
-    probes = {
-        ("model-alpha", "scaffolding_rigor"): _probe_block(
-            p50_all=7.94, p50_miss=15.034, p50_hit=7.823, cache_read=256
-        )
-    }
+def test_leaderboard_dashes_the_split_when_a_probe_carries_no_samples():
+    """Pooled comes from the stored aggregate; the split needs the samples.
+    A block without them gets a pooled figure and dashes, not a crash."""
+    probes = {("model-alpha", "scaffolding_rigor"): _probe_block(p50_all=7.94)}
     md, _ = leaderboard([SUMMARY_A], probes)
-    assert "7.940" in md
-    assert "15.034" not in md
-    assert "7.823" not in md
+    row = next(line for line in md.splitlines() if line.startswith("| model-alpha"))
+    cells = [c.strip() for c in row.split("|")]
+    assert cells[7] == "7.940"
+    assert cells[8] == "-"
+    assert cells[9] == "-"

--- a/tests/tutormoments/test_report.py
+++ b/tests/tutormoments/test_report.py
@@ -332,10 +332,38 @@ EXPECTED_COLUMNS = [
     "appropriate_scaffolding",
     "appropriate_rigor",
     "avoids_overscaffold",
+    "ttft_p50",
+    "ttft_cold_p50",
+    "ttft_warm_p50",
     "tutor_lat_p50",
     "tutor_lat_p95",
     "tokens_total",
 ]
+
+
+def _probe_block(
+    *,
+    p50_all: float,
+    p50_miss: float | None = None,
+    p50_hit: float | None = None,
+    cache_hit_rate: float | None = 0.5,
+    cache_read: int | None = 8000,
+    n_hits: int = 40,
+) -> dict:
+    """One `tutormoments latency` result, shaped as the probe writes it."""
+    return {
+        "tutor": {
+            "n_samples": 112,
+            "cache_hit_rate": cache_hit_rate,
+            "cache_read_p50_on_hits": cache_read,
+            "ttft": {
+                "all": {"n": 112, "p50_seconds": p50_all},
+                "miss": {"n": 40, "p50_seconds": p50_miss} if p50_miss else None,
+                "hit": {"n": n_hits, "p50_seconds": p50_hit} if p50_hit else None,
+            },
+            "ttlt": {"all": {"n": 112, "p50_seconds": p50_all + 1.0}},
+        }
+    }
 
 
 def test_leaderboard_returns_both_formats():
@@ -626,3 +654,88 @@ def test_leaderboard_tolerates_pre_streaming_summaries():
     md, _ = leaderboard([SUMMARY_A])
     row = next(line for line in md.split("\n") if "model-alpha" in line)
     assert "1.234" in row, "existing latency columns still render"
+
+
+# ---------------------------------------------------------------------------
+# TTFT columns, joined in from `tutormoments latency` probe runs
+# ---------------------------------------------------------------------------
+
+
+def test_leaderboard_joins_probe_ttft_onto_the_matching_cell():
+    """The probe writes its own run directory; the leaderboard is where the
+    two meet. Join key is (tutor_model, mode) -- the cell the probe measured."""
+    probes = {
+        ("model-alpha", "scaffolding_rigor"): _probe_block(
+            p50_all=9.446, p50_miss=12.377, p50_hit=8.794
+        )
+    }
+    md, csv_str = leaderboard([SUMMARY_A], probes)
+    assert "9.446" in md
+    assert "12.377" in md
+    assert "8.794" in md
+    assert "9.446" in csv_str
+
+
+def test_leaderboard_dashes_ttft_for_a_cell_with_no_probe():
+    """A benchmark run records TTFT too, but under --concurrency. A cell
+    without a probe must show nothing rather than borrow that number."""
+    md, _ = leaderboard([SUMMARY_A, SUMMARY_B], {})
+    for line in md.splitlines():
+        if line.startswith("| model-"):
+            assert "-" in line.split("|")[7]
+
+
+def test_leaderboard_ttft_join_is_per_mode():
+    """Same model, two prompt modes: a probe of one must not fill the other."""
+    plain = _make_run_summary(
+        tutor_model="model-alpha",
+        mode="plain",
+        n=100,
+        scaffold_cal=0.70,
+        rigor_cal=0.55,
+        overscaffold_rate=0.10,
+    )
+    probes = {("model-alpha", "scaffolding_rigor"): _probe_block(p50_all=9.446)}
+    md, _ = leaderboard([SUMMARY_A, plain], probes)
+    rows = {
+        line.split("|")[2].strip(): line
+        for line in md.splitlines()
+        if line.startswith("| model-alpha")
+    }
+    assert "9.446" in rows["scaffolding_rigor"]
+    assert "9.446" not in rows["plain"]
+
+
+def test_leaderboard_publishes_pooled_ttft_when_the_provider_reports_no_cache():
+    """Gemini reports no cache tokens at all, so it has neither a cold nor a
+    warm bucket -- but its pooled figure is measured exactly like everyone
+    else's and is what ranks the roster. Withholding it would drop the model
+    off the table for a provider-reporting reason."""
+    probes = {
+        ("model-alpha", "scaffolding_rigor"): _probe_block(
+            p50_all=14.94, cache_hit_rate=None, cache_read=None
+        )
+    }
+    md, _ = leaderboard([SUMMARY_A], probes)
+    row = next(line for line in md.splitlines() if line.startswith("| model-alpha"))
+    cells = [c.strip() for c in row.split("|")]
+    assert cells[7] == "14.940"  # ttft_p50
+    assert cells[8] == "-"  # ttft_cold_p50
+    assert cells[9] == "-"  # ttft_warm_p50
+
+
+def test_leaderboard_withholds_the_whole_split_on_an_incidental_cache():
+    """Together's hits read back one quantised block of shared system prompt,
+    so its hit/miss labels track run warmup rather than session warmth. That
+    invalidates the cold half as much as the warm half: on the pilot its
+    "cold" p50 was 15.03s against a pooled 7.94s, because the misses were the
+    calls at run start."""
+    probes = {
+        ("model-alpha", "scaffolding_rigor"): _probe_block(
+            p50_all=7.94, p50_miss=15.034, p50_hit=7.823, cache_read=256
+        )
+    }
+    md, _ = leaderboard([SUMMARY_A], probes)
+    assert "7.940" in md
+    assert "15.034" not in md
+    assert "7.823" not in md

--- a/tests/website/test_refresh_data.py
+++ b/tests/website/test_refresh_data.py
@@ -37,13 +37,15 @@ def _probe_dir(
     tutor: str,
     mode: str = "scaffolding_rigor",
     p50_all: float = 9.0,
-    p50_miss: float = 12.0,
-    p50_hit: float = 8.0,
-    cache_read: int | None = 8000,
-    cache_hit_rate: float | None = 0.5,
+    first: tuple = (12.0, 12.5, 13.0),
+    later: tuple = (7.5, 8.0, 8.5),
     measured_at: str = "2026-08-18T10:00:00",
     sub_id: str = "589e8acf8ac761f2",
 ) -> None:
+    samples = [{"ttft_seconds": v, "turn_index": 0} for v in first]
+    samples += [
+        {"ttft_seconds": v, "turn_index": 1 + i % 2} for i, v in enumerate(later)
+    ]
     run = root / run_id
     run.mkdir(parents=True)
     (run / "latency.json").write_text(
@@ -54,15 +56,10 @@ def _probe_dir(
                 "mode": mode,
                 "tutor": {
                     "n_samples": 336,
-                    "cache_hit_rate": cache_hit_rate,
-                    "cache_read_p50_on_hits": cache_read,
-                    "ttft": {
-                        "all": {"n": 336, "p50_seconds": p50_all},
-                        "miss": {"n": 112, "p50_seconds": p50_miss},
-                        "hit": {"n": 224, "p50_seconds": p50_hit},
-                    },
+                    "ttft": {"all": {"n": 336, "p50_seconds": p50_all}},
                     "ttlt": {"all": {"n": 336, "p50_seconds": p50_all + 1}},
                 },
+                "samples": samples,
                 "subsample": {
                     "subsample_source": "frozen_packaged",
                     "subsample_id": sub_id,
@@ -88,8 +85,8 @@ def test_probe_ttft_reads_pooled_p50_and_the_split(refresh, tmp_path):
     assert figures["claude-opus-4-8"] == {
         "ttft_s": 9.0,
         "ttlt_s": 10.0,
-        "ttft_cold_s": 12.0,
-        "ttft_warm_s": 8.0,
+        "ttft_first_s": 12.5,
+        "ttft_later_s": 8.0,
     }
     assert provenance["subsample_id"] == "589e8acf8ac761f2"
     assert provenance["measured_at"]["claude-opus-4-8"] == "2026-08-18T10:00:00"
@@ -107,34 +104,37 @@ def test_probe_ttft_flattens_the_provider_slash_to_the_site_id(refresh, tmp_path
     assert "deepseek-ai_DeepSeek-V4-Pro" in figures
 
 
-def test_probe_ttft_defers_to_the_runtime_on_an_incidental_cache(refresh, tmp_path):
-    """The gate this script must not reimplement: a 0.91 hit rate reading back
-    256 tokens of shared system prompt is not session warmth, so neither half
-    of the split may be published -- but the pooled figure still is."""
+def test_probe_ttft_splits_by_turn_regardless_of_cache_reporting(refresh, tmp_path):
+    """The split keys on turn position, which the probe recorded itself -- so
+    Gemini (no cache tokens) and DeepSeek (automatic prefix cache whose labels
+    the runtime rejects) get first/later figures like everyone else."""
     _probe_dir(
         tmp_path,
-        "ds_scaffolding_rigor_latency_20260818",
-        tutor="deepseek-ai/DeepSeek-V4-Pro",
-        cache_hit_rate=0.91,
-        cache_read=256,
+        "gem_scaffolding_rigor_latency_20260818",
+        tutor="gemini-2.5-pro",
+        p50_all=14.08,
+        first=(14.6, 14.7, 14.8),
+        later=(13.6, 13.7, 13.8),
     )
     figures, _ = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
-    assert figures["deepseek-ai_DeepSeek-V4-Pro"] == {"ttft_s": 9.0, "ttlt_s": 10.0}
+    assert figures["gemini-2.5-pro"] == {
+        "ttft_s": 14.08,
+        "ttlt_s": 15.08,
+        "ttft_first_s": 14.7,
+        "ttft_later_s": 13.7,
+    }
 
 
-def test_probe_ttft_publishes_pooled_when_the_provider_reports_no_cache(
-    refresh, tmp_path
-):
-    """Gemini reports no cache tokens, so it has no cold or warm bucket. It
-    must still reach the chart -- pooled TTFT is measured identically on every
-    provider."""
+def test_probe_ttft_omits_the_split_when_a_probe_has_no_samples(refresh, tmp_path):
+    """Pooled comes from the stored aggregate; the split needs samples. An
+    empty samples list yields a pooled-only row rather than a crash."""
     _probe_dir(
         tmp_path,
         "gem_scaffolding_rigor_latency_20260818",
         tutor="gemini-2.5-pro",
         p50_all=14.94,
-        cache_hit_rate=None,
-        cache_read=None,
+        first=(),
+        later=(),
     )
     figures, _ = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
     assert figures["gemini-2.5-pro"] == {"ttft_s": 14.94, "ttlt_s": 15.94}
@@ -179,7 +179,7 @@ def test_apply_ttft_drops_a_stale_figure(refresh):
     to prevent."""
     rows = [
         {"id": "kept", "latency_s": 10.0, "ttft_s": 99.0, "ttft_warm_s": 98.0},
-        {"id": "gone", "latency_s": 7.0, "ttft_s": 99.0, "ttlt_s": 99.5},
+        {"id": "gone", "latency_s": 7.0, "ttft_s": 99.0, "ttft_first_s": 99.5},
     ]
     assert refresh.apply_ttft(rows, {"kept": {"ttft_s": 9.4}}) == 1
     assert rows[0] == {"id": "kept", "latency_s": 10.0, "ttft_s": 9.4}

--- a/tests/website/test_refresh_data.py
+++ b/tests/website/test_refresh_data.py
@@ -87,6 +87,7 @@ def test_probe_ttft_reads_pooled_p50_and_the_split(refresh, tmp_path):
     figures, provenance = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
     assert figures["claude-opus-4-8"] == {
         "ttft_s": 9.0,
+        "ttlt_s": 10.0,
         "ttft_cold_s": 12.0,
         "ttft_warm_s": 8.0,
     }
@@ -118,7 +119,7 @@ def test_probe_ttft_defers_to_the_runtime_on_an_incidental_cache(refresh, tmp_pa
         cache_read=256,
     )
     figures, _ = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
-    assert figures["deepseek-ai_DeepSeek-V4-Pro"] == {"ttft_s": 9.0}
+    assert figures["deepseek-ai_DeepSeek-V4-Pro"] == {"ttft_s": 9.0, "ttlt_s": 10.0}
 
 
 def test_probe_ttft_publishes_pooled_when_the_provider_reports_no_cache(
@@ -136,7 +137,7 @@ def test_probe_ttft_publishes_pooled_when_the_provider_reports_no_cache(
         cache_read=None,
     )
     figures, _ = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
-    assert figures["gemini-2.5-pro"] == {"ttft_s": 14.94}
+    assert figures["gemini-2.5-pro"] == {"ttft_s": 14.94, "ttlt_s": 15.94}
 
 
 def test_probe_ttft_ignores_other_prompt_modes(refresh, tmp_path):
@@ -178,7 +179,7 @@ def test_apply_ttft_drops_a_stale_figure(refresh):
     to prevent."""
     rows = [
         {"id": "kept", "latency_s": 10.0, "ttft_s": 99.0, "ttft_warm_s": 98.0},
-        {"id": "gone", "latency_s": 7.0, "ttft_s": 99.0},
+        {"id": "gone", "latency_s": 7.0, "ttft_s": 99.0, "ttlt_s": 99.5},
     ]
     assert refresh.apply_ttft(rows, {"kept": {"ttft_s": 9.4}}) == 1
     assert rows[0] == {"id": "kept", "latency_s": 10.0, "ttft_s": 9.4}

--- a/tests/website/test_refresh_data.py
+++ b/tests/website/test_refresh_data.py
@@ -1,0 +1,238 @@
+"""Unit tests for the TTFT half of website/scripts/refresh-data.py.
+
+The script previously carried its own copy of the probe's publishability rules
+and got them wrong -- it gated on cache hit *rate*, which the runtime refuses to
+do, and would have published a "warm" figure for a provider whose hits read back
+one shared block of system prompt. These tests pin the corrected behaviour:
+figures come from `tutormoments.latency`, the site's model ids are matched to the
+probe's, and a stale figure is never left standing next to a fresh one.
+
+Score and end-to-end-latency assembly is thin I/O over an analysis export and is
+covered by tests/analysis/test_benchmark_perf_cost.py.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "website" / "scripts" / "refresh-data.py"
+
+
+@pytest.fixture(scope="module")
+def refresh():
+    """Load the script by path: its filename is not a valid module name."""
+    spec = importlib.util.spec_from_file_location("refresh_data", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _probe_dir(
+    root: Path,
+    run_id: str,
+    *,
+    tutor: str,
+    mode: str = "scaffolding_rigor",
+    p50_all: float = 9.0,
+    p50_miss: float = 12.0,
+    p50_hit: float = 8.0,
+    cache_read: int | None = 8000,
+    cache_hit_rate: float | None = 0.5,
+    measured_at: str = "2026-08-18T10:00:00",
+    sub_id: str = "589e8acf8ac761f2",
+) -> None:
+    run = root / run_id
+    run.mkdir(parents=True)
+    (run / "latency.json").write_text(
+        json.dumps(
+            {
+                "source": "probe",
+                "tutor_model": tutor,
+                "mode": mode,
+                "tutor": {
+                    "n_samples": 336,
+                    "cache_hit_rate": cache_hit_rate,
+                    "cache_read_p50_on_hits": cache_read,
+                    "ttft": {
+                        "all": {"n": 336, "p50_seconds": p50_all},
+                        "miss": {"n": 112, "p50_seconds": p50_miss},
+                        "hit": {"n": 224, "p50_seconds": p50_hit},
+                    },
+                    "ttlt": {"all": {"n": 336, "p50_seconds": p50_all + 1}},
+                },
+                "subsample": {
+                    "subsample_source": "frozen_packaged",
+                    "subsample_id": sub_id,
+                    "subsample_complete": True,
+                },
+                "measurement_environment": {"measured_at": measured_at},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# probe_ttft
+# ---------------------------------------------------------------------------
+
+
+def test_probe_ttft_reads_pooled_p50_and_the_split(refresh, tmp_path):
+    _probe_dir(
+        tmp_path, "a_scaffolding_rigor_latency_20260818", tutor="claude-opus-4-8"
+    )
+    figures, provenance = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
+    assert figures["claude-opus-4-8"] == {
+        "ttft_s": 9.0,
+        "ttft_cold_s": 12.0,
+        "ttft_warm_s": 8.0,
+    }
+    assert provenance["subsample_id"] == "589e8acf8ac761f2"
+    assert provenance["measured_at"]["claude-opus-4-8"] == "2026-08-18T10:00:00"
+
+
+def test_probe_ttft_flattens_the_provider_slash_to_the_site_id(refresh, tmp_path):
+    """Site ids mirror result-directory names, not the model id the probe
+    records: deepseek-ai/DeepSeek-V4-Pro -> deepseek-ai_DeepSeek-V4-Pro."""
+    _probe_dir(
+        tmp_path,
+        "ds_scaffolding_rigor_latency_20260818",
+        tutor="deepseek-ai/DeepSeek-V4-Pro",
+    )
+    figures, _ = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
+    assert "deepseek-ai_DeepSeek-V4-Pro" in figures
+
+
+def test_probe_ttft_defers_to_the_runtime_on_an_incidental_cache(refresh, tmp_path):
+    """The gate this script must not reimplement: a 0.91 hit rate reading back
+    256 tokens of shared system prompt is not session warmth, so neither half
+    of the split may be published -- but the pooled figure still is."""
+    _probe_dir(
+        tmp_path,
+        "ds_scaffolding_rigor_latency_20260818",
+        tutor="deepseek-ai/DeepSeek-V4-Pro",
+        cache_hit_rate=0.91,
+        cache_read=256,
+    )
+    figures, _ = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
+    assert figures["deepseek-ai_DeepSeek-V4-Pro"] == {"ttft_s": 9.0}
+
+
+def test_probe_ttft_publishes_pooled_when_the_provider_reports_no_cache(
+    refresh, tmp_path
+):
+    """Gemini reports no cache tokens, so it has no cold or warm bucket. It
+    must still reach the chart -- pooled TTFT is measured identically on every
+    provider."""
+    _probe_dir(
+        tmp_path,
+        "gem_scaffolding_rigor_latency_20260818",
+        tutor="gemini-2.5-pro",
+        p50_all=14.94,
+        cache_hit_rate=None,
+        cache_read=None,
+    )
+    figures, _ = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
+    assert figures["gemini-2.5-pro"] == {"ttft_s": 14.94}
+
+
+def test_probe_ttft_ignores_other_prompt_modes(refresh, tmp_path):
+    _probe_dir(
+        tmp_path, "a_plain_latency_20260818", tutor="claude-opus-4-8", mode="plain"
+    )
+    figures, _ = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
+    assert figures == {}
+
+
+def test_probe_ttft_flags_a_mixed_subsample(refresh, tmp_path, capsys):
+    """Two frozen-but-different samples each pass per-probe eligibility; the
+    chart must not silently plot them on one axis."""
+    _probe_dir(
+        tmp_path,
+        "a_scaffolding_rigor_latency_20260818",
+        tutor="claude-opus-4-8",
+        sub_id="589e8acf8ac761f2",
+    )
+    _probe_dir(
+        tmp_path,
+        "b_scaffolding_rigor_latency_20260817",
+        tutor="claude-sonnet-4-6",
+        sub_id="84b4ad5615876a3e",
+    )
+    _, provenance = refresh.probe_ttft(REPO, tmp_path, "scaffolding_rigor")
+    assert provenance["subsample_id"] is None
+    assert "mix 2 latency subsamples" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# apply_ttft / refresh_ttft_only
+# ---------------------------------------------------------------------------
+
+
+def test_apply_ttft_drops_a_stale_figure(refresh):
+    """A model that lost its probe run must not keep the number from a sample
+    that is no longer being measured -- that is the drift subsample_id exists
+    to prevent."""
+    rows = [
+        {"id": "kept", "latency_s": 10.0, "ttft_s": 99.0, "ttft_warm_s": 98.0},
+        {"id": "gone", "latency_s": 7.0, "ttft_s": 99.0},
+    ]
+    assert refresh.apply_ttft(rows, {"kept": {"ttft_s": 9.4}}) == 1
+    assert rows[0] == {"id": "kept", "latency_s": 10.0, "ttft_s": 9.4}
+    assert rows[1] == {"id": "gone", "latency_s": 7.0}
+
+
+def test_refresh_ttft_only_keeps_the_scores_it_did_not_measure(
+    refresh, tmp_path, monkeypatch
+):
+    """A checkout can have probe runs without a full scored sweep. Rebuilding
+    latency.json wholesale there would discard the paper's scores."""
+    out = tmp_path / "data"
+    out.mkdir()
+    (out / "latency.json").write_text(
+        json.dumps(
+            {
+                "source": "Figure 7, paper",
+                "models": [
+                    {
+                        "id": "claude-opus-4-8",
+                        "name": "Claude Opus 4.8",
+                        "latency_s": 12.5,
+                        "latency_estimated": True,
+                        "score": 0.8445,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(refresh, "OUT_DIR", out)
+    probes = tmp_path / "results"
+    _probe_dir(probes, "a_scaffolding_rigor_latency_20260818", tutor="claude-opus-4-8")
+
+    refresh.refresh_ttft_only(REPO, probes)
+
+    payload = json.loads((out / "latency.json").read_text("utf-8"))
+    row = payload["models"][0]
+    assert row["score"] == 0.8445
+    assert row["latency_s"] == 12.5
+    assert row["ttft_s"] == 9.0
+    assert payload["source"] == "Figure 7, paper"
+    assert payload["ttft"]["subsample_id"] == "589e8acf8ac761f2"
+
+
+def test_refresh_ttft_only_without_probe_runs_leaves_the_file_alone(
+    refresh, tmp_path, monkeypatch
+):
+    out = tmp_path / "data"
+    out.mkdir()
+    original = {"source": "Figure 7, paper", "models": [{"id": "x", "ttft_s": 1.0}]}
+    (out / "latency.json").write_text(json.dumps(original), encoding="utf-8")
+    monkeypatch.setattr(refresh, "OUT_DIR", out)
+
+    refresh.refresh_ttft_only(REPO, tmp_path / "empty")
+
+    assert json.loads((out / "latency.json").read_text("utf-8")) == original

--- a/website/README.md
+++ b/website/README.md
@@ -77,9 +77,13 @@ interchangeable:
   vs. later ones) appear alongside it only where the runtime judges that provider's cache
   labels to mean session warmth — currently the Anthropic and OpenAI paths. A model with no
   probe run has no `ttft_s` key and is left off the chart rather than plotted at zero.
+- **`ttlt_s`** — median time to last token from the same probe: when the student can actually
+  reply. Shown in the tooltip as "Full turn, end to end".
 - **`latency_s`** — end-to-end seconds per tutor turn from a benchmark run, which replays
   moments under `--concurrency`. Rate-limit tiers differ per model, so this compares a model
-  against its own history but not against another model. It stays in the tooltip.
+  against its own history but not against another model. It is kept in the JSON for
+  correspondence with the paper's Figure 7 but is **not displayed** — the tooltip's
+  end-to-end row is the probe's `ttlt_s`.
 
 `ttft_s` values are read from probe runs under `<checkout>/results` (override with
 `--probe-root`), taking the newest run per model that measured the frozen subsample in full.
@@ -88,5 +92,5 @@ hash means different prompts were measured, and the script warns rather than cha
 samples together. See `docs/latency.md` in the main repo.
 
 `latency_s` is still read off the paper's Figure 7 (±0.2s) for every model; a checkout with
-`results/benchmark/` present replaces those with exact values. The chart footnote says so
-while the estimate stands.
+`results/benchmark/` present replaces those with exact values. Since nothing on the page
+renders it, that estimate no longer needs a footnote.

--- a/website/README.md
+++ b/website/README.md
@@ -71,12 +71,11 @@ interchangeable:
 
 - **`ttft_s`** — median time to first *visible* token, from `tutormoments latency`. That probe
   runs strictly serially, so this is the figure that is comparable across models, and it is
-  what the chart's x-axis plots. Pooled over all samples, because that is the only figure
-  measured identically on every provider: Gemini reports no cache tokens at all, so it has
-  neither a cold nor a warm bucket. `ttft_cold_s` / `ttft_warm_s` (first message of a session
-  vs. later ones) appear alongside it only where the runtime judges that provider's cache
-  labels to mean session warmth — currently the Anthropic and OpenAI paths. A model with no
-  probe run has no `ttft_s` key and is left off the chart rather than plotted at zero.
+  what the chart's x-axis plots. `ttft_first_s` / `ttft_later_s` split it by turn position —
+  the first message of a session against turns 3 and 5 — which the probe recorded itself, so
+  every probed model gets the split regardless of what its provider reports about caching.
+  A model with no probe run has no `ttft_s` key and is left off the chart rather than
+  plotted at zero.
 - **`ttlt_s`** — median time to last token from the same probe: when the student can actually
   reply. Shown in the tooltip as "Full turn, end to end".
 - **`latency_s`** — end-to-end seconds per tutor turn from a benchmark run, which replays

--- a/website/README.md
+++ b/website/README.md
@@ -49,8 +49,13 @@ Results live in the benchmark's `results/` (gitignored) alongside the `analysis/
 After running new models:
 
 ```sh
-python3 scripts/refresh-data.py /path/to/tutormoments/checkout
+/path/to/tutormoments/.venv/bin/python scripts/refresh-data.py /path/to/tutormoments
 ```
+
+Run it with an interpreter that can `import tutormoments` — the checkout's own venv is the
+easy one. The TTFT figures come with publishability rules that live in
+`tutormoments.latency`, and the script reads them out rather than restating them. Under a
+bare `python3` it refreshes everything else and says that it skipped `ttft_s`.
 
 This regenerates `static/data/{leaderboard,latency,action_distribution}.json`. The
 action-distribution figure reads the repo's
@@ -59,10 +64,29 @@ action-distribution figure reads the repo's
 new models to the `MODELS` list in the script (plus `ACTION_CSV_MODELS`, and `MODEL_STYLE` in
 `static/js/main.js`). Partial refreshes are fine — missing inputs just skip that JSON.
 
-## TODOs when things go live
+### The two latency figures
 
-- `static/data/latency.json` — latencies are currently read off the paper's Figure 7 (±0.2s); the refresh script replaces them with exact values from a checkout with results
-- `latency_s` is end-to-end seconds per tutor turn, taken from benchmark runs. `ttft_s` (time to first visible token) is separate: it appears only for models that have a `tutormoments latency` probe run, because benchmark runs measure latency under `--concurrency` and are not comparable across models. Models without a probe run — and models on providers with no real prompt cache — simply have no `ttft_s` key. See `docs/latency.md` in the main repo.
-- `ttft_s` is **not wired correctly yet, and the refresh script should not be trusted for it.** Two known problems, both tracked for the follow-up PR that wires probe results into the leaderboard and this chart:
-  - `ttft()` gates on `cache_hit_rate >= 0.5`. The runtime deliberately does *not* gate on a hit rate — the rate is fixed by `--max-turns` (exactly 0.5 at 3, 0.67 at 5), so the threshold sits on the structural boundary and one stray missed call drops a model. Worse, a provider with automatic prefix caching can hit on 91% of calls while reading back only a 256-token block of shared system prompt, which passes this gate and publishes a "warm" figure that is not warm. Call `tutormoments.latency.warm_figure_is_publishable` instead of reimplementing the check; it tests provider, hit *count*, and how much was actually read back.
-  - It reads probe runs from `results/benchmark/`, but `tutormoments latency` writes to `results/` unless given `--results-root results/benchmark`.
+`static/data/latency.json` carries both, from different sources, and they are not
+interchangeable:
+
+- **`ttft_s`** — median time to first *visible* token, from `tutormoments latency`. That probe
+  runs strictly serially, so this is the figure that is comparable across models, and it is
+  what the chart's x-axis plots. Pooled over all samples, because that is the only figure
+  measured identically on every provider: Gemini reports no cache tokens at all, so it has
+  neither a cold nor a warm bucket. `ttft_cold_s` / `ttft_warm_s` (first message of a session
+  vs. later ones) appear alongside it only where the runtime judges that provider's cache
+  labels to mean session warmth — currently the Anthropic and OpenAI paths. A model with no
+  probe run has no `ttft_s` key and is left off the chart rather than plotted at zero.
+- **`latency_s`** — end-to-end seconds per tutor turn from a benchmark run, which replays
+  moments under `--concurrency`. Rate-limit tiers differ per model, so this compares a model
+  against its own history but not against another model. It stays in the tooltip.
+
+`ttft_s` values are read from probe runs under `<checkout>/results` (override with
+`--probe-root`), taking the newest run per model that measured the frozen subsample in full.
+The `ttft.subsample_id` recorded in the JSON is what makes the series auditable: a different
+hash means different prompts were measured, and the script warns rather than charting two
+samples together. See `docs/latency.md` in the main repo.
+
+`latency_s` is still read off the paper's Figure 7 (±0.2s) for every model; a checkout with
+`results/benchmark/` present replaces those with exact values. The chart footnote says so
+while the estimate stands.

--- a/website/index.html
+++ b/website/index.html
@@ -136,7 +136,7 @@
         Share of tutor actions across twelve pedagogical moves, for each model and for the human tutors in
         the same transcripts (dashed line). Prompting for the evaluation shifts models toward asking students
         to justify their answers — while humans spread their choices across more varied strategies, including
-        simply stepping back and letting the student work.
+        stepping back and letting the student work.
       </p>
       <div class="chart-tabs" role="tablist" aria-label="Prompt condition">
         <button role="tab" aria-selected="true" data-prompt="plain">Plain prompt</button>
@@ -150,14 +150,13 @@
 
     <!-- Performance vs. time to first token -->
     <div class="chart-block" id="latency-block">
-      <h3 class="chart-title">The best tutors keep students waiting</h3>
+      <h3 class="chart-title">The best models would keep students waiting</h3>
       <p class="chart-sub">
         Overall performance (mean of appropriate scaffolding and appropriate rigor, evaluation-aware prompt)
         against median time to first visible token, measured one request at a time over 112 moments. The two
         strongest tutors leave a student looking at nothing for 8.5 to 9 seconds, and Gemini 2.5 Pro for 14 —
-        a long time for production education technology deployments. Waiting does not buy teaching quality
-        either: DeepSeek V4 Pro is slower than both Claude models and scores 0.2 lower. Fast, pedagogically
-        sound tutors are an open target.
+        a long time for production education technology deployments. Human speech latency is around 100-200 ms,
+        while humans on Zoom are around 500-1000ms. Fast, pedagogically sound tutors are an open target.
       </p>
       <div class="chart-card">
         <div id="latency-chart"></div>
@@ -201,7 +200,7 @@
     <div class="acknowledgments">
       <h3>Acknowledgments</h3>
       <p>
-        This project has been made possible in part through support from the Gates Foundation and Learning Commons.
+        This project has been made possible in part through support from the Gates Foundation and the Learning Commons.
       </p>
     </div>
   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -148,13 +148,16 @@
       </div>
     </div>
 
-    <!-- Performance vs. latency (paper Fig. 7) -->
+    <!-- Performance vs. time to first token -->
     <div class="chart-block" id="latency-block">
-      <h3 class="chart-title">The best tutors are also the slowest</h3>
+      <h3 class="chart-title">The best tutors keep students waiting</h3>
       <p class="chart-sub">
         Overall performance (mean of appropriate scaffolding and appropriate rigor, evaluation-aware prompt)
-        against average response latency per tutor turn. The strongest models take 10+ seconds to answer —
-        a long time for production education technology deployments. Fast, pedagogically sound tutors are an open target.
+        against median time to first visible token, measured one request at a time over 112 moments. The two
+        strongest tutors leave a student looking at nothing for 8.5 to 9 seconds, and Gemini 2.5 Pro for 14 —
+        a long time for production education technology deployments. Waiting does not buy teaching quality
+        either: DeepSeek V4 Pro is slower than both Claude models and scores 0.2 lower. Fast, pedagogically
+        sound tutors are an open target.
       </p>
       <div class="chart-card">
         <div id="latency-chart"></div>

--- a/website/scripts/refresh-data.py
+++ b/website/scripts/refresh-data.py
@@ -173,17 +173,18 @@ def load_latency_module(repo: Path):
 def probe_ttft(repo: Path, probe_root: Path, prompt: str) -> tuple[dict, dict]:
     """TTFT figures per site model id, from `tutormoments latency` probe runs.
 
-    Returns ``({site_id: {ttft_s, ttft_cold_s?, ttft_warm_s?, measured_at}},
+    Returns ``({site_id: {ttft_s, ttlt_s?, ttft_first_s?, ttft_later_s?}},
     provenance)``.
 
     Only probe runs are read. A benchmark run also records TTFT, but under
     --concurrency, which distorts it by a model-dependent amount and makes it
     incomparable across models -- exactly the comparison this chart invites.
 
-    `ttft_s` is the pooled p50 over all samples: the only figure measured
-    identically on all four providers, since Gemini reports no cache tokens and
-    so has neither a cold nor a warm bucket. The cold/warm split is carried
-    alongside it when the runtime says that provider's split is publishable.
+    `ttft_s` is the pooled p50 over all samples. `ttft_first_s` /
+    `ttft_later_s` split it by turn position -- the first message of a session
+    against the later ones -- which the probe recorded itself, so every model
+    with a probe run gets the split regardless of what its provider reports
+    about caching.
     """
     lat_mod = load_latency_module(repo)
     if lat_mod is None:
@@ -197,17 +198,18 @@ def probe_ttft(repo: Path, probe_root: Path, prompt: str) -> tuple[dict, dict]:
         # Site ids mirror result-directory names, which flatten the provider
         # slash (deepseek-ai/DeepSeek-V4-Pro -> deepseek-ai_DeepSeek-V4-Pro).
         site_id = tutor_model.replace("/", "_")
-        figs = lat_mod.probe_figures(block.get("tutor") or {})
+        figs = lat_mod.probe_figures(block)
         if figs["ttft_p50"] is None:
             continue
         env = block.get("measurement_environment") or {}
         row = {"ttft_s": round(figs["ttft_p50"], 2)}
-        if figs["ttlt_p50"] is not None:
-            row["ttlt_s"] = round(figs["ttlt_p50"], 2)
-        if figs["ttft_cold_p50"] is not None:
-            row["ttft_cold_s"] = round(figs["ttft_cold_p50"], 2)
-        if figs["ttft_warm_p50"] is not None:
-            row["ttft_warm_s"] = round(figs["ttft_warm_p50"], 2)
+        for src, key in (
+            ("ttlt_p50", "ttlt_s"),
+            ("ttft_first_p50", "ttft_first_s"),
+            ("ttft_later_p50", "ttft_later_s"),
+        ):
+            if figs[src] is not None:
+                row[key] = round(figs[src], 2)
         figures[site_id] = row
         measured[site_id] = env.get("measured_at")
         subsamples.add((block.get("subsample") or {}).get("subsample_id"))
@@ -238,7 +240,17 @@ def apply_ttft(rows: list, figures: dict) -> int:
     """
     n = 0
     for row in rows:
-        for key in ("ttft_s", "ttlt_s", "ttft_cold_s", "ttft_warm_s"):
+        # ttft_cold_s / ttft_warm_s are legacy: the split published under
+        # those names keyed on cache state and is superseded by the turn-based
+        # first/later one. Popped so a refreshed row cannot carry both.
+        for key in (
+            "ttft_s",
+            "ttlt_s",
+            "ttft_first_s",
+            "ttft_later_s",
+            "ttft_cold_s",
+            "ttft_warm_s",
+        ):
             row.pop(key, None)
         figs = figures.get(row["id"])
         if figs:

--- a/website/scripts/refresh-data.py
+++ b/website/scripts/refresh-data.py
@@ -202,6 +202,8 @@ def probe_ttft(repo: Path, probe_root: Path, prompt: str) -> tuple[dict, dict]:
             continue
         env = block.get("measurement_environment") or {}
         row = {"ttft_s": round(figs["ttft_p50"], 2)}
+        if figs["ttlt_p50"] is not None:
+            row["ttlt_s"] = round(figs["ttlt_p50"], 2)
         if figs["ttft_cold_p50"] is not None:
             row["ttft_cold_s"] = round(figs["ttft_cold_p50"], 2)
         if figs["ttft_warm_p50"] is not None:
@@ -236,7 +238,7 @@ def apply_ttft(rows: list, figures: dict) -> int:
     """
     n = 0
     for row in rows:
-        for key in ("ttft_s", "ttft_cold_s", "ttft_warm_s"):
+        for key in ("ttft_s", "ttlt_s", "ttft_cold_s", "ttft_warm_s"):
             row.pop(key, None)
         figs = figures.get(row["id"])
         if figs:

--- a/website/scripts/refresh-data.py
+++ b/website/scripts/refresh-data.py
@@ -9,11 +9,23 @@ static JSON. Re-run this after benchmarking new models:
 Reads (same sources as the repo's analysis/working-paper-20260630 scripts):
   results/benchmark/_full_combined/<model>__<prompt>/scores.json   -> leaderboard.json
   results/benchmark/<model>_v10_<prompt>_tutor_oracle_student*/exchanges/*.json
-                                                                   -> latency.json
+                                                                   -> latency.json (latency_s)
+  results/<model>_<prompt>_latency_<date>/latency.json             -> latency.json (ttft_s)
   data/taxonomy/{human,lm}/classified.csv (via tutormoments.taxonomy)  -> action_distribution.json
 
 Writes to static/data/. Sections of the site hide automatically when their JSON
 is absent, so partial refreshes are fine.
+
+Run this with an interpreter that can ``import tutormoments`` -- the checkout's
+own venv is the easy one:
+
+    /path/to/tutormoments/.venv/bin/python scripts/refresh-data.py /path/to/tutormoments
+
+The TTFT figures come with publishability rules (which providers' cache labels
+can be trusted, how many hit samples support a percentile) that live in
+`tutormoments.latency` and must not be reimplemented here -- an earlier version
+of this script did reimplement them and got them wrong. Without that import the
+script still refreshes everything else and says what it skipped.
 """
 
 from __future__ import annotations
@@ -79,7 +91,11 @@ def write_json(name: str, payload: dict) -> None:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     path = OUT_DIR / name
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    print(f"wrote {path.relative_to(SITE_ROOT)}")
+    try:
+        shown = path.relative_to(SITE_ROOT)
+    except ValueError:  # OUT_DIR redirected outside the site (tests)
+        shown = path
+    print(f"wrote {shown}")
 
 
 def perf(bench: Path, model: str, prompt: str) -> dict | None:
@@ -122,50 +138,149 @@ def latency(bench: Path, model: str, prompt: str, ids: set[str]) -> float | None
     return round(statistics.mean(lats), 2) if lats else None
 
 
-def ttft(bench: Path, model: str, prompt: str) -> float | None:
-    """Warm-cache TTFT p50 from a `tutormoments latency` probe run.
+def load_latency_module(repo: Path):
+    """Import `tutormoments.latency` from the checkout, or None if unavailable.
+
+    The probe's rules about what may be published -- whether a provider's
+    cache labels mean session warmth at all, how many hit samples support a
+    percentile -- belong to the runtime, and this script's job is to read them
+    out, not to restate them. An earlier version restated them and gated on
+    cache hit *rate*, which the runtime deliberately rejects: the rate is fixed
+    by --max-turns, so the threshold sat on the structural boundary, and a
+    provider whose "hits" read back 256 tokens of shared system prompt sailed
+    through it.
+
+    Returns None (rather than falling back to a local copy of the rules) when
+    the interpreter cannot import the package, so a bare `python3` run still
+    refreshes the rest of the site and reports the gap.
+    """
+    src = repo / "src"
+    if src.is_dir() and str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+    try:
+        from tutormoments import latency  # noqa: PLC0415
+    except ImportError as exc:
+        print(
+            f"cannot import tutormoments.latency ({exc}); skipping ttft_s. "
+            f"Re-run with an interpreter that has the package installed, e.g. "
+            f"{repo}/.venv/bin/python",
+            file=sys.stderr,
+        )
+        return None
+    return latency
+
+
+def probe_ttft(repo: Path, probe_root: Path, prompt: str) -> tuple[dict, dict]:
+    """TTFT figures per site model id, from `tutormoments latency` probe runs.
+
+    Returns ``({site_id: {ttft_s, ttft_cold_s?, ttft_warm_s?, measured_at}},
+    provenance)``.
 
     Only probe runs are read. A benchmark run also records TTFT, but under
     --concurrency, which distorts it by a model-dependent amount and makes it
     incomparable across models -- exactly the comparison this chart invites.
 
-    KNOWN BROKEN -- do not trust this output; see website/README.md. The hit
-    *rate* gate below is the one the runtime deliberately rejects: the rate is
-    fixed by --max-turns (0.5 at 3, 0.67 at 5), so the 0.5 threshold sits on
-    the structural boundary and one stray missed call drops a model, while a
-    provider whose "hits" read back 256 tokens of shared system prompt passes
-    it and publishes a warm figure that is not warm. The fix is to call
-    tutormoments.latency.warm_figure_is_publishable rather than reimplement
-    the check, and to read from the results root the probe actually writes to
-    (results/, not results/benchmark/). Tracked for the follow-up PR that
-    wires probe results into the leaderboard and this chart.
+    `ttft_s` is the pooled p50 over all samples: the only figure measured
+    identically on all four providers, since Gemini reports no cache tokens and
+    so has neither a cold nor a warm bucket. The cold/warm split is carried
+    alongside it when the runtime says that provider's split is publishable.
     """
-    needle = f"{model}_{prompt}_latency"
-    for run in sorted(bench.iterdir(), reverse=True):  # newest run id first
-        if not (run.is_dir() and run.name.startswith(needle)):
+    lat_mod = load_latency_module(repo)
+    if lat_mod is None:
+        return {}, {}
+
+    probes = lat_mod.probe_runs(str(probe_root))
+    figures, measured, subsamples = {}, {}, set()
+    for (tutor_model, mode), block in probes.items():
+        if mode != prompt:
             continue
-        fp = run / "latency.json"
-        if not fp.exists():
+        # Site ids mirror result-directory names, which flatten the provider
+        # slash (deepseek-ai/DeepSeek-V4-Pro -> deepseek-ai_DeepSeek-V4-Pro).
+        site_id = tutor_model.replace("/", "_")
+        figs = lat_mod.probe_figures(block.get("tutor") or {})
+        if figs["ttft_p50"] is None:
             continue
-        try:
-            block = json.loads(fp.read_text("utf-8")).get("tutor") or {}
-        except (json.JSONDecodeError, OSError):
-            continue
-        rate = block.get("cache_hit_rate")
-        if rate is None or rate < 0.5:
-            continue
-        p50 = ((block.get("ttft") or {}).get("hit") or {}).get("p50_seconds")
-        if p50 is not None:
-            return round(p50, 2)
-    return None
+        env = block.get("measurement_environment") or {}
+        row = {"ttft_s": round(figs["ttft_p50"], 2)}
+        if figs["ttft_cold_p50"] is not None:
+            row["ttft_cold_s"] = round(figs["ttft_cold_p50"], 2)
+        if figs["ttft_warm_p50"] is not None:
+            row["ttft_warm_s"] = round(figs["ttft_warm_p50"], 2)
+        figures[site_id] = row
+        measured[site_id] = env.get("measured_at")
+        subsamples.add((block.get("subsample") or {}).get("subsample_id"))
+
+    if len(subsamples) > 1:
+        print(
+            f"probe runs mix {len(subsamples)} latency subsamples "
+            f"({', '.join(sorted(str(i) for i in subsamples))}); those figures "
+            "were measured over different prompts and must not be charted "
+            "together -- re-measure the roster against one subsample",
+            file=sys.stderr,
+        )
+    provenance = {
+        "mode": prompt,
+        "subsample_id": subsamples.pop() if len(subsamples) == 1 else None,
+        "measured_at": measured,
+    }
+    return figures, provenance
 
 
-def build_benchmark_json(repo: Path) -> None:
+def apply_ttft(rows: list, figures: dict) -> int:
+    """Write TTFT figures onto latency.json rows in place; returns how many.
+
+    Absent figures are *removed* rather than left standing: a stale ttft_s from
+    an earlier subsample next to a freshly measured one is the failure the
+    subsample_id exists to prevent. Rows the chart plots on TTFT therefore only
+    ever carry a figure from the run just read.
+    """
+    n = 0
+    for row in rows:
+        for key in ("ttft_s", "ttft_cold_s", "ttft_warm_s"):
+            row.pop(key, None)
+        figs = figures.get(row["id"])
+        if figs:
+            row.update(figs)
+            n += 1
+    return n
+
+
+def refresh_ttft_only(repo: Path, probe_root: Path) -> None:
+    """Update ttft_s in the existing latency.json, leaving the rest alone.
+
+    The two figures in latency.json come from different places: latency_s from
+    benchmark runs, ttft_s from probe runs. A checkout can easily have the
+    probes without the benchmark results (probes are cheap to re-run; a full
+    scored sweep is not), and in that case rebuilding the file wholesale would
+    throw away the scores it already carries.
+    """
+    fp = OUT_DIR / "latency.json"
+    if not fp.exists():
+        print(f"no {fp} to update — skipping ttft_s", file=sys.stderr)
+        return
+    payload = json.loads(fp.read_text("utf-8"))
+    figures, provenance = probe_ttft(repo, probe_root, "scaffolding_rigor")
+    if not figures:
+        return
+    n = apply_ttft(payload.get("models") or [], figures)
+    # Keep provenance above the rows it describes.
+    payload = {
+        "source": payload.get("source"),
+        "ttft": provenance,
+        "models": payload.get("models") or [],
+    }
+    write_json("latency.json", payload)
+    print(f"  ttft_s updated for {n} model(s) from probe runs in {probe_root}")
+
+
+def build_benchmark_json(repo: Path, probe_root: Path) -> None:
     bench = repo / "results" / "benchmark"
     if not bench.exists():
         print(
-            f"no {bench} — skipping leaderboard.json and latency.json", file=sys.stderr
+            f"no {bench} — skipping leaderboard.json scores and latency_s",
+            file=sys.stderr,
         )
+        refresh_ttft_only(repo, probe_root)
         return
 
     ids_fp = bench / "_balanced_520_scenario_ids.json"
@@ -194,12 +309,6 @@ def build_benchmark_json(repo: Path) -> None:
                 "latency_estimated": False,
                 "score": round((ea["scaffolding"] + ea["rigor"]) / 2, 4),
             }
-            # Only present for models with a probe run; omitted rather than
-            # zero-filled so the chart can distinguish "not measured" from
-            # "fast". See docs/latency.md.
-            first_token = ttft(bench, model, "scaffolding_rigor")
-            if first_token is not None:
-                row["ttft_s"] = first_token
             lat_models.append(row)
 
     if lb_models:
@@ -213,10 +322,15 @@ def build_benchmark_json(repo: Path) -> None:
             },
         )
     if lat_models:
+        # ttft_s is only present for models with a probe run -- omitted rather
+        # than zero-filled, so the chart can tell "not measured" from "fast".
+        figures, provenance = probe_ttft(repo, probe_root, "scaffolding_rigor")
+        apply_ttft(lat_models, figures)
         write_json(
             "latency.json",
             {
                 "source": f"Generated by scripts/refresh-data.py from {repo}",
+                "ttft": provenance,
                 "models": lat_models,
             },
         )
@@ -295,6 +409,14 @@ def main() -> None:
         help="path to a local allenai/tutormoments checkout with results",
     )
     ap.add_argument(
+        "--probe-root",
+        type=Path,
+        default=None,
+        help="results root holding `tutormoments latency` probe runs "
+        "(default: <checkout>/results, where the probe writes unless given "
+        "--results-root)",
+    )
+    ap.add_argument(
         "--action-csv",
         type=Path,
         default=None,
@@ -309,7 +431,12 @@ def main() -> None:
         repo = args.tutormoments_repo.expanduser().resolve()
         if not repo.exists():
             ap.error(f"{repo} does not exist")
-        build_benchmark_json(repo)
+        probe_root = (
+            args.probe_root.expanduser().resolve()
+            if args.probe_root
+            else repo / "results"
+        )
+        build_benchmark_json(repo, probe_root)
 
     csv_path = args.action_csv or (
         repo

--- a/website/static/data/latency.json
+++ b/website/static/data/latency.json
@@ -1,5 +1,5 @@
 {
-  "source": "score = mean of evaluation-aware Appropriate Scaffolding and Appropriate Rigor (exact, from Table 8 of the TutorMoments-Preview working paper, 2026-06-30). ttft_s / ttlt_s / ttft_cold_s / ttft_warm_s measured by `tutormoments latency`, a serial probe (see the ttft block for mode, subsample and timestamps). latency_s is end-to-end seconds per tutor turn from benchmark runs, kept for correspondence with the paper's Figure 7 but not displayed; still read off that figure to ~\u00b10.2s until refreshed from a checkout with results/benchmark.",
+  "source": "score = mean of evaluation-aware Appropriate Scaffolding and Appropriate Rigor (exact, from Table 8 of the TutorMoments-Preview working paper, 2026-06-30). ttft_s / ttlt_s measured by `tutormoments latency`, a serial probe; ttft_first_s / ttft_later_s split TTFT by turn position (the first message of a session vs turns 3 and 5). See the ttft block for mode, subsample and timestamps. latency_s is end-to-end seconds per tutor turn from benchmark runs, kept for correspondence with the paper's Figure 7 but not displayed; still read off that figure to ~\u00b10.2s until refreshed from a checkout with results/benchmark.",
   "ttft": {
     "mode": "scaffolding_rigor",
     "subsample_id": "589e8acf8ac761f2",
@@ -22,8 +22,8 @@
       "score": 0.8445,
       "ttft_s": 9.04,
       "ttlt_s": 10.52,
-      "ttft_cold_s": 13.22,
-      "ttft_warm_s": 7.99
+      "ttft_first_s": 13.22,
+      "ttft_later_s": 7.99
     },
     {
       "id": "claude-sonnet-4-6",
@@ -33,8 +33,8 @@
       "score": 0.8115,
       "ttft_s": 8.47,
       "ttlt_s": 8.73,
-      "ttft_cold_s": 9.62,
-      "ttft_warm_s": 7.63
+      "ttft_first_s": 9.62,
+      "ttft_later_s": 7.63
     },
     {
       "id": "deepseek-ai_DeepSeek-V4-Pro",
@@ -43,7 +43,9 @@
       "latency_estimated": true,
       "score": 0.602,
       "ttft_s": 11.09,
-      "ttlt_s": 11.86
+      "ttlt_s": 11.86,
+      "ttft_first_s": 12.91,
+      "ttft_later_s": 9.97
     },
     {
       "id": "gemini-2.5-pro",
@@ -52,7 +54,9 @@
       "latency_estimated": true,
       "score": 0.804,
       "ttft_s": 14.08,
-      "ttlt_s": 14.15
+      "ttlt_s": 14.15,
+      "ttft_first_s": 14.74,
+      "ttft_later_s": 13.68
     },
     {
       "id": "gemini-3.5-flash",
@@ -61,7 +65,9 @@
       "latency_estimated": true,
       "score": 0.7655,
       "ttft_s": 5.51,
-      "ttlt_s": 5.72
+      "ttlt_s": 5.72,
+      "ttft_first_s": 6.11,
+      "ttft_later_s": 5.21
     },
     {
       "id": "gpt-5.5-2026-04-23",
@@ -71,8 +77,8 @@
       "score": 0.652,
       "ttft_s": 6.38,
       "ttlt_s": 7.28,
-      "ttft_cold_s": 6.91,
-      "ttft_warm_s": 5.92
+      "ttft_first_s": 7.53,
+      "ttft_later_s": 5.89
     },
     {
       "id": "gpt-5.4-mini-2026-03-17",
@@ -82,8 +88,8 @@
       "score": 0.571,
       "ttft_s": 3.16,
       "ttlt_s": 3.47,
-      "ttft_cold_s": 3.72,
-      "ttft_warm_s": 2.71
+      "ttft_first_s": 3.76,
+      "ttft_later_s": 2.71
     }
   ]
 }

--- a/website/static/data/latency.json
+++ b/website/static/data/latency.json
@@ -1,12 +1,82 @@
 {
-  "source": "Figure 7, TutorMoments-Preview working paper (2026-06-30). score = mean of evaluation-aware Appropriate Scaffolding and Appropriate Rigor (exact, from Table 8). TODO: latency_s values are read off the paper figure to ~±0.2s; replace with exact values via scripts/refresh-data.py.",
+  "source": "score = mean of evaluation-aware Appropriate Scaffolding and Appropriate Rigor (exact, from Table 8 of the TutorMoments-Preview working paper, 2026-06-30). ttft_s / ttft_cold_s / ttft_warm_s measured by `tutormoments latency`, a serial probe (see the ttft block for mode, subsample and timestamps). latency_s is end-to-end seconds per tutor turn, still read off the paper's Figure 7 to ~\u00b10.2s; a checkout with results/benchmark replaces it with exact values via scripts/refresh-data.py.",
+  "ttft": {
+    "mode": "scaffolding_rigor",
+    "subsample_id": "589e8acf8ac761f2",
+    "measured_at": {
+      "claude-opus-4-8": "2026-08-18T14:21:39",
+      "claude-sonnet-4-6": "2026-08-18T15:31:44",
+      "deepseek-ai_DeepSeek-V4-Pro": "2026-08-18T12:12:06",
+      "gemini-2.5-pro": "2026-08-18T12:06:09",
+      "gemini-3.5-flash": "2026-08-18T12:54:57",
+      "gpt-5.4-mini-2026-03-17": "2026-08-18T11:58:28",
+      "gpt-5.5-2026-04-23": "2026-08-18T11:23:02"
+    }
+  },
   "models": [
-    { "id": "claude-opus-4-8", "name": "Claude Opus 4.8", "latency_s": 12.5, "latency_estimated": true, "score": 0.8445 },
-    { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "latency_s": 10.0, "latency_estimated": true, "score": 0.8115 },
-    { "id": "deepseek-ai_DeepSeek-V4-Pro", "name": "DeepSeek V4 Pro", "latency_s": 7.0, "latency_estimated": true, "score": 0.602 },
-    { "id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro", "latency_s": 17.6, "latency_estimated": true, "score": 0.804 },
-    { "id": "gemini-3.5-flash", "name": "Gemini 3.5 Flash", "latency_s": 9.0, "latency_estimated": true, "score": 0.7655 },
-    { "id": "gpt-5.5-2026-04-23", "name": "GPT 5.5", "latency_s": 10.3, "latency_estimated": true, "score": 0.652 },
-    { "id": "gpt-5.4-mini-2026-03-17", "name": "GPT 5.4 mini", "latency_s": 4.2, "latency_estimated": true, "score": 0.571 }
+    {
+      "id": "claude-opus-4-8",
+      "name": "Claude Opus 4.8",
+      "latency_s": 12.5,
+      "latency_estimated": true,
+      "score": 0.8445,
+      "ttft_s": 9.04,
+      "ttft_cold_s": 13.22,
+      "ttft_warm_s": 7.99
+    },
+    {
+      "id": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6",
+      "latency_s": 10.0,
+      "latency_estimated": true,
+      "score": 0.8115,
+      "ttft_s": 8.47,
+      "ttft_cold_s": 9.62,
+      "ttft_warm_s": 7.63
+    },
+    {
+      "id": "deepseek-ai_DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro",
+      "latency_s": 7.0,
+      "latency_estimated": true,
+      "score": 0.602,
+      "ttft_s": 11.09
+    },
+    {
+      "id": "gemini-2.5-pro",
+      "name": "Gemini 2.5 Pro",
+      "latency_s": 17.6,
+      "latency_estimated": true,
+      "score": 0.804,
+      "ttft_s": 14.08
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "name": "Gemini 3.5 Flash",
+      "latency_s": 9.0,
+      "latency_estimated": true,
+      "score": 0.7655,
+      "ttft_s": 5.51
+    },
+    {
+      "id": "gpt-5.5-2026-04-23",
+      "name": "GPT 5.5",
+      "latency_s": 10.3,
+      "latency_estimated": true,
+      "score": 0.652,
+      "ttft_s": 6.38,
+      "ttft_cold_s": 6.91,
+      "ttft_warm_s": 5.92
+    },
+    {
+      "id": "gpt-5.4-mini-2026-03-17",
+      "name": "GPT 5.4 mini",
+      "latency_s": 4.2,
+      "latency_estimated": true,
+      "score": 0.571,
+      "ttft_s": 3.16,
+      "ttft_cold_s": 3.72,
+      "ttft_warm_s": 2.71
+    }
   ]
 }

--- a/website/static/data/latency.json
+++ b/website/static/data/latency.json
@@ -1,5 +1,5 @@
 {
-  "source": "score = mean of evaluation-aware Appropriate Scaffolding and Appropriate Rigor (exact, from Table 8 of the TutorMoments-Preview working paper, 2026-06-30). ttft_s / ttft_cold_s / ttft_warm_s measured by `tutormoments latency`, a serial probe (see the ttft block for mode, subsample and timestamps). latency_s is end-to-end seconds per tutor turn, still read off the paper's Figure 7 to ~\u00b10.2s; a checkout with results/benchmark replaces it with exact values via scripts/refresh-data.py.",
+  "source": "score = mean of evaluation-aware Appropriate Scaffolding and Appropriate Rigor (exact, from Table 8 of the TutorMoments-Preview working paper, 2026-06-30). ttft_s / ttlt_s / ttft_cold_s / ttft_warm_s measured by `tutormoments latency`, a serial probe (see the ttft block for mode, subsample and timestamps). latency_s is end-to-end seconds per tutor turn from benchmark runs, kept for correspondence with the paper's Figure 7 but not displayed; still read off that figure to ~\u00b10.2s until refreshed from a checkout with results/benchmark.",
   "ttft": {
     "mode": "scaffolding_rigor",
     "subsample_id": "589e8acf8ac761f2",
@@ -21,6 +21,7 @@
       "latency_estimated": true,
       "score": 0.8445,
       "ttft_s": 9.04,
+      "ttlt_s": 10.52,
       "ttft_cold_s": 13.22,
       "ttft_warm_s": 7.99
     },
@@ -31,6 +32,7 @@
       "latency_estimated": true,
       "score": 0.8115,
       "ttft_s": 8.47,
+      "ttlt_s": 8.73,
       "ttft_cold_s": 9.62,
       "ttft_warm_s": 7.63
     },
@@ -40,7 +42,8 @@
       "latency_s": 7.0,
       "latency_estimated": true,
       "score": 0.602,
-      "ttft_s": 11.09
+      "ttft_s": 11.09,
+      "ttlt_s": 11.86
     },
     {
       "id": "gemini-2.5-pro",
@@ -48,7 +51,8 @@
       "latency_s": 17.6,
       "latency_estimated": true,
       "score": 0.804,
-      "ttft_s": 14.08
+      "ttft_s": 14.08,
+      "ttlt_s": 14.15
     },
     {
       "id": "gemini-3.5-flash",
@@ -56,7 +60,8 @@
       "latency_s": 9.0,
       "latency_estimated": true,
       "score": 0.7655,
-      "ttft_s": 5.51
+      "ttft_s": 5.51,
+      "ttlt_s": 5.72
     },
     {
       "id": "gpt-5.5-2026-04-23",
@@ -65,6 +70,7 @@
       "latency_estimated": true,
       "score": 0.652,
       "ttft_s": 6.38,
+      "ttlt_s": 7.28,
       "ttft_cold_s": 6.91,
       "ttft_warm_s": 5.92
     },
@@ -75,6 +81,7 @@
       "latency_estimated": true,
       "score": 0.571,
       "ttft_s": 3.16,
+      "ttlt_s": 3.47,
       "ttft_cold_s": 3.72,
       "ttft_warm_s": 2.71
     }

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -250,9 +250,9 @@
         if (typeof d.ttft_cold_s === "number" && typeof d.ttft_warm_s === "number") {
           html += ttRow("First message / later", d.ttft_cold_s.toFixed(1) + " / " + d.ttft_warm_s.toFixed(1) + " s");
         }
-        if (typeof d.latency_s === "number") {
-          html += ttRow("Full turn, end to end", d.latency_s.toFixed(1) + " s" +
-            (d.latency_estimated ? " (approx.)" : ""));
+        // TTLT from the same serial probe: when the student can reply.
+        if (typeof d.ttlt_s === "number") {
+          html += ttRow("Full turn, end to end", d.ttlt_s.toFixed(1) + " s");
         }
         return html;
       });
@@ -260,12 +260,10 @@
 
     mount.appendChild(svg);
 
-    var notes = [];
-    if (missing) notes.push(missing + " model(s) omitted: no latency probe run.");
-    if (data.models.some(function (d) { return d.latency_estimated; })) {
-      notes.push("Scores are exact (Table 8 of the paper); end-to-end turn times in the tooltip are read off Figure 7 to about a fifth of a second.");
+    if (missing) {
+      document.getElementById("latency-footnote").textContent =
+        missing + " model(s) omitted: no latency probe run.";
     }
-    document.getElementById("latency-footnote").textContent = notes.join(" ");
   }
 
   /* ---------- action distribution strip plot (paper Fig. 4) ---------- */

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -248,7 +248,7 @@
         // Cold/warm is present only where the provider's cache labels mean
         // session warmth; elsewhere the pooled figure is all there is.
         if (typeof d.ttft_cold_s === "number" && typeof d.ttft_warm_s === "number") {
-          html += ttRow("First message / later", d.ttft_cold_s.toFixed(1) + " / " + d.ttft_warm_s.toFixed(1) + " s");
+          html += ttRow("First / later messages", d.ttft_cold_s.toFixed(1) + " / " + d.ttft_warm_s.toFixed(1) + " s");
         }
         // TTLT from the same serial probe: when the student can reply.
         if (typeof d.ttlt_s === "number") {

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -245,10 +245,10 @@
         var html = '<div class="tt-title">' + d.name + "</div>" +
           ttRow("Score", d.score.toFixed(3)) +
           ttRow("Time to first token", d.ttft_s.toFixed(1) + " s");
-        // Cold/warm is present only where the provider's cache labels mean
-        // session warmth; elsewhere the pooled figure is all there is.
-        if (typeof d.ttft_cold_s === "number" && typeof d.ttft_warm_s === "number") {
-          html += ttRow("First / later messages", d.ttft_cold_s.toFixed(1) + " / " + d.ttft_warm_s.toFixed(1) + " s");
+        // Split on turn position (turn 1 vs turns 3 and 5), so every model
+        // with a probe run has it -- no dependence on cache reporting.
+        if (typeof d.ttft_first_s === "number" && typeof d.ttft_later_s === "number") {
+          html += ttRow("First / later messages", d.ttft_first_s.toFixed(1) + " / " + d.ttft_later_s.toFixed(1) + " s");
         }
         // TTLT from the same serial probe: when the student can reply.
         if (typeof d.ttlt_s === "number") {

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -165,24 +165,46 @@
     table.innerHTML = html;
   }
 
-  /* ---------- latency vs performance scatter (paper Fig. 7) ---------- */
+  /* ---------- time-to-first-token vs performance scatter ----------
+     x is TTFT p50 from `tutormoments latency`, a strictly serial probe: the
+     only latency figure that is comparable across models. The paper's Fig. 7
+     plotted end-to-end seconds per turn, which benchmark runs gather under
+     concurrency, so it moves with each model's rate-limit tier as well as with
+     the model. That figure is kept in the tooltip rather than on the axis.
+     See docs/latency.md in allenai/tutormoments. */
+
+  function niceMax(v) {
+    return Math.max(2, Math.ceil((v * 1.06) / 2) * 2);
+  }
 
   function renderLatency(data) {
     var mount = document.getElementById("latency-chart");
+    // Models without a probe run carry no ttft_s and cannot be placed on this
+    // axis. Omitted rather than zero-filled: "not measured" is not "fast".
+    var models = data.models.filter(function (d) { return typeof d.ttft_s === "number"; });
+    var missing = data.models.length - models.length;
+    if (!models.length) {
+      document.getElementById("latency-block").hidden = true;
+      return;
+    }
+
     var W = 920, H = 480;
     var m = { top: 24, right: 120, bottom: 58, left: 74 };
     var iw = W - m.left - m.right, ih = H - m.top - m.bottom;
 
-    var xMin = 2, xMax = 20, yMin = 0.5, yMax = 0.9;
+    var xMin = 0, yMin = 0.5, yMax = 0.9;
+    var xMax = niceMax(Math.max.apply(null, models.map(function (d) { return d.ttft_s; })));
+    var xStep = xMax > 24 ? 4 : 2;
     var x = function (v) { return m.left + ((v - xMin) / (xMax - xMin)) * iw; };
     var y = function (v) { return m.top + (1 - (v - yMin) / (yMax - yMin)) * ih; };
 
     var svg = el("svg", { viewBox: "0 0 " + W + " " + H, role: "img",
-      "aria-label": "Scatter plot of tutoring performance against mean response latency for seven language models" });
+      "aria-label": "Scatter plot of tutoring performance against median time to first token for "
+        + models.length + " language models" });
 
     // gridlines + ticks
     var xi, yi;
-    for (xi = 4; xi <= 18; xi += 2) {
+    for (xi = xStep; xi <= xMax - 0.001; xi += xStep) {
       el("line", { x1: x(xi), y1: m.top, x2: x(xi), y2: m.top + ih, stroke: GRID, "stroke-width": 1 }, svg);
       el("text", { x: x(xi), y: m.top + ih + 22, "text-anchor": "middle", "font-size": 12, fill: INK_MUTED }, svg)
         .textContent = xi;
@@ -196,17 +218,17 @@
 
     // axis titles
     el("text", { x: m.left + iw / 2, y: H - 12, "text-anchor": "middle", "font-size": 13, fill: INK }, svg)
-      .textContent = "Mean tutor latency per turn (seconds)";
+      .textContent = "Time to first token, median seconds";
     var yl = el("text", { x: 18, y: m.top + ih / 2, "text-anchor": "middle", "font-size": 13, fill: INK,
       transform: "rotate(-90 18 " + (m.top + ih / 2) + ")" }, svg);
     yl.textContent = "Appropriate scaffolding & rigor (mean)";
 
     // points + direct labels
-    var labelLeft = { "gemini-2.5-pro": true };
+    var labelLeft = { "gemini-2.5-pro": true, "claude-sonnet-4-6": true };
     var labelBelow = { "gpt-5.5-2026-04-23": true };
-    data.models.forEach(function (d) {
+    models.forEach(function (d) {
       var s = MODEL_STYLE[d.id] || { color: INK, marker: "square" };
-      var cx = x(d.latency_s), cy = y(d.score);
+      var cx = x(d.ttft_s), cy = y(d.score);
       markerNode(s.marker, cx, cy, 8, s.color, svg);
 
       var lx = labelLeft[d.id] ? cx - 14 : cx + 14;
@@ -220,18 +242,30 @@
       // oversized invisible hit target for hover
       var hit = el("circle", { cx: cx, cy: cy, r: 17, fill: "transparent", cursor: "pointer" }, svg);
       attachHover(hit, function () {
-        return '<div class="tt-title">' + d.name + "</div>" +
+        var html = '<div class="tt-title">' + d.name + "</div>" +
           ttRow("Score", d.score.toFixed(3)) +
-          ttRow("Latency / turn", d.latency_s.toFixed(1) + " s" + (d.latency_estimated ? " (approx.)" : ""));
+          ttRow("Time to first token", d.ttft_s.toFixed(1) + " s");
+        // Cold/warm is present only where the provider's cache labels mean
+        // session warmth; elsewhere the pooled figure is all there is.
+        if (typeof d.ttft_cold_s === "number" && typeof d.ttft_warm_s === "number") {
+          html += ttRow("First message / later", d.ttft_cold_s.toFixed(1) + " / " + d.ttft_warm_s.toFixed(1) + " s");
+        }
+        if (typeof d.latency_s === "number") {
+          html += ttRow("Full turn, end to end", d.latency_s.toFixed(1) + " s" +
+            (d.latency_estimated ? " (approx.)" : ""));
+        }
+        return html;
       });
     });
 
     mount.appendChild(svg);
 
+    var notes = [];
+    if (missing) notes.push(missing + " model(s) omitted: no latency probe run.");
     if (data.models.some(function (d) { return d.latency_estimated; })) {
-      document.getElementById("latency-footnote").textContent =
-        "Scores are exact (Table 8 of the paper).";
+      notes.push("Scores are exact (Table 8 of the paper); end-to-end turn times in the tooltip are read off Figure 7 to about a fifth of a second.");
     }
+    document.getElementById("latency-footnote").textContent = notes.join(" ");
   }
 
   /* ---------- action distribution strip plot (paper Fig. 4) ---------- */


### PR DESCRIPTION
Stacked on #37 (`latency-ttft-probe`). That PR added the probe; this one runs it over the roster and wires the results into the leaderboard and the website, which was tracked there as follow-up work.

## The measurement

Seven leaderboard models, `scaffolding_rigor`, frozen 112-moment subsample (`589e8acf8ac761f2`), default `max_turns` of 5 — 336 tutor calls each, 2,352 total, measured 2026-08-18 10:27–15:31 on one machine.

| model | TTFT p50 | p5 / p95 | first message | later | TTLT p50 |
|---|---|---|---|---|---|
| `gpt-5.4-mini-2026-03-17` | **3.16** | 1.77 / 7.16 | 3.76 | 2.71 | 3.47 |
| `gemini-3.5-flash` | **5.51** | 3.62 / 10.50 | 6.11 | 5.21 | 5.72 |
| `gpt-5.5-2026-04-23` | **6.38** | 3.40 / 9.65 | 7.53 | 5.89 | 7.28 |
| `claude-sonnet-4-6` | **8.47** | 3.12 / 21.09 | 9.62 | 7.63 | 8.73 |
| `claude-opus-4-8` | **9.04** | 4.34 / 27.90 | 13.22 | 7.99 | 10.52 |
| `deepseek-ai/DeepSeek-V4-Pro` | **11.09** | 4.42 / 36.43 | 12.91 | 9.97 | 11.86 |
| `gemini-2.5-pro` | **14.08** | 9.13 / 24.34 | 14.74 | 13.68 | 14.15 |

"First / later" splits on **turn position** — the 112 turn-1 calls against the 224 on turns 3 and 5 — which the probe recorded itself, so the split exists identically on every provider with no dependence on cache reporting.

Non-Anthropic lanes ran concurrently; the two Anthropic tutors ran with the account to themselves, because every probe's simulated student is `claude-opus-4-6` there. The student drift control says that mattered: its three slowest medians (2.69–2.76s) are all runs from the concurrent phase, against 2.46–2.48s for the two that ran alone. Overall drift was 0.32s across five hours, an order of magnitude below the differences being claimed.

Sanity checks hold — `ttfc ≤ ttft ≤ ttlt` on all 2,352 calls, no failed moments, every frozen id resolved — with one exception: `DeepSeek-V4-Pro` recorded `n_no_visible_output` 1 of 336, a call that emitted 572 output tokens and no visible one. Its percentiles are conditional on 335.

## Findings that changed the docs

**The first/later gap is mostly not a caching effect.** Opus 4.8 is 5.2s faster on later turns, which reads as a strong case for caching until it is decomposed: prefill (`ttfc`) is 1.18s on first and later messages alike, identical to a millisecond, on a cache reading back 9,390 tokens. The whole gap is thinking time, falling monotonically by turn (11.75s → 6.96s → 6.00s). Sonnet's real prefill saving is 0.53s. Gemini 2.5 Pro — with no session cache in this harness at all — is still 1.06s faster on later turns: pure thinking adaptation. Caching stays a ~90% cost lever.

**A cache-state split mislabels; a turn split doesn't.** The obvious way to report first/later is cache miss/hit, and it is wrong twice over: Gemini reports no cache tokens (no buckets at all), and where automatic caching exists the labels lie — `gpt-5.5`'s miss bucket held 27 later-turn calls whose prefix silently failed to cache, diluting its "first message" figure to 6.91s when the actual turn-1 p50 is 7.53s; Together's misses track run warmup, not session position. So the *published* split keys on turn index (ground truth, no gate needed), while the cache-state aggregates stay in `latency.json` and the probe's terminal summary — fidelity-gated by `warm_figure_is_publishable` — as the diagnostic for what caching does. On Anthropic the two splits agree to a hundredth of a second, which is itself a check.

**The cache-fidelity gate is not a list of Anthropic models.** It tests what the hits read back: the OpenAI path passes (5,888-token median), Together fails at 256. DeepSeek's 0.786 hit rate sits *above* the 0.667 structural ceiling — itself the tell that it's a prefix cache, not a session cache.

## Wiring

- `latency.probe_runs` — newest frozen-and-complete probe per `(tutor_model, mode)`; derived or incomplete samples ineligible; `probe_subsample_ids` surfaces a mixed set so two different frozen samples cannot be published as one.
- `latency.probe_figures` — pooled `ttft_p50`/`ttlt_p50` plus `ttft_first_p50`/`ttft_later_p50`, computed from `samples` so probes written before the split existed still yield one.
- `report.leaderboard` — new `ttft_p50`, `ttft_first_p50`, `ttft_later_p50` columns, joined by cell. A cell with no probe shows `-` instead of borrowing the concurrency-distorted figure from its own run. Run-based `tutor_lat_*` stays, labelled as the within-model figure.
- `refresh-data.py` — the known-broken `ttft()` is gone. It imports the runtime's rules rather than restating them, reads probes from `results/` where the probe actually writes, and can refresh the TTFT keys alone so a checkout with probes but no scored sweep keeps its scores; stale figures (including the legacy `ttft_cold_s`/`ttft_warm_s` keys) are dropped rather than left beside fresh ones.
- Chart x-axis is TTFT; the tooltip carries the first/later split and the probe's measured TTLT. Nothing on the page reads off the paper anymore — the Figure 7 `latency_s` estimate stays in the JSON, undisplayed, until a checkout with `results/benchmark/` replaces it.

The ranking figure is the pooled p50: one number per model over an identical 112-first/224-later sample, the mix fixed by run structure rather than provider behavior.

Also fixes a pre-existing bug the join exposed: `report` recovered `(tutor_model, mode)` by splitting the run id, which cannot represent a mode containing an underscore. It yielded `scaffolding` for `scaffolding_rigor`, mislabelling the row and silently missing the probe join. It now reads `config.json` first.

## Verification

`pytest tests -q` → 602 passed, 13 skipped; ruff clean. New tests cover the probe join, the turn-position split (including a no-cache-reporting provider and a samples-less block), the stale-figure drop, the config.json recovery, and the mixed-subsample warning. The leaderboard join and the chart were both verified end to end against the real sweep output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)