### PR TITLE
Capture the canonical per-call usage vector at the client boundary

### DIFF
--- a/src/tutormoments/client.py
+++ b/src/tutormoments/client.py
@@ -80,11 +80,21 @@ class ModelResponse:
     """Unified response from any provider."""
 
     text: str
+    # Zero legacy counters plus the canonical cost vector (see
+    # normalize_usage). No provenance here: this default is only used where
+    # no real API call happened (e.g. registered/callable tutors), so there
+    # is no provider/model/endpoint to attribute the zeros to.
     usage: dict = field(
         default_factory=lambda: {
             "input_tokens": 0,
             "output_tokens": 0,
             "total_tokens": 0,
+            "input_uncached": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+            "output": 0,
+            "reasoning": 0,
+            "total": 0,
         }
     )
     # Wall-clock seconds from the start of the successful generate() attempt
@@ -514,12 +524,9 @@ class ModelClient:
         )
 
         text = response.text or ""
-        usage_meta = response.usage_metadata
-        usage = {
-            "input_tokens": getattr(usage_meta, "prompt_token_count", 0) or 0,
-            "output_tokens": getattr(usage_meta, "candidates_token_count", 0) or 0,
-            "total_tokens": getattr(usage_meta, "total_token_count", 0) or 0,
-        }
+        usage = _gemini_usage(
+            response.usage_metadata, model=self.model, endpoint="sync"
+        )
         return ModelResponse(text=text, usage=usage)
 
     def _stream_gemini(self, contents, config):
@@ -551,11 +558,7 @@ class ModelClient:
             if not saw_visible:
                 timer.chunk()
 
-        usage = {
-            "input_tokens": getattr(usage_meta, "prompt_token_count", 0) or 0,
-            "output_tokens": getattr(usage_meta, "candidates_token_count", 0) or 0,
-            "total_tokens": getattr(usage_meta, "total_token_count", 0) or 0,
-        }
+        usage = _gemini_usage(usage_meta, model=self.model, endpoint="stream")
         return ModelResponse(
             text="".join(pieces),
             usage=usage,
@@ -610,16 +613,9 @@ class ModelClient:
         response = self._client.chat.completions.create(**kwargs)
 
         text = response.choices[0].message.content or ""
-        cached = 0
-        details = getattr(response.usage, "prompt_tokens_details", None)
-        if details is not None:
-            cached = getattr(details, "cached_tokens", 0) or 0
-        usage = {
-            "input_tokens": response.usage.prompt_tokens or 0,
-            "output_tokens": response.usage.completion_tokens or 0,
-            "total_tokens": response.usage.total_tokens or 0,
-            "cached_tokens": cached,
-        }
+        usage = _openai_style_usage(
+            response.usage, provider=self.provider, model=self.model, endpoint="sync"
+        )
         return ModelResponse(text=text, usage=usage)
 
     def _generate_together(
@@ -636,8 +632,10 @@ class ModelClient:
         Together uses `max_tokens` (not `max_completion_tokens`) and does not
         accept `reasoning_effort`. Open-weight reasoners (DeepSeek-V4, Kimi)
         produce their own chain-of-thought internally; there's no depth knob
-        to pass. Caching isn't supported, so the cacheable head is just
-        concatenated into the prompt (same as the Gemini path).
+        to pass. There is no cache_control-style API, so the cacheable head is
+        just concatenated into the prompt (same as the Gemini path); Together
+        still reports server-side cache hits via cached_tokens (observed live
+        on DeepSeek-V4-Pro), whether or not a billing discount applies.
         """
         content = (cacheable_prefix or "") + prompt
         kwargs = {
@@ -660,12 +658,9 @@ class ModelClient:
         text = response.choices[0].message.content or ""
         if json_mode:
             text = _strip_json_fences(text)
-        u = response.usage
-        usage = {
-            "input_tokens": getattr(u, "prompt_tokens", 0) or 0,
-            "output_tokens": getattr(u, "completion_tokens", 0) or 0,
-            "total_tokens": getattr(u, "total_tokens", 0) or 0,
-        }
+        usage = _openai_style_usage(
+            response.usage, provider=self.provider, model=self.model, endpoint="sync"
+        )
         return ModelResponse(text=text, usage=usage)
 
     def _stream_openai_compatible(self, kwargs: dict, *, inline_think: bool):
@@ -708,22 +703,15 @@ class ModelClient:
             if piece:
                 pieces.append(piece)
 
-        cached = 0
-        details = getattr(usage_obj, "prompt_tokens_details", None)
-        if details is not None:
-            cached = getattr(details, "cached_tokens", 0) or 0
-        usage = {
-            "input_tokens": getattr(usage_obj, "prompt_tokens", 0) or 0,
-            "output_tokens": getattr(usage_obj, "completion_tokens", 0) or 0,
-            "total_tokens": getattr(usage_obj, "total_tokens", 0) or 0,
-            "cached_tokens": cached,
-        }
+        usage = _openai_style_usage(
+            usage_obj, provider=self.provider, model=self.model, endpoint="stream"
+        )
         return ModelResponse(
             text="".join(pieces),
             usage=usage,
             timing=timer.as_dict(
                 output_tokens=usage["output_tokens"] or None,
-                cache_read_input_tokens=cached,
+                cache_read_input_tokens=usage["cached_tokens"],
             ),
         )
 
@@ -832,7 +820,7 @@ class ModelClient:
         if json_mode:
             text = _strip_json_fences(text)
 
-        usage = _anthropic_usage(response.usage)
+        usage = _anthropic_usage(response.usage, model=self.model, endpoint="sync")
         return ModelResponse(text=text, usage=usage)
 
     def _stream_anthropic(self, kwargs: dict, *, json_mode: bool):
@@ -868,7 +856,7 @@ class ModelClient:
         if json_mode:
             text = _strip_json_fences(text)
 
-        usage = _anthropic_usage(message.usage)
+        usage = _anthropic_usage(message.usage, model=self.model, endpoint="stream")
         return ModelResponse(
             text=text,
             usage=usage,
@@ -986,20 +974,206 @@ def _strip_json_fences(text: str) -> str:
     return stripped.strip()
 
 
-def _anthropic_usage(usage) -> dict:
+# ===================================================================
+# Usage normalization (canonical cost vector)
+# ===================================================================
+#
+# Every LLM call records the same five-bucket vector, built from the exact
+# cached/uncached split the provider reported -- never estimated. `total` is
+# derived from the buckets so there is exactly one definition of "total".
+# Provenance (provider/model/endpoint) rides alongside as strings; only the
+# integer-valued keys are meaningful to sum. The legacy per-provider keys
+# (input_tokens/output_tokens/total_tokens, cached_tokens, cache_*_input_tokens)
+# stay alongside so existing readers and old transcripts keep working.
+
+
+def normalize_usage(
+    provider: str,
+    model: str,
+    endpoint: str,
+    *,
+    input_uncached: int = 0,
+    cache_read: int = 0,
+    cache_write: int = 0,
+    output: int = 0,
+    reasoning: int = 0,
+) -> dict:
+    """Build the canonical usage vector + provenance for one LLM call.
+
+    input_uncached: prompt tokens billed at the full input rate.
+    cache_read: tokens served from the provider's prompt cache.
+    cache_write: tokens written to cache (Anthropic; 0 elsewhere today).
+    output: completion tokens, excluding reasoning where separable.
+    reasoning: thinking tokens billed at the output rate (Gemini reports
+        them separately; other providers fold them into output).
+    endpoint: "sync" | "stream" | "batch" -- batch-tagged usage is what the
+        batch discount applies to in cost computation.
+    """
+    return {
+        "input_uncached": input_uncached,
+        "cache_read": cache_read,
+        "cache_write": cache_write,
+        "output": output,
+        "reasoning": reasoning,
+        "total": input_uncached + cache_read + cache_write + output + reasoning,
+        "provider": provider,
+        "model": model,
+        "endpoint": endpoint,
+    }
+
+
+def _gemini_usage(usage_meta, *, model: str, endpoint: str) -> dict:
+    """Normalize a Gemini usage_metadata object (sync and stream paths).
+
+    prompt_token_count includes the cached share, so the uncached part is the
+    difference. thoughts_token_count is disjoint from candidates_token_count
+    (their sum plus the prompt is total_token_count), which is why the legacy
+    provider total disagrees with input+output on thinking models.
+    """
+    prompt = getattr(usage_meta, "prompt_token_count", 0) or 0
+    candidates = getattr(usage_meta, "candidates_token_count", 0) or 0
+    total = getattr(usage_meta, "total_token_count", 0) or 0
+    cached = getattr(usage_meta, "cached_content_token_count", 0) or 0
+    thoughts = getattr(usage_meta, "thoughts_token_count", 0) or 0
+    return {
+        "input_tokens": prompt,
+        "output_tokens": candidates,
+        "total_tokens": total,
+        **normalize_usage(
+            "gemini",
+            model,
+            endpoint,
+            input_uncached=prompt - cached,
+            cache_read=cached,
+            output=candidates,
+            reasoning=thoughts,
+        ),
+    }
+
+
+def _gemini_batch_usage(usage_meta: dict, *, model: str) -> dict:
+    """Normalize the camelCase usageMetadata dict from a Gemini batch result."""
+    prompt = usage_meta.get("promptTokenCount", 0) or 0
+    candidates = usage_meta.get("candidatesTokenCount", 0) or 0
+    total = usage_meta.get("totalTokenCount", 0) or 0
+    cached = usage_meta.get("cachedContentTokenCount", 0) or 0
+    thoughts = usage_meta.get("thoughtsTokenCount", 0) or 0
+    return {
+        "input_tokens": prompt,
+        "output_tokens": candidates,
+        "total_tokens": total,
+        **normalize_usage(
+            "gemini",
+            model,
+            "batch",
+            input_uncached=prompt - cached,
+            cache_read=cached,
+            output=candidates,
+            reasoning=thoughts,
+        ),
+    }
+
+
+def _openai_style_usage(usage_obj, *, provider: str, model: str, endpoint: str) -> dict:
+    """Normalize an OpenAI-shaped usage object (OpenAI + Together, sync/stream).
+
+    prompt_tokens includes the cached share, reported under
+    prompt_tokens_details.cached_tokens. Together populates it too (observed
+    live on DeepSeek-V4-Pro); whether Together discounts those tokens is a
+    pricing-table question, not a capture question. GPT-5.6-generation models
+    additionally meter cache writes (billed at 1.25x input) under
+    prompt_tokens_details.cache_write_tokens -- also a subset of
+    prompt_tokens, disjoint from cached_tokens (verified live on
+    gpt-5.6-luna: prompt 1120 = 1117 written + 3 uncached). usage_obj may be
+    None (Together streams sometimes never deliver the usage chunk): every
+    bucket records 0 rather than a guess.
+    """
+    prompt = getattr(usage_obj, "prompt_tokens", 0) or 0
+    completion = getattr(usage_obj, "completion_tokens", 0) or 0
+    total = getattr(usage_obj, "total_tokens", 0) or 0
+    details = getattr(usage_obj, "prompt_tokens_details", None)
+    cached = (getattr(details, "cached_tokens", 0) or 0) if details is not None else 0
+    written = (
+        (getattr(details, "cache_write_tokens", 0) or 0) if details is not None else 0
+    )
+    return {
+        "input_tokens": prompt,
+        "output_tokens": completion,
+        "total_tokens": total,
+        "cached_tokens": cached,
+        **normalize_usage(
+            provider,
+            model,
+            endpoint,
+            input_uncached=prompt - cached - written,
+            cache_read=cached,
+            cache_write=written,
+            output=completion,
+        ),
+    }
+
+
+def _openai_batch_usage(usage: dict, *, model: str) -> dict:
+    """Normalize the usage dict from an OpenAI batch result line.
+
+    Prompt caching does not apply on the OpenAI Batch API, so the whole prompt
+    is uncached by construction -- cache_read is forced to 0 even if a
+    cached_tokens field ever appears in a batch response body.
+    """
+    prompt = usage.get("prompt_tokens", 0) or 0
+    completion = usage.get("completion_tokens", 0) or 0
+    total = usage.get("total_tokens", 0) or 0
+    return {
+        "input_tokens": prompt,
+        "output_tokens": completion,
+        "total_tokens": total,
+        **normalize_usage(
+            "openai",
+            model,
+            "batch",
+            input_uncached=prompt,
+            output=completion,
+        ),
+    }
+
+
+def _anthropic_usage(usage, *, model: str, endpoint: str) -> dict:
     """Normalize an Anthropic usage object into the shared usage dict.
 
-    Shared by the streamed and non-streamed paths so both report identically.
+    Shared by the sync, streamed, and batch paths so all report identically.
+    Anthropic's input_tokens already excludes the cache buckets (the three are
+    disjoint), so it maps straight to input_uncached -- the cache buckets must
+    never be re-added at the base input rate.
     """
     input_tokens = usage.input_tokens or 0
     output_tokens = usage.output_tokens or 0
+    cache_write = getattr(usage, "cache_creation_input_tokens", 0) or 0
+    cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "total_tokens": input_tokens + output_tokens,
-        "cache_creation_input_tokens": getattr(usage, "cache_creation_input_tokens", 0)
-        or 0,
-        "cache_read_input_tokens": getattr(usage, "cache_read_input_tokens", 0) or 0,
+        "cache_creation_input_tokens": cache_write,
+        "cache_read_input_tokens": cache_read,
+        **normalize_usage(
+            "anthropic",
+            model,
+            endpoint,
+            input_uncached=input_tokens,
+            cache_read=cache_read,
+            cache_write=cache_write,
+            output=output_tokens,
+        ),
+    }
+
+
+def _zero_usage(provider: str, model: str, endpoint: str) -> dict:
+    """Zeroed usage row for failed calls -- keeps the canonical keys present."""
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        **normalize_usage(provider, model, endpoint),
     }
 
 
@@ -1285,7 +1459,7 @@ def run_sync_entries(
             raw_entries[key] = {
                 "text": "",
                 "error": str(e),
-                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "usage": _zero_usage(client.provider, client.model, "sync"),
             }
     return raw_entries
 
@@ -1507,21 +1681,17 @@ def _run_batch_gemini(
                     parts = candidates[0].get("content", {}).get("parts", [])
                     if parts:
                         text = parts[0].get("text", "")
-                usage = response.get("usageMetadata", {})
+                usage_meta = response.get("usageMetadata", {})
                 raw_entries[key] = {
                     "text": text,
-                    "usage": {
-                        "input_tokens": usage.get("promptTokenCount", 0),
-                        "output_tokens": usage.get("candidatesTokenCount", 0),
-                        "total_tokens": usage.get("totalTokenCount", 0),
-                    },
+                    "usage": _gemini_batch_usage(usage_meta, model=client.model),
                 }
             else:
                 error = result.get("error")
                 raw_entries[key] = {
                     "text": "",
                     "error": str(error) if error else "No response",
-                    "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    "usage": _zero_usage("gemini", client.model, "batch"),
                 }
         return raw_entries
     finally:
@@ -1666,7 +1836,7 @@ def _run_batch_openai(
                 raw_entries[key] = {
                     "text": "",
                     "error": str(error),
-                    "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    "usage": _zero_usage("openai", client.model, "batch"),
                 }
                 continue
 
@@ -1679,11 +1849,7 @@ def _run_batch_openai(
             usage = response_body.get("usage", {})
             raw_entries[key] = {
                 "text": text,
-                "usage": {
-                    "input_tokens": usage.get("prompt_tokens", 0),
-                    "output_tokens": usage.get("completion_tokens", 0),
-                    "total_tokens": usage.get("total_tokens", 0),
-                },
+                "usage": _openai_batch_usage(usage, model=client.model),
             }
         return raw_entries
     finally:
@@ -1878,12 +2044,9 @@ def _run_batch_anthropic(
             text = _extract_anthropic_text(message.content)
             if json_mode:
                 text = _strip_json_fences(text)
-            usage = {
-                "input_tokens": message.usage.input_tokens or 0,
-                "output_tokens": message.usage.output_tokens or 0,
-                "total_tokens": (message.usage.input_tokens or 0)
-                + (message.usage.output_tokens or 0),
-            }
+            usage = _anthropic_usage(
+                message.usage, model=client.model, endpoint="batch"
+            )
             raw_entries[key] = {"text": text, "usage": usage}
         else:
             error_msg = f"{result.result.type}"
@@ -1892,7 +2055,7 @@ def _run_batch_anthropic(
             raw_entries[key] = {
                 "text": "",
                 "error": error_msg,
-                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "usage": _zero_usage("anthropic", client.model, "batch"),
             }
 
     return raw_entries

--- a/tests/tutormoments/test_client.py
+++ b/tests/tutormoments/test_client.py
@@ -519,11 +519,23 @@ def test_run_sync_entries_records_error_per_key(monkeypatch):
             out = run_sync_entries(c, [build_batch_entry("k1", "p1")])
     assert out["k1"]["text"] == ""
     assert "boom" in out["k1"]["error"]
-    assert out["k1"]["usage"] == {
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "total_tokens": 0,
-    }
+    # Error rows keep zeros but carry the canonical keys + provenance.
+    usage = out["k1"]["usage"]
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "input_uncached",
+        "cache_read",
+        "cache_write",
+        "output",
+        "reasoning",
+        "total",
+    ):
+        assert usage[key] == 0
+    assert usage["provider"] == "anthropic"
+    assert usage["model"] == "claude-opus-4-6"
+    assert usage["endpoint"] == "sync"
 
 
 def test_run_batch_anthropic_remaps_custom_ids(monkeypatch):
@@ -548,7 +560,12 @@ def test_run_batch_anthropic_remaps_custom_ids(monkeypatch):
             b.type = "text"
             b.text = text
             msg.content = [b]
-            msg.usage = MagicMock(input_tokens=1, output_tokens=1)
+            msg.usage = MagicMock(
+                input_tokens=1,
+                output_tokens=1,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
             r.result.message = msg
             return r
 
@@ -618,7 +635,12 @@ def test_run_batch_anthropic_resume_rebuilds_id_map(monkeypatch):
             b.type = "text"
             b.text = text
             msg.content = [b]
-            msg.usage = MagicMock(input_tokens=1, output_tokens=1)
+            msg.usage = MagicMock(
+                input_tokens=1,
+                output_tokens=1,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
             r.result.message = msg
             return r
 
@@ -743,3 +765,360 @@ def test_run_batch_unsupported_provider_raises(monkeypatch):
         c = ModelClient("deepseek-ai/DeepSeek-V3")
         with pytest.raises(ValueError, match="Batch API not supported"):
             run_batch(c, [build_batch_entry("k", "p")], poll_interval=0)
+
+
+# ===================================================================
+# Canonical usage vector (cost tracking, Phase 1)
+# ===================================================================
+
+from types import SimpleNamespace
+
+from tutormoments.client import normalize_usage
+
+
+def test_normalize_usage_total_is_derived_and_provenance_rides_along():
+    u = normalize_usage(
+        "gemini",
+        "gemini-3.1-pro-preview",
+        "sync",
+        input_uncached=200,
+        cache_read=100,
+        cache_write=25,
+        output=30,
+        reasoning=50,
+    )
+    assert u["total"] == 405  # one definition: sum of the five buckets
+    assert u["provider"] == "gemini"
+    assert u["model"] == "gemini-3.1-pro-preview"
+    assert u["endpoint"] == "sync"
+
+
+def test_model_response_default_usage_has_canonical_zero_vector():
+    usage = ModelResponse("x").usage
+    for key in ("input_uncached", "cache_read", "cache_write", "output", "reasoning"):
+        assert usage[key] == 0
+    assert usage["total"] == 0
+
+
+def _gemini_usage_meta(prompt=300, candidates=25, cached=100, thoughts=50):
+    return SimpleNamespace(
+        prompt_token_count=prompt,
+        candidates_token_count=candidates,
+        total_token_count=prompt + candidates + thoughts,
+        cached_content_token_count=cached,
+        thoughts_token_count=thoughts,
+    )
+
+
+def _assert_gemini_vector(usage, endpoint):
+    assert usage["input_uncached"] == 200  # prompt 300 minus 100 cached
+    assert usage["cache_read"] == 100
+    assert usage["cache_write"] == 0
+    assert usage["output"] == 25
+    assert usage["reasoning"] == 50
+    # Canonical total agrees with the provider's thinking-inclusive total,
+    # unlike legacy input+output recomputation.
+    assert usage["total"] == 375
+    assert usage["total_tokens"] == 375
+    assert usage["provider"] == "gemini"
+    assert usage["endpoint"] == endpoint
+
+
+def test_gemini_sync_captures_cache_read_and_reasoning(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "k")
+    with patch("google.genai.Client") as MockGenai:
+        client_obj = MagicMock()
+        client_obj.models.generate_content.return_value = SimpleNamespace(
+            text="hi", usage_metadata=_gemini_usage_meta()
+        )
+        MockGenai.return_value = client_obj
+        resp = ModelClient("gemini-3.1-pro-preview").generate("Q", json_mode=False)
+    _assert_gemini_vector(resp.usage, "sync")
+
+
+def test_gemini_stream_captures_cache_read_and_reasoning(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "k")
+    chunk = SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[SimpleNamespace(text="hi", thought=False)]
+                )
+            )
+        ],
+        usage_metadata=_gemini_usage_meta(),
+    )
+    with patch("google.genai.Client") as MockGenai:
+        client_obj = MagicMock()
+        client_obj.models.generate_content_stream.return_value = iter([chunk])
+        MockGenai.return_value = client_obj
+        resp = ModelClient("gemini-3.1-pro-preview").generate(
+            "Q", json_mode=False, stream=True
+        )
+    _assert_gemini_vector(resp.usage, "stream")
+
+
+def test_openai_sync_splits_cached_tokens_out_of_prompt(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))],
+        usage=SimpleNamespace(
+            prompt_tokens=500,
+            completion_tokens=20,
+            total_tokens=520,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=400),
+        ),
+    )
+    with patch("openai.OpenAI") as MockOpenAI:
+        client_obj = MagicMock()
+        client_obj.chat.completions.create.return_value = response
+        MockOpenAI.return_value = client_obj
+        resp = ModelClient("gpt-5.5-2026-04-23").generate("Q", json_mode=False)
+    usage = resp.usage
+    assert usage["input_uncached"] == 100
+    assert usage["cache_read"] == 400
+    assert usage["reasoning"] == 0
+    assert usage["output"] == 20
+    assert usage["total"] == 520
+    assert usage["input_tokens"] == 500  # legacy keys preserved
+    assert usage["provider"] == "openai"
+    assert usage["endpoint"] == "sync"
+
+
+def test_openai_sync_captures_cache_write_tokens(monkeypatch):
+    """GPT-5.6-generation models meter cache writes (billed at 1.25x input)
+    under prompt_tokens_details.cache_write_tokens, a subset of prompt_tokens
+    disjoint from cached_tokens. Mirrors live gpt-5.6-luna evidence
+    (2026-08-24): prompt 1120 = 1117 written + 3 uncached, plus a mixed case.
+    Older models' usage objects lack the attribute entirely -> 0 (covered by
+    test_openai_sync_splits_cached_tokens_out_of_prompt's fixture)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))],
+        usage=SimpleNamespace(
+            prompt_tokens=1120,
+            completion_tokens=5,
+            total_tokens=1125,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=100, cache_write_tokens=1017
+            ),
+        ),
+    )
+    with patch("openai.OpenAI") as MockOpenAI:
+        client_obj = MagicMock()
+        client_obj.chat.completions.create.return_value = response
+        MockOpenAI.return_value = client_obj
+        resp = ModelClient("gpt-5.5-2026-04-23").generate("Q", json_mode=False)
+    usage = resp.usage
+    assert usage["cache_write"] == 1017
+    assert usage["cache_read"] == 100
+    assert usage["input_uncached"] == 3  # prompt - cached - written
+    assert usage["output"] == 5
+    assert usage["total"] == 1125
+    assert usage["input_tokens"] == 1120  # legacy key untouched
+
+
+def test_together_sync_and_stream_report_identical_vectors(monkeypatch):
+    """Regression for the sync/stream asymmetry: the sync Together path used
+    to drop cached_tokens that the streamed path captured."""
+    monkeypatch.setenv("TOGETHER_API_KEY", "sk-test")
+    usage_obj = SimpleNamespace(
+        prompt_tokens=50,
+        completion_tokens=10,
+        total_tokens=60,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=7),
+    )
+
+    with patch("openai.OpenAI") as MockOpenAI:
+        client_obj = MagicMock()
+        client_obj.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))],
+            usage=usage_obj,
+        )
+        MockOpenAI.return_value = client_obj
+        sync_usage = (
+            ModelClient("deepseek-ai/DeepSeek-V4-Pro")
+            .generate("Q", json_mode=False)
+            .usage
+        )
+
+    chunks = [
+        SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="hi"))], usage=None
+        ),
+        SimpleNamespace(choices=[], usage=usage_obj),
+    ]
+    with patch("openai.OpenAI") as MockOpenAI:
+        client_obj = MagicMock()
+        client_obj.chat.completions.create.return_value = iter(chunks)
+        MockOpenAI.return_value = client_obj
+        stream_usage = (
+            ModelClient("deepseek-ai/DeepSeek-V4-Pro")
+            .generate("Q", json_mode=False, stream=True)
+            .usage
+        )
+
+    assert sync_usage["cached_tokens"] == 7
+    assert sync_usage["cache_read"] == 7
+    assert sync_usage["input_uncached"] == 43
+    assert sync_usage["provider"] == "together"
+    assert sync_usage["endpoint"] == "sync"
+    assert stream_usage["endpoint"] == "stream"
+    for key, value in sync_usage.items():
+        if key != "endpoint":
+            assert stream_usage[key] == value, key
+
+
+def test_anthropic_sync_cache_buckets_stay_disjoint_from_input(monkeypatch):
+    """input_tokens already excludes the cache buckets, so input_uncached maps
+    to it directly -- re-adding cache tokens at the base rate is the
+    double-count trap the costing layer guards against."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    msg = _fake_anthropic_message("hi", in_tok=10, out_tok=5)
+    msg.usage = MagicMock(
+        input_tokens=10,
+        output_tokens=5,
+        cache_creation_input_tokens=100,
+        cache_read_input_tokens=800,
+    )
+    with patch("anthropic.Anthropic") as MockAnthropic:
+        client_obj = MagicMock()
+        client_obj.messages.create.return_value = msg
+        MockAnthropic.return_value = client_obj
+        resp = ModelClient("claude-opus-4-6").generate("Q", json_mode=False)
+    usage = resp.usage
+    assert usage["input_uncached"] == 10
+    assert usage["cache_read"] == 800
+    assert usage["cache_write"] == 100
+    assert usage["output"] == 5
+    assert usage["total"] == 915
+    assert usage["total_tokens"] == 15  # legacy definition unchanged
+    assert usage["endpoint"] == "sync"
+
+
+def test_run_batch_anthropic_cache_fields_survive(monkeypatch):
+    """Regression for the open-coded batch usage dict that silently dropped
+    the cache buckets: the batch path must route through _anthropic_usage."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    with (
+        patch("anthropic.Anthropic") as MockAnthropic,
+        patch("tutormoments.client.time.sleep"),
+    ):
+        client_obj = MagicMock()
+        batch = MagicMock()
+        batch.id = "b1"
+        batch.processing_status = "ended"
+        client_obj.messages.batches.create.return_value = batch
+        client_obj.messages.batches.retrieve.return_value = batch
+
+        r = MagicMock()
+        r.custom_id = "r0"
+        r.result.type = "succeeded"
+        msg = MagicMock()
+        block = MagicMock()
+        block.type = "text"
+        block.text = "A"
+        msg.content = [block]
+        msg.usage = MagicMock(
+            input_tokens=10,
+            output_tokens=5,
+            cache_creation_input_tokens=55,
+            cache_read_input_tokens=1234,
+        )
+        r.result.message = msg
+        client_obj.messages.batches.results.return_value = [r]
+        MockAnthropic.return_value = client_obj
+        c = ModelClient("claude-opus-4-6")
+        out = run_batch(c, [build_batch_entry("kA", "pA")], poll_interval=0)
+    usage = out["kA"]["usage"]
+    assert usage["cache_read"] == 1234
+    assert usage["cache_write"] == 55
+    assert usage["cache_read_input_tokens"] == 1234  # legacy key too
+    assert usage["input_uncached"] == 10
+    assert usage["total"] == 1304
+    assert usage["endpoint"] == "batch"
+    assert usage["provider"] == "anthropic"
+
+
+def test_run_batch_openai_forces_cache_read_zero(monkeypatch):
+    """Prompt caching does not apply on the OpenAI Batch API, so cache_read is
+    0 by construction even if the response body carries a cached_tokens field."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    with patch("openai.OpenAI") as MockOpenAI, patch("tutormoments.client.time.sleep"):
+        client_obj = MagicMock()
+        uploaded = MagicMock()
+        uploaded.id = "file-1"
+        client_obj.files.create.return_value = uploaded
+        batch = MagicMock()
+        batch.id = "ob1"
+        batch.status = "completed"
+        batch.output_file_id = "out-1"
+        client_obj.batches.create.return_value = batch
+        client_obj.batches.retrieve.return_value = batch
+        line = json.dumps(
+            {
+                "custom_id": "kA",
+                "response": {
+                    "body": {
+                        "choices": [{"message": {"content": "A"}}],
+                        "usage": {
+                            "prompt_tokens": 12,
+                            "completion_tokens": 3,
+                            "total_tokens": 15,
+                            "prompt_tokens_details": {"cached_tokens": 9},
+                        },
+                    }
+                },
+            }
+        )
+        content_obj = MagicMock()
+        content_obj.content = line.encode("utf-8")
+        client_obj.files.content.return_value = content_obj
+        MockOpenAI.return_value = client_obj
+        c = ModelClient("gpt-5.4")
+        out = run_batch(c, [build_batch_entry("kA", "pA")], poll_interval=0)
+    usage = out["kA"]["usage"]
+    assert usage["cache_read"] == 0
+    assert usage["input_uncached"] == 12
+    assert usage["output"] == 3
+    assert usage["total"] == 15
+    assert usage["endpoint"] == "batch"
+    assert usage["provider"] == "openai"
+
+
+def test_run_batch_gemini_captures_cache_read_and_reasoning(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "key-test")
+    with (
+        patch("google.genai.Client") as MockGenai,
+        patch("tutormoments.client.time.sleep"),
+    ):
+        client_obj = MagicMock()
+        uploaded = MagicMock()
+        uploaded.name = "files/up1"
+        client_obj.files.upload.return_value = uploaded
+        batch = MagicMock()
+        batch.name = "batches/gb1"
+        batch.state.name = "JOB_STATE_SUCCEEDED"
+        batch.dest.file_name = "files/out1"
+        client_obj.batches.create.return_value = batch
+        client_obj.batches.get.return_value = batch
+        line = json.dumps(
+            {
+                "key": "kA",
+                "response": {
+                    "candidates": [{"content": {"parts": [{"text": "A"}]}}],
+                    "usageMetadata": {
+                        "promptTokenCount": 300,
+                        "candidatesTokenCount": 25,
+                        "totalTokenCount": 375,
+                        "cachedContentTokenCount": 100,
+                        "thoughtsTokenCount": 50,
+                    },
+                },
+            }
+        )
+        client_obj.files.download.return_value = line.encode("utf-8")
+        MockGenai.return_value = client_obj
+        c = ModelClient("gemini-3.1-pro-preview")
+        out = run_batch(c, [build_batch_entry("kA", "pA")], poll_interval=0)
+    _assert_gemini_vector(out["kA"]["usage"], "batch")


### PR DESCRIPTION
## What

Every LLM call now normalizes provider usage into one canonical vector — `input_uncached` / `cache_read` / `cache_write` / `output` / `reasoning`, with a derived `total` — plus provenance (`provider`, `model`, `endpoint`), via `normalize_usage()` and per-provider extractors in `client.py`.

## Why

This is the data layer for real cost accounting (phase 1 of the cost-tracking plan). Providers bill these buckets at very different rates — cache reads ~0.1× input, cache writes 1.25×, batch 0.5× — and report them incompatibly: OpenAI/Gemini include cached tokens *inside* their prompt-token count, Anthropic reports cache buckets *disjoint* from `input_tokens`. A single input-token count therefore cannot price a call, and today's recorded totals both overstate (cached tokens at full price, no batch discount) and understate (Anthropic cache volume and Gemini reasoning tokens dropped entirely) what the bill says.

## Per-provider fixes folded in

- **Gemini**: capture `cached_content_token_count` and `thoughts_token_count` (reasoning tokens were previously invisible to totals).
- **OpenAI**: split `cached_tokens` out of `prompt_tokens`; capture `cache_write_tokens` — GPT-5.6-gen models meter cache writes at 1.25×, verified live (prompt 1120 = 1117 written + 3 uncached).
- **Together**: sync path now captures `cached_tokens` like the streamed path did; live DeepSeek-V4-Pro calls report ~96% cached, contradicting the old "caching isn't supported" comment.
- **Anthropic batch**: route through `_anthropic_usage` so cache buckets survive (an open-coded dict was silently dropping them).
- Batch paths tagged `endpoint="batch"`; OpenAI batch forces `cache_read=0` (prompt caching does not apply on the OpenAI Batch API).
- Error rows keep zeros but gain the canonical keys and provenance.

## Compatibility

Legacy keys (`input_tokens`/`output_tokens`/`total_tokens`, `cached_tokens`, `cache_*_input_tokens`) still ride along in every usage dict, so the existing three-key accumulators and all current readers are unaffected. Aggregation moves to the canonical vector in a follow-up.

## Verification

1. **Mocked unit tests** per provider and path (sync/stream/batch), including regressions for the Together sync/stream asymmetry and the Anthropic batch cache-field drop.
2. **Live smoke** on all four providers (claude-sonnet-5, gemini-3.6-flash, gpt-5.6-luna, deepseek-ai/DeepSeek-V4-Pro), sync + stream: canonical keys present, `total` = sum of buckets, provenance correct, legacy↔canonical identities hold.
3. **Reconciliation against provider billing dashboards**: OpenAI matched exactly (reads 10,116; writes ~16.3K; uncached 18); Anthropic cache reads matched exactly (7,924).


## Scope — what this PR deliberately does *not* do

This is the first PR of a planned sequence; it is capture-only and changes no benchmark behavior or on-disk output. Deferred on purpose:

1. **Aggregation** (next PR): the accumulators in `conversation.py` / `scoring.py` still sum only the three legacy keys, so the canonical vector does not yet survive into transcripts or `summary.json`. This PR makes the data exist at the call boundary; the follow-up makes it persist.
2. **Run-level totals**: `summary.json` still omits scorer usage and still recomputes `total_tokens = input + output` (which drops Gemini reasoning tokens). Fixed together with aggregation.
3. **Dollar costs**: a versioned pricing table and a costing module (list cost per tutor conversation, cache-aware; billed-cost estimate with the batch discount) come after aggregation — there is nothing to price until the vector persists.
4. **Open pricing questions** tracked for that PR: whether Together discounts the `cached_tokens` it reports, and whether Gemini implicit caching applies inside its batch endpoint.

Reviewing this PR = reviewing the field mappings and the identities in the tests (`total` = sum of buckets; OpenAI/Gemini/Together: `prompt_tokens` = `input_uncached + cache_read + cache_write`; Anthropic: cache buckets disjoint from `input_tokens`). The dashboard reconciliations above validated exactly those mappings against what the providers actually bill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
