### PR TITLE
Explicit provider-native model configs, a facts-only registry, and a live smoke layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
-# API keys - Only the providers you want to run are required
+# API keys - Only the providers you want to run are required.
+# Note: `tutormoments smoke` needs the key for every provider in your active
+# config (narrow with --providers to smoke a subset).
 GEMINI_API_KEY=<your_key_here>
 OPENAI_API_KEY=<your_key_here>
 ANTHROPIC_API_KEY=<your_key_here>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What
+
+<!-- What does this PR change, and why? -->
+
+## Checklist
+
+- [ ] `pytest tests -q` passes locally.
+- [ ] If this PR touches core API wire-format paths (`src/tutormoments/client.py`,
+  `models.py`, `models.yaml`, `config.py`, `default_config.yaml`, `smoke.py`):
+  I ran `tutormoments smoke` locally and all checks passed. Paste the summary
+  line here:
+
+  ```
+  smoke: _ passed, _ warnings, _ failed
+  ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,50 @@ jobs:
       # without real API calls, so this is safe for pull requests from forks.
       - run: pip install -e ".[dev,build-dev,analysis]"
       - run: pytest tests -q
+
+  # Advisory only, always green: CI is offline by design (no secrets, safe for
+  # fork PRs), so it CANNOT verify that providers accept our wire formats.
+  # When a PR touches the files that build provider payloads, this job reminds
+  # the author to run `tutormoments smoke` locally (real API calls, costs
+  # cents) and tick the checklist item in the PR description.
+  smoke-reminder:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # sticky comment; read-only on fork PRs (step is best-effort)
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: core
+        name: Detect core-API changes
+        run: |
+          CORE='src/tutormoments/client.py src/tutormoments/models.py src/tutormoments/models.yaml src/tutormoments/config.py src/tutormoments/default_config.yaml src/tutormoments/smoke.py'
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- $CORE | grep -q .; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.core.outputs.touched == 'true'
+        name: Post step summary
+        run: |
+          {
+            echo '## Live smoke test reminder (advisory)'
+            echo 'This PR touches provider wire-format code (client.py / models.py /'
+            echo 'models.yaml / config.py / default_config.yaml / smoke.py).'
+            echo 'CI cannot verify real API acceptance -- it runs offline by design.'
+            echo 'Run `tutormoments smoke` locally and check the box in the PR description.'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - if: steps.core.outputs.touched == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        name: Upsert sticky PR comment (same-repo PRs only)
+        continue-on-error: true
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- smoke-reminder -->';
+            const body = marker + '\n**Advisory:** this PR touches core API wire-format paths. ' +
+              'Please run `tutormoments smoke` locally and tick the smoke checklist item in the ' +
+              'PR description. CI is offline by design and cannot verify provider acceptance.';
+            const {data: comments} = await github.rest.issues.listComments(
+              {...context.repo, issue_number: context.issue.number});
+            const prev = comments.find(c => c.body.includes(marker));
+            if (prev) await github.rest.issues.updateComment({...context.repo, comment_id: prev.id, body});
+            else await github.rest.issues.createComment({...context.repo, issue_number: context.issue.number, body});

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,15 +51,17 @@ imports them.
   response, which is recorded as `"..."` and scored as if the tutor said it.
   Never reintroduce a cap to save tokens.
 - Never make choices about which language model to use or language model configuration for any API call without consulting the user; this is a language model benchmark, the choice of model matters
-- `src/tutormoments/models.yaml` (the model registry) is benchmark-defining LM
-  configuration: its ladder->wire mappings decide what each thinking condition
-  actually sends to a provider. Never edit it without consulting the user, and
-  verify new or changed rungs live with `tutormoments smoke` before relying on
-  them. Config states only canonical `thinking:` ladder levels
-  (none/low/high/xhigh/dynamic, required on every arm and
-  role block); the raw provider knobs (boolean `thinking`, `thinking_budget`,
-  `reasoning_effort`, `effort`) are invalid in config and rejected at load.
+- Tutor benchmark arms live in `benchmark_models:` and state exact
+  provider-native reasoning parameters in the config YAML, plus a `condition`
+  label for grouping results. Reviewers should not have to reverse-engineer
+  hidden ladder mappings to know what was run. The student/scorer/taxonomy/
+  groundtruth role blocks still use canonical `thinking:` ladder levels
+  (none/low/high/xhigh/dynamic) because they are fixed evaluation apparatus.
   See docs/thinking.md.
+- `src/tutormoments/models.yaml` (the model registry) remains benchmark-
+  defining for stable model facts and the legacy/role thinking ladder. Never
+  edit it without consulting the user, and verify new or changed ladder rungs
+  live with `tutormoments smoke` before relying on them.
 - The offline suite can only prove the code agrees with itself. The live
   verification layer is `tutormoments smoke` (one tiny real call per
   configured arm/role plus a submit-then-cancel batch per provider): run it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,24 @@ imports them.
   response, which is recorded as `"..."` and scored as if the tutor said it.
   Never reintroduce a cap to save tokens.
 - Never make choices about which language model to use or language model configuration for any API call without consulting the user; this is a language model benchmark, the choice of model matters
+- `src/tutormoments/models.yaml` (the model registry) is benchmark-defining LM
+  configuration: its ladder->wire mappings decide what each thinking condition
+  actually sends to a provider. Never edit it without consulting the user, and
+  verify new or changed rungs live with `tutormoments smoke` before relying on
+  them. Config states only canonical `thinking:` ladder levels
+  (none/minimal/low/medium/high/xhigh/max/dynamic, required on every arm and
+  role block); the raw provider knobs (boolean `thinking`, `thinking_budget`,
+  `reasoning_effort`, `effort`) are invalid in config and rejected at load.
+  See docs/thinking.md.
+- The offline suite can only prove the code agrees with itself. The live
+  verification layer is `tutormoments smoke` (one tiny real call per
+  configured arm/role plus a submit-then-cancel batch per provider): run it
+  before merging any PR that touches core API wire-format paths
+  (`src/tutormoments/client.py`, `models.py`, `models.yaml`, `config.py`,
+  `default_config.yaml`, `smoke.py` -- keep this list in sync with the
+  smoke-reminder job in .github/workflows/ci.yml). Smoke output goes to
+  stdout / gitignored `results/smoke/`, never committed. CI stays offline: no
+  API secrets in GitHub, ever (public repo, fork PRs).
 - This repo is public. PR commits are public. Before pushing anything to remote, think about whether it could expose unnecessary information.
 
 ## Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,17 +51,17 @@ imports them.
   response, which is recorded as `"..."` and scored as if the tutor said it.
   Never reintroduce a cap to save tokens.
 - Never make choices about which language model to use or language model configuration for any API call without consulting the user; this is a language model benchmark, the choice of model matters
-- Tutor benchmark arms live in `benchmark_models:` and state exact
-  provider-native reasoning parameters in the config YAML, plus a `condition`
-  label for grouping results. Reviewers should not have to reverse-engineer
-  hidden ladder mappings to know what was run. The student/scorer/taxonomy/
-  groundtruth role blocks still use canonical `thinking:` ladder levels
-  (none/low/high/xhigh/dynamic) because they are fixed evaluation apparatus.
-  See docs/thinking.md.
-- `src/tutormoments/models.yaml` (the model registry) remains benchmark-
-  defining for stable model facts and the legacy/role thinking ladder. Never
-  edit it without consulting the user, and verify new or changed ladder rungs
-  live with `tutormoments smoke` before relying on them.
+- Every model-bearing config block states exact provider-native reasoning
+  parameters in the config YAML: tutor arms live in `benchmark_models:` (plus
+  a `condition` label for grouping results), and the student/scorer/taxonomy/
+  groundtruth role blocks use the same provider-native keys. Reviewers should
+  never have to reverse-engineer a hidden mapping to know what was run. There
+  is no thinking ladder; parameters are shape-validated at config load and
+  proven live with `tutormoments smoke`. See docs/thinking.md.
+- `src/tutormoments/models.yaml` (the model registry) holds stable per-model
+  facts only: provider routing, pricing (the cost-tracking data), and output
+  caps. It is still benchmark-relevant (pricing and caps affect runs), so
+  never edit it without consulting the user.
 - The offline suite can only prove the code agrees with itself. The live
   verification layer is `tutormoments smoke` (one tiny real call per
   configured arm/role plus a submit-then-cancel batch per provider): run it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ imports them.
   actually sends to a provider. Never edit it without consulting the user, and
   verify new or changed rungs live with `tutormoments smoke` before relying on
   them. Config states only canonical `thinking:` ladder levels
-  (none/minimal/low/medium/high/xhigh/max/dynamic, required on every arm and
+  (none/low/high/xhigh/dynamic, required on every arm and
   role block); the raw provider knobs (boolean `thinking`, `thinking_budget`,
   `reasoning_effort`, `effort`) are invalid in config and rejected at load.
   See docs/thinking.md.

--- a/README.md
+++ b/README.md
@@ -126,30 +126,27 @@ The report and viewer commands read `summary.json` files from run directories.
 
 ## Running new tutor models
 
-The `models:` roster maps **arms** — benchmark conditions — not bare models.
-Each entry names a model (`model:` defaults to the key) and states its
-reasoning condition with a required `thinking:` level from the canonical
-ladder (`none | low | high | xhigh | dynamic`).
-The model registry (`src/tutormoments/models.yaml`) translates the level to
-each provider's wire knob and rejects conditions the model cannot honor —
-see `docs/thinking.md`. The same model can run under several arms:
+The `benchmark_models:` roster maps **arms** — benchmark conditions — not
+bare models. Each entry names the provider model id, states the exact
+provider-native reasoning parameters the run will send, and includes a
+`condition:` label for grouping results. This keeps the benchmark config
+auditable in provider parlance. The same model can run under several arms:
 
 ```yaml
-models:
-  my-new-model-id:        { thinking: high }
-  my-model-no-thinking:   { model: my-new-model-id, thinking: none }
+benchmark_models:
+  gemini-2.5-low: { model: gemini-2.5-pro, thinking_budget: 4096, condition: low }
+  gemini-2.5-dyn: { model: gemini-2.5-pro, thinking_budget: -1, condition: dynamic }
+  gpt-5.5-low:    { model: gpt-5.5-2026-04-23, reasoning: low, condition: low }
 ```
 
 ```bash
-tutormoments run --tutors my-new-model-id my-model-no-thinking --data_path <release dir>
+tutormoments run --tutors gemini-2.5-low gpt-5.5-low --data_path <release dir>
 ```
 
-Running a model for the first time needs (1) a `models:` entry for it in
-`src/tutormoments/models.yaml` (one reviewed entry: family + pricing — this
-is benchmark-defining configuration) and (2) the provider API key exported.
-The retired raw knobs (`thinking: true/false`, `thinking_budget`,
-`reasoning_effort`, `effort`) are rejected at config load with a migration
-hint.
+Running a model for the first time needs the provider API key exported and a
+model id whose provider can be inferred. `src/tutormoments/models.yaml` still
+holds stable per-model facts such as pricing and output caps; it no longer
+hides tutor-arm reasoning parameters from the run config.
 
 Tutors are selectable per-run via the CLI. The Student model is set in the config; changing the student model would change the shape of the evaluation. Modify your 
 config to swap the student model with another API-callable model:
@@ -158,11 +155,10 @@ config to swap the student model with another API-callable model:
 student: { model: claude-opus-4-6, mode: oracle, thinking: none } # default
 ```
 
-The student/scorer/taxonomy/groundtruth blocks use the same `{model, thinking}`
-shape as arms but deliberately do NOT reference an arm by name: the roster is
-the set of selectable tutor conditions, while the role blocks are the fixed
-evaluation apparatus. Keeping them inline means retuning a tutor arm can never
-silently change the student or the scoring regime as a side effect.
+The student/scorer/taxonomy/groundtruth blocks still use `{model, thinking}`
+with the canonical ladder because they are the fixed evaluation apparatus,
+not the tutor conditions being reported. Keeping them inline means retuning a
+tutor arm can never silently change the student or scoring regime.
 
 ## Custom Tutor / Student Models
 

--- a/README.md
+++ b/README.md
@@ -143,22 +143,25 @@ benchmark_models:
 tutormoments run --tutors gemini-2.5-low gpt-5.5-low --data_path <release dir>
 ```
 
-Running a model for the first time needs the provider API key exported and a
-model id whose provider can be inferred. `src/tutormoments/models.yaml` still
-holds stable per-model facts such as pricing and output caps; it no longer
-hides tutor-arm reasoning parameters from the run config.
+Running a model for the first time needs the provider API key exported and an
+entry in `src/tutormoments/models.yaml` — the per-model facts table (provider
+routing, pricing for cost tracking, output caps). It holds no reasoning
+configuration: what each arm sends is stated in the config YAML itself, in
+provider parlance, and validated at load (see `docs/thinking.md`). Verify a
+new arm live with `tutormoments smoke` before benchmarking it.
 
 Tutors are selectable per-run via the CLI. The Student model is set in the config; changing the student model would change the shape of the evaluation. Modify your 
 config to swap the student model with another API-callable model:
 
 ```yaml
-student: { model: claude-opus-4-6, mode: oracle, thinking: none } # default
+student: { model: claude-opus-4-6, mode: oracle, thinking: { type: disabled } } # default
 ```
 
-The student/scorer/taxonomy/groundtruth blocks still use `{model, thinking}`
-with the canonical ladder because they are the fixed evaluation apparatus,
-not the tutor conditions being reported. Keeping them inline means retuning a
-tutor arm can never silently change the student or scoring regime.
+The student/scorer/taxonomy/groundtruth blocks state their thinking
+parameters the same provider-native way as arms (minus `condition` — they are
+the fixed evaluation apparatus, not the tutor conditions being reported).
+Keeping them inline means retuning a tutor arm can never silently change the
+student or scoring regime.
 
 ## Custom Tutor / Student Models
 

--- a/README.md
+++ b/README.md
@@ -126,25 +126,36 @@ The report and viewer commands read `summary.json` files from run directories.
 
 ## Running new tutor models
 
-No code changes are needed for hosted models: add a roster entry in your config
-and export the provider API key. The provider is inferred from the model id
-(`claude-*` → anthropic, `gpt-*` → openai, `gemini-*` → gemini,
-`deepseek-ai/*` → together).
+The `models:` roster maps **arms** — benchmark conditions — not bare models.
+Each entry names a model (`model:` defaults to the key) and states its
+reasoning condition with a required `thinking:` level from the canonical
+ladder (`none | minimal | low | medium | high | xhigh | max | dynamic`).
+The model registry (`src/tutormoments/models.yaml`) translates the level to
+each provider's wire knob and rejects conditions the model cannot honor —
+see `docs/thinking.md`. The same model can run under several arms:
 
 ```yaml
 models:
-  my-new-model-id: { thinking: true, effort: high }
+  my-new-model-id:        { thinking: high }
+  my-model-no-thinking:   { model: my-new-model-id, thinking: none }
 ```
 
 ```bash
-tutormoments run --tutors my-new-model-id --data_path <release dir>
+tutormoments run --tutors my-new-model-id my-model-no-thinking --data_path <release dir>
 ```
+
+Running a model for the first time needs (1) a `models:` entry for it in
+`src/tutormoments/models.yaml` (one reviewed entry: family + pricing — this
+is benchmark-defining configuration) and (2) the provider API key exported.
+The retired raw knobs (`thinking: true/false`, `thinking_budget`,
+`reasoning_effort`, `effort`) are rejected at config load with a migration
+hint.
 
 Tutors are selectable per-run via the CLI. The Student model is set in the config; changing the student model would change the shape of the evaluation. Modify your 
 config to swap the student model with another API-callable model:
 
 ```yaml
-student: { model: claude-opus-4-6, mode: oracle, thinking: false } # default
+student: { model: claude-opus-4-6, mode: oracle, thinking: none } # default
 ```
 
 ## Custom Tutor / Student Models
@@ -382,6 +393,26 @@ Run the runtime test suite without real API calls:
 pytest tests/tutormoments -q          # runtime only (needs [dev])
 pytest tests -q                   # full suite (needs [dev,build-dev,analysis]; missing extras skip)
 ```
+
+### Live smoke checks
+
+The test suite mocks every provider SDK, so it can never prove a provider
+actually accepts our wire formats. `tutormoments smoke` is the live half: one
+tiny real call per configured arm/role with its exact thinking condition
+(costs cents), plus one submit-then-cancel batch per provider, with a
+thinking-evidence column that catches silently-ignored knobs. Run it before
+merging changes to core API logic (`client.py`, `models.py`, `models.yaml`,
+`config.py`, `default_config.yaml`, `smoke.py`) — CI posts an advisory
+reminder on such PRs but stays offline by design.
+
+```bash
+tutormoments smoke                          # everything in the active config
+tutormoments smoke --arms gemini-2.5-pro    # one arm
+tutormoments smoke --providers anthropic --no-batch
+```
+
+Exit codes: 0 = all passed, 1 = a check failed, 2 = config/environment error
+(a missing API key for a selected provider is an error, not a silent skip).
 
 
 ### Dataset construction (maintainers)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The report and viewer commands read `summary.json` files from run directories.
 The `models:` roster maps **arms** — benchmark conditions — not bare models.
 Each entry names a model (`model:` defaults to the key) and states its
 reasoning condition with a required `thinking:` level from the canonical
-ladder (`none | minimal | low | medium | high | xhigh | max | dynamic`).
+ladder (`none | low | high | xhigh | dynamic`).
 The model registry (`src/tutormoments/models.yaml`) translates the level to
 each provider's wire knob and rejects conditions the model cannot honor —
 see `docs/thinking.md`. The same model can run under several arms:

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ config to swap the student model with another API-callable model:
 student: { model: claude-opus-4-6, mode: oracle, thinking: none } # default
 ```
 
+The student/scorer/taxonomy/groundtruth blocks use the same `{model, thinking}`
+shape as arms but deliberately do NOT reference an arm by name: the roster is
+the set of selectable tutor conditions, while the role blocks are the fixed
+evaluation apparatus. Keeping them inline means retuning a tutor arm can never
+silently change the student or the scoring regime as a side effect.
+
 ## Custom Tutor / Student Models
 
 You can register a different approach to the LM Tutor / Synthetic student,

--- a/configs/local.example.yaml
+++ b/configs/local.example.yaml
@@ -15,18 +15,19 @@ providers:
   gemini:    { env: GEMINI_API_KEY }
   together:  { env: TOGETHER_API_KEY }
 
-# Each key is an ARM (a benchmark condition): `model` defaults to the key;
-# `thinking` is required (none/minimal/low/medium/high/xhigh/max/dynamic).
-# The same model may appear under several arms with different conditions:
-#   gpt-5.5-no-thinking: { model: gpt-5.5-2026-04-23, thinking: none }
-models:
-  claude-opus-4-8:             { thinking: xhigh }
-  claude-sonnet-4-6:           { thinking: high }
-  gemini-2.5-pro:              { thinking: dynamic }
-  gemini-3.5-flash:            { thinking: dynamic }
-  gpt-5.4-mini-2026-03-17:     { thinking: high }
-  gpt-5.5-2026-04-23:          { thinking: high }
-  deepseek-ai/DeepSeek-V4-Pro: { thinking: dynamic }
+# Each key is an ARM (a benchmark condition). `model` names the provider model
+# id, provider-native keys state the exact request parameters, and `condition`
+# is the grouping label written into results:
+#   gemini-2.5-low: { model: gemini-2.5-pro, thinking_budget: 4096, condition: low }
+#   gpt-5.5-low:   { model: gpt-5.5-2026-04-23, reasoning: low, condition: low }
+benchmark_models:
+  claude-opus-4-8:         { model: claude-opus-4-8, thinking: { type: adaptive }, effort: xhigh, condition: xhigh }
+  claude-sonnet-4-6:       { model: claude-sonnet-4-6, thinking: { type: adaptive }, effort: high, condition: high }
+  gemini-2.5-pro:          { model: gemini-2.5-pro, include_thoughts: true, thinking_budget: -1, condition: dynamic }
+  gemini-3.5-flash:        { model: gemini-3.5-flash, include_thoughts: true, thinking_budget: -1, condition: dynamic }
+  gpt-5.4-mini-2026-03-17: { model: gpt-5.4-mini-2026-03-17, reasoning: high, condition: high }
+  gpt-5.5-2026-04-23:      { model: gpt-5.5-2026-04-23, reasoning: high, condition: high }
+  deepseek-v4-pro:         { model: deepseek-ai/DeepSeek-V4-Pro, condition: dynamic }
 
 student: { model: claude-opus-4-6, mode: oracle, thinking: none }
 scorer:  { model: claude-opus-4-6, thinking: dynamic }

--- a/configs/local.example.yaml
+++ b/configs/local.example.yaml
@@ -29,8 +29,12 @@ benchmark_models:
   gpt-5.5-2026-04-23:      { model: gpt-5.5-2026-04-23, reasoning: high, condition: high }
   deepseek-v4-pro:         { model: deepseek-ai/DeepSeek-V4-Pro, condition: dynamic }
 
-student: { model: claude-opus-4-6, mode: oracle, thinking: none }
-scorer:  { model: claude-opus-4-6, thinking: dynamic }
+# Role blocks state provider-native thinking parameters the same way arms do.
+# "Off" is stated explicitly ({type: disabled}) rather than by omitting the
+# param, so the condition stays stable under model swaps and smoke can assert
+# it; `thinking: {type: adaptive}` is model-paced thinking.
+student: { model: claude-opus-4-6, mode: oracle, thinking: { type: disabled } }
+scorer:  { model: claude-opus-4-6, thinking: { type: adaptive } }
 
 defaults: { trials: 1, max_turns: 5 }
 retry:    { max_retries: 5, base_delay: 5 }

--- a/configs/local.example.yaml
+++ b/configs/local.example.yaml
@@ -15,17 +15,21 @@ providers:
   gemini:    { env: GEMINI_API_KEY }
   together:  { env: TOGETHER_API_KEY }
 
+# Each key is an ARM (a benchmark condition): `model` defaults to the key;
+# `thinking` is required (none/minimal/low/medium/high/xhigh/max/dynamic).
+# The same model may appear under several arms with different conditions:
+#   gpt-5.5-no-thinking: { model: gpt-5.5-2026-04-23, thinking: none }
 models:
-  claude-opus-4-8:             { thinking: true, effort: xhigh }
-  claude-sonnet-4-6:           { thinking: true, effort: high }
-  gemini-2.5-pro:              { thinking: true, thinking_budget: -1 }
-  gemini-3.5-flash:            { thinking: true, thinking_budget: -1 }
-  gpt-5.4-mini-2026-03-17:     { thinking: true, reasoning_effort: high }
-  gpt-5.5-2026-04-23:          { thinking: true, reasoning_effort: high }
-  deepseek-ai/DeepSeek-V4-Pro: {}
+  claude-opus-4-8:             { thinking: xhigh }
+  claude-sonnet-4-6:           { thinking: high }
+  gemini-2.5-pro:              { thinking: dynamic }
+  gemini-3.5-flash:            { thinking: dynamic }
+  gpt-5.4-mini-2026-03-17:     { thinking: high }
+  gpt-5.5-2026-04-23:          { thinking: high }
+  deepseek-ai/DeepSeek-V4-Pro: { thinking: dynamic }
 
-student: { model: claude-opus-4-6, mode: oracle, thinking: false }
-scorer:  { model: claude-opus-4-6, thinking: adaptive }
+student: { model: claude-opus-4-6, mode: oracle, thinking: none }
+scorer:  { model: claude-opus-4-6, thinking: dynamic }
 
 defaults: { trials: 1, max_turns: 5 }
 retry:    { max_retries: 5, base_delay: 5 }

--- a/docs/thinking.md
+++ b/docs/thinking.md
@@ -1,17 +1,18 @@
 # Benchmark thinking configuration
 
 How TutorMoments states, validates, and transmits model reasoning settings.
-Tutor arms are benchmark-defining: changing a configured provider knob changes
-the experiment. Verify changed arm settings against the live API with
+Every configured condition is benchmark-defining: changing a provider knob
+changes the experiment. Verify changed settings against the live API with
 `tutormoments smoke` before relying on them.
 
-## Tutor arms are explicit
+## Every condition is explicit, in provider parlance
 
 Providers expose reasoning depth through incompatible knobs
 (`thinking_budget`, `thinking_level`, `reasoning`, `effort`, provider-specific
 `thinking` blocks). Reviewers need to see the exact settings used for each
-benchmarked model in that provider's parlance, so the tutor roster uses
-`benchmark_models:`:
+benchmarked model in that provider's parlance, so config states them
+directly — there is no intermediate "thinking level" vocabulary to decode.
+The tutor roster is `benchmark_models:`:
 
 ```yaml
 benchmark_models:
@@ -25,71 +26,66 @@ provider model id. Provider-native keys are validated at config load and
 forwarded by the client. `condition` is the grouping label written to
 `config.json`, `summary.json`, latency probe output, and leaderboard rows.
 
-## Infrastructure roles use the ladder
-
-The student/scorer/taxonomy/groundtruth blocks use a smaller canonical ladder:
+The student/scorer/taxonomy/groundtruth role blocks state their thinking
+parameters the same way (minus `condition` — they are benchmark apparatus,
+not reported arms):
 
 ```yaml
-student: { model: claude-opus-4-6, mode: oracle, thinking: none }
-scorer:  { model: claude-opus-4-6, thinking: dynamic }
+student: { model: claude-opus-4-6, mode: oracle, thinking: { type: disabled } }
+scorer:  { model: claude-opus-4-6, thinking: { type: adaptive } }
 ```
 
-Those roles are benchmark apparatus rather than reported tutor arms. Keeping
-their settings on the ladder keeps one reviewed default for the fixed
-evaluation machinery while tutor-arm configs stay fully explicit.
+## The per-provider keys
 
-Rung meanings: `none` = thinking verifiably off; `low`/`high`/`xhigh` =
-explicit depth rungs; `dynamic` = the model decides (Gemini budget -1,
-Anthropic adaptive, open-weight internal reasoning).
+The allowed keys mirror exactly the knobs the client knows how to send; an
+unknown or provider-mismatched key is a config error at load time, before any
+tokens are spent. The authoritative validation is
+`tutormoments.models.resolve_thinking`; the contract tests in
+`tests/tutormoments/test_models.py` pin every wire fragment.
 
-## Legacy ladder mapping
+| provider | keys | wire form |
+|---|---|---|
+| anthropic | `thinking` (required; a thinking block or `null` = send no thinking param), `effort` (adaptive only) | `thinking={...}` plus `output_config.effort` (extra_body on sync, params on batch) |
+| gemini | exactly one of `thinking_budget` / `thinking_level`, optional `include_thoughts` | `generation_config.thinking_config` |
+| openai | `reasoning` (required) | `reasoning_effort` |
+| together | none (open-weight internal reasoners) | nothing sent |
 
-The authoritative copy is `src/tutormoments/models.yaml`; the contract tests
-in `tests/tutormoments/test_models.py` pin every cell. The mapping is used by
-infrastructure role blocks and by older `models:` configs still accepted for
-compatibility. Summary:
+Validation is shape-level: key ownership, mutual exclusion (Gemini's budget
+vs. level; the API 400s if both are sent), and structural rules (Anthropic
+`budget_tokens` only with `type: enabled` and positive; `effort` only with
+`type: adaptive`). Value vocabularies (which effort tiers or reasoning levels
+a given model accepts) are the provider's to extend, so they are proven live
+with `tutormoments smoke`, not enumerated offline.
 
-| family | none | low | high | xhigh | dynamic |
-|---|---|---|---|---|---|
-| anthropic 4.6 tier (opus/sonnet-4-6) | omit `thinking` | adaptive + effort low | high | – (no xhigh on 4.6) | `{type: adaptive}`, no effort |
-| anthropic 4.7+ (opus-4-7/4-8) | omit | adaptive + effort low | high | xhigh | `{type: adaptive}` |
-| anthropic sonnet-5 | `{type: disabled}` (omission runs adaptive on Sonnet 5) | low | high | xhigh | `{type: adaptive}` |
-| anthropic legacy (frozen pre-adaptive set) | omit | enabled+4096 | enabled+16384 | – | – |
-| gemini-2.5-pro | – (API rejects budget 0) | budget 4096 | 16384 | 32768 (2x high; the Pro budget cap — Pro only, Flash caps at 24576) | budget −1 |
-| gemini-2.5-flash | budget 0, include_thoughts false | 4096 | 16384 | – | budget −1 |
-| gemini-3.x | – (thinking_level floor is not off) | thinking_level low ⚠ | high ⚠ | – | budget −1 (the proven wire shape) |
-| openai gpt-5 line | reasoning_effort none ⚠ | low | high | xhigh ⚠ | – |
-| openai o-series | – (no off switch) | low | high | – | – |
-| together open-weight | – (always-thinking) | – | – | – | emit nothing |
+Provider notes:
+- Anthropic: what an omitted thinking param (`thinking: null`) means depends
+  on the model generation — thinking off on the 4.x tiers, adaptive on
+  Sonnet 5 and later. Prefer the explicit `thinking: {type: disabled}` for
+  "off": the condition then survives a model swap, and smoke can assert it
+  (an omitted param has no verifiable expectation and judges as "na").
+- Anthropic `enabled` mode keeps the `max_tokens >= budget + 64` headroom
+  rule; the client enforces it.
+- Gemini `thinking_budget: -1` is model-paced; `0` is off (rejected by
+  always-thinking models such as 2.5 Pro). `include_thoughts` defaults to
+  true except with budget 0. The 3.x line replaced `thinking_budget` with
+  `thinking_level`; every published 3.x run so far has used the budget `-1`
+  shape.
+- The OpenAI o-series exposes only a depth knob (`reasoning`), never an off
+  switch.
 
-"–" = unsatisfiable: config load raises. "⚠" = documented but not yet
-verified live from this codebase: the registry lists these rungs under
-`unverified`, and they raise a "not yet verified" error until proven.
+## Choosing budget operating points
 
-Notes:
-- Anthropic effort rides in `output_config.effort` (extra_body on sync,
-  params on batch), exactly as before the ladder.
-- Anthropic legacy `enabled` mode keeps the `max_tokens >= budget + 64`
-  headroom rule.
-- Gemini 3.x: `thinking_level` and `thinking_budget` are mutually exclusive
-  on the wire (the API 400s if both are sent), which is why the family is
-  split from 2.5.
-
-## Shared budget rungs
-
-Legacy budget-based ladder families use:
+The default arms use model-paced settings or provider effort tiers. When an
+experiment needs fixed numeric budgets, the numbers this project has used are
 
     low = 4096   high = 16384
 
-Anchors, from provider guidance and the literature:
-- 16k+ is Anthropic's guidance for complex tasks, roughly where published
-  budget-vs-accuracy sweeps find diminishing returns, and this codebase's
-  historical default budget.
-- 4096 sits a quarter of the way there — a genuinely shallow condition that
-  is still above Anthropic's documented 1,024 minimum on every family.
-
-Tutor arms that need a different numeric operating point should state it
-directly in `benchmark_models:` instead of adding a ladder rung.
+anchored in provider guidance and the literature: 16k+ is Anthropic's
+guidance for complex tasks, roughly where published budget-vs-accuracy sweeps
+find diminishing returns, and this codebase's historical default budget;
+4096 sits a quarter of the way there — a genuinely shallow condition that is
+still above Anthropic's documented 1,024 minimum. State the number directly
+in the arm (`thinking_budget: 4096` / `budget_tokens: 4096`).
 
 Sources: Anthropic extended-thinking docs
 (https://docs.claude.com/en/docs/build-with-claude/extended-thinking), Gemini
@@ -100,18 +96,20 @@ findings (e.g. https://arxiv.org/pdf/2507.04023).
 
 ## Adding a model
 
-One entry in `src/tutormoments/models.yaml` under `models:` — name the
-`family` (add a `families:` entry only for a genuinely new capability shape)
-and fill the per-model facts (`max_output_cap` if the API caps output,
-`pricing` when known). Model ids match exact-first, then longest prefix,
-case-insensitively, so a dated point release resolves to its base entry.
-Then verify with `tutormoments smoke` before benchmarking.
+`src/tutormoments/models.yaml` holds stable per-model facts only: `provider`,
+`max_output_cap` (if the API caps output), and `pricing` (per-MTok rates for
+cost tracking; empty means "not priced yet", never "free"). Add one entry
+there so the run is priced and capped correctly — an unregistered id still
+routes by name prefix, but runs unpriced. Model ids match exact-first, then
+longest prefix, case-insensitively, so a dated point release resolves to its
+base entry. Then verify the arm with `tutormoments smoke` before
+benchmarking.
 
-## Verifying an `unverified` rung
+## Verifying a new or changed condition
 
-1. Add the model/rung to a scratch config (or use `--arms`).
-2. Temporarily remove the rung from the family's `unverified` list.
-3. Run `tutormoments smoke --arms <arm>` and confirm: the call succeeds AND
+1. Add the arm to a scratch config (or use `--arms`).
+2. Run `tutormoments smoke --arms <arm>` and confirm: the call succeeds AND
    the thinking-evidence column matches the stated condition (reasoning
-   tokens present for on-rungs, absent for `none`).
-4. Commit the `unverified` removal with the smoke output in the PR.
+   tokens present when the knobs demand thinking, absent when they turn it
+   off).
+3. Include the smoke output in the PR.

--- a/docs/thinking.md
+++ b/docs/thinking.md
@@ -1,41 +1,53 @@
-# The thinking ladder and the model registry
+# Benchmark thinking configuration
 
-How TutorMoments states, validates, and transmits each arm's reasoning
-condition. This is benchmark-defining configuration: changing a mapping below
-changes the experiment. Never change it without consulting the benchmark
-owner, and verify any new or changed rung against the live API with
-`tutormoments smoke` before relying on it.
+How TutorMoments states, validates, and transmits model reasoning settings.
+Tutor arms are benchmark-defining: changing a configured provider knob changes
+the experiment. Verify changed arm settings against the live API with
+`tutormoments smoke` before relying on them.
 
-## Why a ladder
+## Tutor arms are explicit
 
-Providers expose reasoning depth through four incompatible knobs
-(`thinking_budget`, `thinking_level`, `reasoning_effort`, `effort`), and
-before this design each config consumer re-interpreted the raw values its own
-way — which produced validation/runtime divergence and made "the same model
-at two thinking levels" inexpressible. Now:
+Providers expose reasoning depth through incompatible knobs
+(`thinking_budget`, `thinking_level`, `reasoning`, `effort`, provider-specific
+`thinking` blocks). Reviewers need to see the exact settings used for each
+benchmarked model in that provider's parlance, so the tutor roster uses
+`benchmark_models:`:
 
-- Config states ONE canonical value per arm/role:
-  `thinking: none | low | high | xhigh | dynamic`
-  (required — every benchmarked condition is explicit). The ladder is
-  deliberately small: a rung exists only when an experiment needs it, and
-  adding one (e.g. `medium` for OpenAI's default effort tier, or `minimal`/
-  `max`) is a reviewed registry line plus a `tutormoments smoke`
-  verification.
-- The model registry (`src/tutormoments/models.yaml`) translates it to the
-  provider's wire knob, exactly once, at config load
-  (`tutormoments.models.resolve_thinking`).
-- The translation is fail-closed: a rung a model cannot honor (e.g. `none`
-  on an always-thinking model), an unregistered model, or a retired raw knob
-  in config is rejected before any tokens are spent.
+```yaml
+benchmark_models:
+  gemini-2.5-low: { model: gemini-2.5-pro, thinking_budget: 4096, condition: low }
+  gpt-5.5-low:    { model: gpt-5.5-2026-04-23, reasoning: low, condition: low }
+  opus-4.8-xhigh: { model: claude-opus-4-8, thinking: { type: adaptive }, effort: xhigh, condition: xhigh }
+```
+
+The arm key is the selectable tutor id and the result join key. `model` is the
+provider model id. Provider-native keys are validated at config load and
+forwarded by the client. `condition` is the grouping label written to
+`config.json`, `summary.json`, latency probe output, and leaderboard rows.
+
+## Infrastructure roles use the ladder
+
+The student/scorer/taxonomy/groundtruth blocks use a smaller canonical ladder:
+
+```yaml
+student: { model: claude-opus-4-6, mode: oracle, thinking: none }
+scorer:  { model: claude-opus-4-6, thinking: dynamic }
+```
+
+Those roles are benchmark apparatus rather than reported tutor arms. Keeping
+their settings on the ladder keeps one reviewed default for the fixed
+evaluation machinery while tutor-arm configs stay fully explicit.
 
 Rung meanings: `none` = thinking verifiably off; `low`/`high`/`xhigh` =
-explicit depth rungs; `dynamic` = the model decides (Gemini budget −1,
+explicit depth rungs; `dynamic` = the model decides (Gemini budget -1,
 Anthropic adaptive, open-weight internal reasoning).
 
-## The ladder -> wire mapping
+## Legacy ladder mapping
 
 The authoritative copy is `src/tutormoments/models.yaml`; the contract tests
-in `tests/tutormoments/test_models.py` pin every cell. Summary:
+in `tests/tutormoments/test_models.py` pin every cell. The mapping is used by
+infrastructure role blocks and by older `models:` configs still accepted for
+compatibility. Summary:
 
 | family | none | low | high | xhigh | dynamic |
 |---|---|---|---|---|---|
@@ -63,10 +75,9 @@ Notes:
   on the wire (the API 400s if both are sent), which is why the family is
   split from 2.5.
 
-## The shared budget ladder (why these numbers)
+## Shared budget rungs
 
-All budget-based families (Gemini 2.5, Anthropic legacy) use one ladder so
-rung names stay comparable across providers:
+Legacy budget-based ladder families use:
 
     low = 4096   high = 16384
 
@@ -77,10 +88,8 @@ Anchors, from provider guidance and the literature:
 - 4096 sits a quarter of the way there — a genuinely shallow condition that
   is still above Anthropic's documented 1,024 minimum on every family.
 
-The ladder deliberately omits rungs no experiment uses today (`minimal`,
-`medium` — OpenAI's default effort tier, `max` — provider caps, which would
-mean a different depth per family). Re-adding one is a reviewed registry
-line plus a smoke verification.
+Tutor arms that need a different numeric operating point should state it
+directly in `benchmark_models:` instead of adding a ladder rung.
 
 Sources: Anthropic extended-thinking docs
 (https://docs.claude.com/en/docs/build-with-claude/extended-thinking), Gemini
@@ -88,10 +97,6 @@ thinking docs (https://ai.google.dev/gemini-api/docs/thinking), LiteLLM's
 reasoning_effort-to-budget mapping
 (https://docs.litellm.ai/docs/providers/anthropic), and budget-vs-accuracy
 findings (e.g. https://arxiv.org/pdf/2507.04023).
-
-An exact numeric budget (say 3000 tokens) is deliberately inexpressible from
-config: if an experiment needs a new operating point, add a rung value in the
-registry (a reviewed, benchmark-defining change), not a per-config knob.
 
 ## Adding a model
 

--- a/docs/thinking.md
+++ b/docs/thinking.md
@@ -15,8 +15,12 @@ way — which produced validation/runtime divergence and made "the same model
 at two thinking levels" inexpressible. Now:
 
 - Config states ONE canonical value per arm/role:
-  `thinking: none | minimal | low | medium | high | xhigh | max | dynamic`
-  (required — every benchmarked condition is explicit).
+  `thinking: none | low | high | xhigh | dynamic`
+  (required — every benchmarked condition is explicit). The ladder is
+  deliberately small: a rung exists only when an experiment needs it, and
+  adding one (e.g. `medium` for OpenAI's default effort tier, or `minimal`/
+  `max`) is a reviewed registry line plus a `tutormoments smoke`
+  verification.
 - The model registry (`src/tutormoments/models.yaml`) translates it to the
   provider's wire knob, exactly once, at config load
   (`tutormoments.models.resolve_thinking`).
@@ -24,27 +28,27 @@ at two thinking levels" inexpressible. Now:
   on an always-thinking model), an unregistered model, or a retired raw knob
   in config is rejected before any tokens are spent.
 
-Rung meanings: `none` = thinking verifiably off; `minimal`–`max` = explicit
-depth rungs; `dynamic` = the model decides (Gemini budget −1, Anthropic
-adaptive, open-weight internal reasoning).
+Rung meanings: `none` = thinking verifiably off; `low`/`high`/`xhigh` =
+explicit depth rungs; `dynamic` = the model decides (Gemini budget −1,
+Anthropic adaptive, open-weight internal reasoning).
 
 ## The ladder -> wire mapping
 
 The authoritative copy is `src/tutormoments/models.yaml`; the contract tests
 in `tests/tutormoments/test_models.py` pin every cell. Summary:
 
-| family | none | minimal | low | medium | high | xhigh | max | dynamic |
-|---|---|---|---|---|---|---|---|---|
-| anthropic 4.6 tier (opus/sonnet-4-6) | omit `thinking` | – | adaptive + effort low | medium | high | – (no xhigh on 4.6) | max | `{type: adaptive}`, no effort |
-| anthropic 4.7+ (opus-4-7/4-8) | omit | – | adaptive + effort low | medium | high | xhigh | max | `{type: adaptive}` |
-| anthropic sonnet-5 | `{type: disabled}` (omission runs adaptive on Sonnet 5) | – | low | medium | high | xhigh | max | `{type: adaptive}` |
-| anthropic legacy (frozen pre-adaptive set) | omit | enabled+1024 | 4096 | 8192 | 16384 | – | 32768 | – |
-| gemini-2.5-pro | – (API rejects budget 0) | 1024 | 4096 | 8192 | 16384 | – | 32768 | budget −1 |
-| gemini-2.5-flash | budget 0, include_thoughts false | 1024 | 4096 | 8192 | 16384 | – | 24576 | budget −1 |
-| gemini-3.x | – (thinking_level floor is not off) | thinking_level minimal ⚠ | low ⚠ | medium ⚠ | high ⚠ | – | – | budget −1 (the proven wire shape) |
-| openai gpt-5 line | reasoning_effort none ⚠ | minimal ⚠ | low | medium | high | xhigh ⚠ | – | – |
-| openai o-series | – (no off switch) | – | low | medium | high | – | – | – |
-| together open-weight | – (always-thinking) | – | – | – | – | – | – | emit nothing |
+| family | none | low | high | xhigh | dynamic |
+|---|---|---|---|---|---|
+| anthropic 4.6 tier (opus/sonnet-4-6) | omit `thinking` | adaptive + effort low | high | – (no xhigh on 4.6) | `{type: adaptive}`, no effort |
+| anthropic 4.7+ (opus-4-7/4-8) | omit | adaptive + effort low | high | xhigh | `{type: adaptive}` |
+| anthropic sonnet-5 | `{type: disabled}` (omission runs adaptive on Sonnet 5) | low | high | xhigh | `{type: adaptive}` |
+| anthropic legacy (frozen pre-adaptive set) | omit | enabled+4096 | enabled+16384 | – | – |
+| gemini-2.5-pro | – (API rejects budget 0) | budget 4096 | 16384 | – | budget −1 |
+| gemini-2.5-flash | budget 0, include_thoughts false | 4096 | 16384 | – | budget −1 |
+| gemini-3.x | – (thinking_level floor is not off) | thinking_level low ⚠ | high ⚠ | – | budget −1 (the proven wire shape) |
+| openai gpt-5 line | reasoning_effort none ⚠ | low | high | xhigh ⚠ | – |
+| openai o-series | – (no off switch) | low | high | – | – |
+| together open-weight | – (always-thinking) | – | – | – | emit nothing |
 
 "–" = unsatisfiable: config load raises. "⚠" = documented but not yet
 verified live from this codebase: the registry lists these rungs under
@@ -64,17 +68,19 @@ Notes:
 All budget-based families (Gemini 2.5, Anthropic legacy) use one ladder so
 rung names stay comparable across providers:
 
-    minimal = 1024   low = 4096   medium = 8192   high = 16384
-    max = provider cap (32768 Gemini Pro / 24576 Gemini Flash / 32768 Anthropic legacy)
+    low = 4096   high = 16384
 
 Anchors, from provider guidance and the literature:
-- 1,024 is Anthropic's documented minimum thinking budget, and the low-effort
-  anchor cross-provider translation layers use.
 - 16k+ is Anthropic's guidance for complex tasks, roughly where published
   budget-vs-accuracy sweeps find diminishing returns, and this codebase's
   historical default budget.
-- Anthropic recommends batch processing above 32k, and 32768/24576 are the
-  Gemini 2.5 Pro/Flash caps.
+- 4096 sits a quarter of the way there — a genuinely shallow condition that
+  is still above Anthropic's documented 1,024 minimum on every family.
+
+The ladder deliberately omits rungs no experiment uses today (`minimal`,
+`medium` — OpenAI's default effort tier, `max` — provider caps, which would
+mean a different depth per family). Re-adding one is a reviewed registry
+line plus a smoke verification.
 
 Sources: Anthropic extended-thinking docs
 (https://docs.claude.com/en/docs/build-with-claude/extended-thinking), Gemini

--- a/docs/thinking.md
+++ b/docs/thinking.md
@@ -1,0 +1,106 @@
+# The thinking ladder and the model registry
+
+How TutorMoments states, validates, and transmits each arm's reasoning
+condition. This is benchmark-defining configuration: changing a mapping below
+changes the experiment. Never change it without consulting the benchmark
+owner, and verify any new or changed rung against the live API with
+`tutormoments smoke` before relying on it.
+
+## Why a ladder
+
+Providers expose reasoning depth through four incompatible knobs
+(`thinking_budget`, `thinking_level`, `reasoning_effort`, `effort`), and
+before this design each config consumer re-interpreted the raw values its own
+way — which produced validation/runtime divergence and made "the same model
+at two thinking levels" inexpressible. Now:
+
+- Config states ONE canonical value per arm/role:
+  `thinking: none | minimal | low | medium | high | xhigh | max | dynamic`
+  (required — every benchmarked condition is explicit).
+- The model registry (`src/tutormoments/models.yaml`) translates it to the
+  provider's wire knob, exactly once, at config load
+  (`tutormoments.models.resolve_thinking`).
+- The translation is fail-closed: a rung a model cannot honor (e.g. `none`
+  on an always-thinking model), an unregistered model, or a retired raw knob
+  in config is rejected before any tokens are spent.
+
+Rung meanings: `none` = thinking verifiably off; `minimal`–`max` = explicit
+depth rungs; `dynamic` = the model decides (Gemini budget −1, Anthropic
+adaptive, open-weight internal reasoning).
+
+## The ladder -> wire mapping
+
+The authoritative copy is `src/tutormoments/models.yaml`; the contract tests
+in `tests/tutormoments/test_models.py` pin every cell. Summary:
+
+| family | none | minimal | low | medium | high | xhigh | max | dynamic |
+|---|---|---|---|---|---|---|---|---|
+| anthropic 4.6 tier (opus/sonnet-4-6) | omit `thinking` | – | adaptive + effort low | medium | high | – (no xhigh on 4.6) | max | `{type: adaptive}`, no effort |
+| anthropic 4.7+ (opus-4-7/4-8) | omit | – | adaptive + effort low | medium | high | xhigh | max | `{type: adaptive}` |
+| anthropic sonnet-5 | `{type: disabled}` (omission runs adaptive on Sonnet 5) | – | low | medium | high | xhigh | max | `{type: adaptive}` |
+| anthropic legacy (frozen pre-adaptive set) | omit | enabled+1024 | 4096 | 8192 | 16384 | – | 32768 | – |
+| gemini-2.5-pro | – (API rejects budget 0) | 1024 | 4096 | 8192 | 16384 | – | 32768 | budget −1 |
+| gemini-2.5-flash | budget 0, include_thoughts false | 1024 | 4096 | 8192 | 16384 | – | 24576 | budget −1 |
+| gemini-3.x | – (thinking_level floor is not off) | thinking_level minimal ⚠ | low ⚠ | medium ⚠ | high ⚠ | – | – | budget −1 (the proven wire shape) |
+| openai gpt-5 line | reasoning_effort none ⚠ | minimal ⚠ | low | medium | high | xhigh ⚠ | – | – |
+| openai o-series | – (no off switch) | – | low | medium | high | – | – | – |
+| together open-weight | – (always-thinking) | – | – | – | – | – | – | emit nothing |
+
+"–" = unsatisfiable: config load raises. "⚠" = documented but not yet
+verified live from this codebase: the registry lists these rungs under
+`unverified`, and they raise a "not yet verified" error until proven.
+
+Notes:
+- Anthropic effort rides in `output_config.effort` (extra_body on sync,
+  params on batch), exactly as before the ladder.
+- Anthropic legacy `enabled` mode keeps the `max_tokens >= budget + 64`
+  headroom rule.
+- Gemini 3.x: `thinking_level` and `thinking_budget` are mutually exclusive
+  on the wire (the API 400s if both are sent), which is why the family is
+  split from 2.5.
+
+## The shared budget ladder (why these numbers)
+
+All budget-based families (Gemini 2.5, Anthropic legacy) use one ladder so
+rung names stay comparable across providers:
+
+    minimal = 1024   low = 4096   medium = 8192   high = 16384
+    max = provider cap (32768 Gemini Pro / 24576 Gemini Flash / 32768 Anthropic legacy)
+
+Anchors, from provider guidance and the literature:
+- 1,024 is Anthropic's documented minimum thinking budget, and the low-effort
+  anchor cross-provider translation layers use.
+- 16k+ is Anthropic's guidance for complex tasks, roughly where published
+  budget-vs-accuracy sweeps find diminishing returns, and this codebase's
+  historical default budget.
+- Anthropic recommends batch processing above 32k, and 32768/24576 are the
+  Gemini 2.5 Pro/Flash caps.
+
+Sources: Anthropic extended-thinking docs
+(https://docs.claude.com/en/docs/build-with-claude/extended-thinking), Gemini
+thinking docs (https://ai.google.dev/gemini-api/docs/thinking), LiteLLM's
+reasoning_effort-to-budget mapping
+(https://docs.litellm.ai/docs/providers/anthropic), and budget-vs-accuracy
+findings (e.g. https://arxiv.org/pdf/2507.04023).
+
+An exact numeric budget (say 3000 tokens) is deliberately inexpressible from
+config: if an experiment needs a new operating point, add a rung value in the
+registry (a reviewed, benchmark-defining change), not a per-config knob.
+
+## Adding a model
+
+One entry in `src/tutormoments/models.yaml` under `models:` — name the
+`family` (add a `families:` entry only for a genuinely new capability shape)
+and fill the per-model facts (`max_output_cap` if the API caps output,
+`pricing` when known). Model ids match exact-first, then longest prefix,
+case-insensitively, so a dated point release resolves to its base entry.
+Then verify with `tutormoments smoke` before benchmarking.
+
+## Verifying an `unverified` rung
+
+1. Add the model/rung to a scratch config (or use `--arms`).
+2. Temporarily remove the rung from the family's `unverified` list.
+3. Run `tutormoments smoke --arms <arm>` and confirm: the call succeeds AND
+   the thinking-evidence column matches the stated condition (reasoning
+   tokens present for on-rungs, absent for `none`).
+4. Commit the `unverified` removal with the smoke output in the PR.

--- a/docs/thinking.md
+++ b/docs/thinking.md
@@ -43,7 +43,7 @@ in `tests/tutormoments/test_models.py` pin every cell. Summary:
 | anthropic 4.7+ (opus-4-7/4-8) | omit | adaptive + effort low | high | xhigh | `{type: adaptive}` |
 | anthropic sonnet-5 | `{type: disabled}` (omission runs adaptive on Sonnet 5) | low | high | xhigh | `{type: adaptive}` |
 | anthropic legacy (frozen pre-adaptive set) | omit | enabled+4096 | enabled+16384 | – | – |
-| gemini-2.5-pro | – (API rejects budget 0) | budget 4096 | 16384 | – | budget −1 |
+| gemini-2.5-pro | – (API rejects budget 0) | budget 4096 | 16384 | 32768 (2x high; the Pro budget cap — Pro only, Flash caps at 24576) | budget −1 |
 | gemini-2.5-flash | budget 0, include_thoughts false | 4096 | 16384 | – | budget −1 |
 | gemini-3.x | – (thinking_level floor is not off) | thinking_level low ⚠ | high ⚠ | – | budget −1 (the proven wire shape) |
 | openai gpt-5 line | reasoning_effort none ⚠ | low | high | xhigh ⚠ | – |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ include = ["tutormoments*", "tutormoments_build*", "analysis*"]
 [tool.setuptools.package-data]
 tutormoments = [
     "default_config.yaml",
+    "models.yaml",
     "latency_probe_ids.json",
     "prompts/tutor/*.txt",
     "prompts/student/*.txt",
@@ -57,6 +58,7 @@ tutormoments = [
     "prompts/scorer/decompose/*.md",
     "prompts/scorer/structure/*.md",
     "prompts/taxonomy/*.md",
+    "prompts/smoke/*.md",
 ]
 tutormoments_build = [
     "moments.schema.json",

--- a/src/tutormoments/cli.py
+++ b/src/tutormoments/cli.py
@@ -199,18 +199,14 @@ def _json_sha256(data) -> str:
 def _spec_json(spec) -> dict | None:
     """JSON-safe dict for a frozen config spec (ArmSpec/StudentSpec/...).
 
-    ThinkingLevel serializes as its string value (it is a str-Enum). None
-    passes through (registered tutors have no spec).
+    Thinking configs are plain provider-native dicts (or None), so asdict is
+    already JSON-safe. None passes through (registered tutors have no spec).
     """
     if spec is None:
         return None
     from dataclasses import asdict
 
-    out = asdict(spec)
-    thinking = out.get("thinking")
-    if thinking is not None:
-        out["thinking"] = str(getattr(thinking, "value", thinking))
-    return out
+    return asdict(spec)
 
 
 def _package_version() -> str | None:

--- a/src/tutormoments/cli.py
+++ b/src/tutormoments/cli.py
@@ -64,8 +64,7 @@ def expand_cells(tutors: list[str], modes: list[str]) -> list[dict]:
         List of cell dicts in sweep order (tutor-major, mode-minor).
     """
     # Lazy import to avoid module-level SDK import
-    from tutormoments.client import infer_provider
-    from tutormoments.config import get_registered_tutor
+    from tutormoments.config import get_registered_tutor, resolve_arm
 
     cells = []
     for tutor in tutors:
@@ -74,7 +73,7 @@ def expand_cells(tutors: list[str], modes: list[str]) -> list[dict]:
             lane = "default"
         else:
             try:
-                lane = infer_provider(tutor)
+                lane = resolve_arm(tutor).provider
             except ValueError:
                 lane = "default"
         for mode in modes:
@@ -195,6 +194,23 @@ def _dataset_label(cfg) -> str:
 def _json_sha256(data) -> str:
     payload = json.dumps(data, sort_keys=True, default=str).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
+
+
+def _spec_json(spec) -> dict | None:
+    """JSON-safe dict for a frozen config spec (ArmSpec/StudentSpec/...).
+
+    ThinkingLevel serializes as its string value (it is a str-Enum). None
+    passes through (registered tutors have no spec).
+    """
+    if spec is None:
+        return None
+    from dataclasses import asdict
+
+    out = asdict(spec)
+    thinking = out.get("thinking")
+    if thinking is not None:
+        out["thinking"] = str(getattr(thinking, "value", thinking))
+    return out
 
 
 def _package_version() -> str | None:
@@ -428,8 +444,19 @@ def run_cell(
     # under run_sweep the lane already set the same tag.
     run_log_path = os.path.join(results_root, run_id, "run.log")
     with per_run_log_file(run_log_path) as run_log, log_context(f"{tutor}/{mode}"):
+        # JSON-safe views of the frozen specs. `tutor` is the ARM name (the
+        # roster key -- what results are keyed by); `model` is the resolved
+        # provider model id (None for registered tutors, which have no model).
+        arm_spec = cfg.resolved_tutors.get(tutor)
+        student_json = _spec_json(cfg.student)
+        scorer_json = _spec_json(cfg.scorer)
+        resolved_tutors_json = {
+            name: _spec_json(spec) for name, spec in cfg.resolved_tutors.items()
+        }
         config_dict = {
             "tutor": tutor,
+            "arm": tutor,
+            "model": arm_spec.model if arm_spec is not None else None,
             "mode": mode,
             "dataset": {
                 "id": cfg.dataset,
@@ -445,18 +472,18 @@ def run_cell(
             # Informational only: replay concurrency does not affect results, so
             # it is deliberately kept out of reproducibility.config_hash below.
             "replay_concurrency": getattr(cfg, "replay_concurrency", None),
-            "student": cfg.student,
-            "scorer": cfg.scorer,
-            "resolved_tutors": cfg.resolved_tutors,
+            "student": student_json,
+            "scorer": scorer_json,
+            "resolved_tutors": resolved_tutors_json,
             "config_source": getattr(cfg, "config_source", None),
             "reproducibility": {
                 "tutormoments_version": _package_version(),
                 "git_commit": _git_commit(),
                 "config_hash": _json_sha256(
                     {
-                        "student": cfg.student,
-                        "scorer": cfg.scorer,
-                        "resolved_tutors": cfg.resolved_tutors,
+                        "student": student_json,
+                        "scorer": scorer_json,
+                        "resolved_tutors": resolved_tutors_json,
                         "defaults": {
                             "sample": cfg.sample,
                             "max_turns": cfg.max_turns,
@@ -543,8 +570,8 @@ def run_cell(
                 trial_idx,
                 n_trials,
                 n_total,
-                (cfg.student or {}).get("model"),
-                (cfg.student or {}).get("mode", "oracle"),
+                cfg.student.model,
+                cfg.student.mode or "oracle",
                 cfg.max_turns,
                 replay_concurrency,
             )
@@ -631,8 +658,8 @@ def run_cell(
                     scenario,
                     tutor_id=tutor,
                     tutor_mode=mode if mode else None,
-                    student_id=(cfg.student or {}).get("model"),
-                    student_mode=(cfg.student or {}).get("mode", "oracle"),
+                    student_id=cfg.student.model,
+                    student_mode=cfg.student.mode or "oracle",
                     max_turns=cfg.max_turns,
                 )
 
@@ -859,6 +886,12 @@ def run_cell(
 
         # Merge latency + token blocks into summary (spec S7)
         metrics = dict(metrics)
+        # Identity block: `tutor_model` stays the ARM name (the historical
+        # join key for report/latency/website); `model` is the resolved
+        # provider model id so the arm's provenance is explicit.
+        metrics["tutor_model"] = tutor
+        metrics["model"] = arm_spec.model if arm_spec is not None else None
+        metrics["mode"] = mode
         metrics["latency"] = latency_block
         metrics["tokens"] = token_block
 
@@ -1092,7 +1125,108 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     tax_p.add_argument("args", nargs=argparse.REMAINDER)
 
+    # smoke: live verification of the active config's wire formats. The
+    # offline suite can only prove the code agrees with itself; this makes one
+    # tiny REAL call per arm/role (cents) plus a submit-then-cancel batch per
+    # provider. Run before merging changes to core API logic (see AGENTS.md).
+    smoke_p = subs.add_parser(
+        "smoke",
+        help="Live-verify the active config's provider wire formats (real API calls)",
+        parents=[log_parent],
+    )
+    smoke_p.add_argument(
+        "--config", default=None, metavar="FILE", help="Explicit config file"
+    )
+    smoke_p.add_argument(
+        "--arms",
+        nargs="+",
+        default=None,
+        metavar="ARM",
+        help="Only these roster arms (default: all)",
+    )
+    smoke_p.add_argument(
+        "--roles",
+        nargs="+",
+        default=None,
+        metavar="ROLE",
+        choices=["tutor", "student", "scorer", "taxonomy", "groundtruth"],
+        help="Only these roles (default: all)",
+    )
+    smoke_p.add_argument(
+        "--providers",
+        nargs="+",
+        default=None,
+        metavar="P",
+        help="Only these providers (others reported as SKIP)",
+    )
+    smoke_p.add_argument(
+        "--no-sync",
+        dest="sync",
+        action="store_false",
+        help="Skip the per-arm sync generate checks",
+    )
+    smoke_p.add_argument(
+        "--no-batch",
+        dest="batch",
+        action="store_false",
+        help="Skip the per-provider batch submit+cancel checks",
+    )
+    smoke_p.add_argument(
+        "--max-tokens",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Output cap for the sync pings (default 0 = model max, "
+        "same resolution the benchmark uses)",
+    )
+    smoke_p.add_argument(
+        "--strict-thinking",
+        action="store_true",
+        help="Escalate model-paced-thinking WARNs (no thinking observed) to FAIL",
+    )
+    smoke_p.add_argument(
+        "--json",
+        default=None,
+        metavar="FILE",
+        help="Also write a machine-readable report (e.g. results/smoke/<ts>.json)",
+    )
+
     return parser
+
+
+def _cmd_smoke(args) -> int:
+    """Implement the 'smoke' subcommand; returns the exit code."""
+    from tutormoments.config import describe_config_source
+    from tutormoments.smoke import build_smoke_plan, format_smoke_report, run_smoke
+
+    if args.config:
+        os.environ["TUTORMOMENTS_CONFIG"] = args.config
+    try:
+        plan = build_smoke_plan(
+            config_path=args.config,
+            arms=args.arms,
+            roles=args.roles,
+            providers=args.providers,
+            include_sync=args.sync,
+            include_batch=args.batch,
+        )
+    except (ValueError, FileNotFoundError) as e:
+        print("Error: " + str(e), file=sys.stderr)
+        return 2
+
+    report_obj = run_smoke(
+        plan,
+        strict_thinking=args.strict_thinking,
+        max_tokens=args.max_tokens,
+        config_source=describe_config_source(args.config),
+    )
+    print(format_smoke_report(report_obj))
+    if args.json:
+        os.makedirs(os.path.dirname(args.json) or ".", exist_ok=True)
+        with open(args.json, "w", encoding="utf-8") as f:
+            f.write(report_obj.to_json())
+        print(f"json report: {args.json}")
+    return 1 if report_obj.failed else 0
 
 
 def _cmd_report(args) -> None:
@@ -1283,6 +1417,9 @@ def main(argv=None) -> None:
 
     elif args.command == "view":
         _cmd_view(args)
+
+    elif args.command == "smoke":
+        sys.exit(_cmd_smoke(args))
 
     else:
         parser.print_help()

--- a/src/tutormoments/cli.py
+++ b/src/tutormoments/cli.py
@@ -457,6 +457,7 @@ def run_cell(
             "tutor": tutor,
             "arm": tutor,
             "model": arm_spec.model if arm_spec is not None else None,
+            "condition": arm_spec.condition if arm_spec is not None else None,
             "mode": mode,
             "dataset": {
                 "id": cfg.dataset,
@@ -891,6 +892,7 @@ def run_cell(
         # provider model id so the arm's provenance is explicit.
         metrics["tutor_model"] = tutor
         metrics["model"] = arm_spec.model if arm_spec is not None else None
+        metrics["condition"] = arm_spec.condition if arm_spec is not None else None
         metrics["mode"] = mode
         metrics["latency"] = latency_block
         metrics["tokens"] = token_block

--- a/src/tutormoments/client.py
+++ b/src/tutormoments/client.py
@@ -989,11 +989,24 @@ def _openai_style_usage(usage_obj, *, provider: str, model: str, endpoint: str) 
     written = (
         (getattr(details, "cache_write_tokens", 0) or 0) if details is not None else 0
     )
+    # Informational, additive: OpenAI reports its thinking spend as a SUBSET
+    # of completion_tokens under completion_tokens_details.reasoning_tokens.
+    # It is not a separate cost bucket (unlike Gemini's thoughts), so it must
+    # not move into the canonical `reasoning` bucket -- that would
+    # double-count against `output`. `tutormoments smoke` reads it as
+    # wire-level evidence that a reasoning_effort knob actually did something.
+    completion_details = getattr(usage_obj, "completion_tokens_details", None)
+    reasoning_tokens = (
+        (getattr(completion_details, "reasoning_tokens", 0) or 0)
+        if completion_details is not None
+        else 0
+    )
     return {
         "input_tokens": prompt,
         "output_tokens": completion,
         "total_tokens": total,
         "cached_tokens": cached,
+        "reasoning_tokens": reasoning_tokens,
         **normalize_usage(
             provider,
             model,
@@ -1016,10 +1029,14 @@ def _openai_batch_usage(usage: dict, *, model: str) -> dict:
     prompt = usage.get("prompt_tokens", 0) or 0
     completion = usage.get("completion_tokens", 0) or 0
     total = usage.get("total_tokens", 0) or 0
+    reasoning_tokens = (usage.get("completion_tokens_details") or {}).get(
+        "reasoning_tokens", 0
+    ) or 0
     return {
         "input_tokens": prompt,
         "output_tokens": completion,
         "total_tokens": total,
+        "reasoning_tokens": reasoning_tokens,
         **normalize_usage(
             "openai",
             model,

--- a/src/tutormoments/client.py
+++ b/src/tutormoments/client.py
@@ -272,12 +272,11 @@ class ModelClient:
     ) -> "ModelResponse":
         """Generate a response from the model with retry logic.
 
-        thinking: a canonical ladder level (ThinkingLevel or its string form).
-        The model registry translates it to the provider's wire knob and
-        rejects levels this model cannot honor. None means "no stated
-        condition": nothing is sent and nothing is checked -- a path for
-        non-benchmark direct calls only (config-driven callers always pass an
-        explicit level).
+        thinking: provider-native thinking params from benchmark_models, or a
+        canonical ladder level for role/legacy callers. The resolver translates
+        this to the provider's wire shape and rejects malformed or unsupported
+        settings before the retry loop. None means "no stated condition":
+        nothing is sent and nothing is checked.
 
         output_schema: optional JSON Schema for structured output. When set,
         the Anthropic path constrains the response via output_config.format
@@ -1354,8 +1353,9 @@ def run_sync_entries(
     """Run entries synchronously one at a time.
 
     Returns {key: {text, usage}} dict (same shape as run_batch). `thinking`
-    takes the same ladder level run_batch does, so a caller switching between
-    the two paths keeps the same benchmark condition.
+    takes the same provider-native mapping or legacy ladder value run_batch
+    does, so a caller switching between the two paths keeps the same benchmark
+    condition.
     """
     raw_entries = {}
     total = len(entries)
@@ -1407,9 +1407,9 @@ def run_batch(
 ) -> dict:
     """Run entries as a batch job via the provider's batch API.
 
-    thinking: the same canonical ladder level generate() takes; the registry
-    translates it per provider and rejects levels the model cannot honor
-    (before anything is uploaded).
+    thinking: the same provider-native mapping or legacy ladder value
+    generate() takes; the resolver translates it per provider and rejects
+    malformed or unsupported settings before anything is uploaded.
 
     Resume support: if `existing_batch_id` is set, skip submission and resume
     polling on that batch (the entries list still drives result parsing, so
@@ -1479,7 +1479,7 @@ def submit_batch(
     The submission half of run_batch, exposed for `tutormoments smoke`:
     verifying that a provider ACCEPTS the batch wire format does not require
     paying for (or waiting on) the batch's completion -- pair with
-    cancel_batch. The same thinking ladder contract as run_batch applies.
+    cancel_batch. The same thinking contract as run_batch applies.
     """
     wire = resolve_thinking(client.model, thinking)
     provider = client.provider

--- a/src/tutormoments/client.py
+++ b/src/tutormoments/client.py
@@ -11,10 +11,11 @@ from dataclasses import dataclass, field
 from dotenv import load_dotenv
 from google.genai import types
 
-# Model facts (provider routing, thinking-ladder wire translation, per-model
-# caps) live in the model registry; the client consumes WireThinking
-# fragments and never interprets thinking levels itself. infer_provider is
-# re-exported because callers historically import it from here.
+# Model facts (provider routing, per-model caps, pricing) live in the model
+# registry, and thinking params are validated/translated by models.py; the
+# client consumes WireThinking fragments and never interprets thinking
+# settings itself. infer_provider is re-exported because callers historically
+# import it from here.
 from tutormoments.models import (
     WireThinking,
     infer_provider,
@@ -272,11 +273,13 @@ class ModelClient:
     ) -> "ModelResponse":
         """Generate a response from the model with retry logic.
 
-        thinking: provider-native thinking params from benchmark_models, or a
-        canonical ladder level for role/legacy callers. The resolver translates
-        this to the provider's wire shape and rejects malformed or unsupported
-        settings before the retry loop. None means "no stated condition":
-        nothing is sent and nothing is checked.
+        thinking: provider-native thinking params (the same mapping the
+        benchmark_models arms and role blocks state in config). The resolver
+        translates this to the provider's wire shape and rejects malformed or
+        unsupported settings before the retry loop. None means "no stated
+        condition": nothing is sent and nothing is checked -- a path for
+        non-benchmark direct calls only (config-driven callers always pass an
+        explicit mapping).
 
         output_schema: optional JSON Schema for structured output. When set,
         the Anthropic path constrains the response via output_config.format
@@ -1353,10 +1356,13 @@ def run_sync_entries(
     """Run entries synchronously one at a time.
 
     Returns {key: {text, usage}} dict (same shape as run_batch). `thinking`
-    takes the same provider-native mapping or legacy ladder value run_batch
-    does, so a caller switching between the two paths keeps the same benchmark
-    condition.
+    takes the same provider-native mapping run_batch does, so a caller
+    switching between the two paths keeps the same benchmark condition.
     """
+    # Fail-fast parity with run_batch: a malformed thinking mapping dies here,
+    # before the loop, instead of being demoted to N identical per-entry
+    # errors by the per-entry exception handler below.
+    resolve_thinking(client.model, thinking)
     raw_entries = {}
     total = len(entries)
     for i, entry in enumerate(entries):
@@ -1407,9 +1413,9 @@ def run_batch(
 ) -> dict:
     """Run entries as a batch job via the provider's batch API.
 
-    thinking: the same provider-native mapping or legacy ladder value
-    generate() takes; the resolver translates it per provider and rejects
-    malformed or unsupported settings before anything is uploaded.
+    thinking: the same provider-native mapping generate() takes; the resolver
+    translates it per provider and rejects malformed or unsupported settings
+    before anything is uploaded.
 
     Resume support: if `existing_batch_id` is set, skip submission and resume
     polling on that batch (the entries list still drives result parsing, so

--- a/src/tutormoments/client.py
+++ b/src/tutormoments/client.py
@@ -11,26 +11,22 @@ from dataclasses import dataclass, field
 from dotenv import load_dotenv
 from google.genai import types
 
+# Model facts (provider routing, thinking-ladder wire translation, per-model
+# caps) live in the model registry; the client consumes WireThinking
+# fragments and never interprets thinking levels itself. infer_provider is
+# re-exported because callers historically import it from here.
+from tutormoments.models import (
+    WireThinking,
+    infer_provider,
+    max_output_cap,
+    resolve_thinking,
+)
+
 load_dotenv(override=True)
 
 logger = logging.getLogger(__name__)
 
-# Order matters (first match wins).
-PROVIDER_PREFIXES = [
-    ("gemini", "gemini"),
-    ("gpt", "openai"),
-    ("o1", "openai"),
-    ("o3", "openai"),
-    ("o4", "openai"),
-    ("claude", "anthropic"),
-    ("deepseek-ai/", "together"),
-    ("moonshotai/", "together"),
-    ("minimaxai/", "together"),
-    ("google/gemma", "together"),
-    ("meta-llama/", "together"),
-    ("qwen/", "together"),
-]
-
+__all__ = ["ModelClient", "ModelResponse", "infer_provider"]
 
 VISION_CAPABLE_PREFIXES = (
     "claude-opus-4",
@@ -55,24 +51,6 @@ def validate_vision_support(model: str) -> None:
             f"Vision-capable prefixes: {', '.join(VISION_CAPABLE_PREFIXES)}."
         )
 
-
-def infer_provider(model: str) -> str:
-    """Infer provider from model name string.
-
-    Examples:
-        'gemini-3.1-pro-preview' -> 'gemini'
-        'gpt-4o'               -> 'openai'
-        'o3-mini'              -> 'openai'
-        'claude-sonnet-4-6'    -> 'anthropic'
-    """
-    model_lower = model.lower()
-    for prefix, provider in PROVIDER_PREFIXES:
-        if model_lower.startswith(prefix):
-            return provider
-    raise ValueError(
-        f"Cannot infer provider for model '{model}'. "
-        f"Expected prefix: {', '.join(p for p, _ in PROVIDER_PREFIXES)}"
-    )
 
 
 @dataclass
@@ -252,43 +230,6 @@ class _InlineThinkGate:
         return False
 
 
-# Adaptive thinking ({"type": "adaptive"}) is the modern default and the shape
-# every current Opus/Sonnet-tier Anthropic model uses. The legacy
-# enabled+budget_tokens shape is needed only by a *closed, frozen set* of
-# pre-adaptive models -- no new model is ever added here. So we default to
-# adaptive and enumerate only the legacy models; a brand-new Anthropic model
-# works with no code change (see README "Running new tutor models"). Legacy
-# enabled+budget is rejected on Opus 4.7+/Sonnet 5/Fable 5. Haiku 4.5 is the
-# one current model still on the legacy shape (extended thinking only, no
-# adaptive support per the Anthropic models overview).
-_ANTHROPIC_LEGACY_THINKING_MODELS = (
-    "claude-3-7-sonnet",
-    "claude-haiku-4-5",
-    "claude-opus-4-0",
-    "claude-opus-4-20250514",
-    "claude-opus-4-1",
-    "claude-opus-4-5",
-    "claude-sonnet-4-0",
-    "claude-sonnet-4-20250514",
-    "claude-sonnet-4-5",
-)
-
-
-def _anthropic_thinking_param(model: str, thinking_budget: int) -> dict:
-    """Return the right `thinking` kwarg shape for the given model.
-
-    Defaults to adaptive ({"type": "adaptive"}), which every current Anthropic
-    model requires. Only the frozen pre-adaptive models in
-    _ANTHROPIC_LEGACY_THINKING_MODELS get the enabled+budget_tokens form.
-    """
-    if model and any(
-        model.startswith(prefix) for prefix in _ANTHROPIC_LEGACY_THINKING_MODELS
-    ):
-        budget = thinking_budget if thinking_budget > 0 else 16384
-        return {"type": "enabled", "budget_tokens": budget}
-    return {"type": "adaptive"}
-
-
 class ModelClient:
     """Provider-agnostic synchronous model client.
 
@@ -346,10 +287,7 @@ class ModelClient:
         json_mode: bool = True,
         max_tokens: int = 0,
         timeout: int = 120,
-        thinking: bool = False,
-        thinking_budget: int = 0,
-        reasoning_effort: str = "",
-        effort: str = "",
+        thinking=None,
         enable_cache: bool = False,
         *,
         output_schema: dict | None = None,
@@ -357,6 +295,13 @@ class ModelClient:
         stream: bool = False,
     ) -> "ModelResponse":
         """Generate a response from the model with retry logic.
+
+        thinking: a canonical ladder level (ThinkingLevel or its string form).
+        The model registry translates it to the provider's wire knob and
+        rejects levels this model cannot honor. None means "no stated
+        condition": nothing is sent and nothing is checked -- a path for
+        non-benchmark direct calls only (config-driven callers always pass an
+        explicit level).
 
         output_schema: optional JSON Schema for structured output. When set,
         the Anthropic path constrains the response via output_config.format
@@ -376,6 +321,9 @@ class ModelClient:
                 "output_schema is only supported on the anthropic provider"
             )
 
+        # Before the retry loop: a config error must fail once, not 5 times.
+        wire = resolve_thinking(self.model, thinking)
+
         if max_tokens <= 0:
             max_tokens = MAX_OUTPUT_TOKENS.get(self.provider, 8192)
 
@@ -393,8 +341,7 @@ class ModelClient:
                         json_mode,
                         max_tokens,
                         timeout,
-                        thinking,
-                        thinking_budget,
+                        wire,
                         images,
                         cacheable_prefix=cacheable_prefix,
                         stream=stream,
@@ -405,9 +352,7 @@ class ModelClient:
                         json_mode,
                         max_tokens,
                         timeout,
-                        thinking,
-                        thinking_budget,
-                        reasoning_effort=reasoning_effort,
+                        wire,
                         images=images,
                         cacheable_prefix=cacheable_prefix,
                         stream=stream,
@@ -418,10 +363,7 @@ class ModelClient:
                         json_mode,
                         max_tokens,
                         timeout,
-                        thinking,
-                        thinking_budget,
-                        reasoning_effort=reasoning_effort,
-                        effort=effort,
+                        wire,
                         images=images,
                         enable_cache=enable_cache,
                         output_schema=output_schema,
@@ -474,8 +416,7 @@ class ModelClient:
         json_mode,
         max_tokens,
         timeout,
-        thinking=False,
-        thinking_budget=0,
+        wire: WireThinking,
         images=None,
         cacheable_prefix: str | None = None,
         stream: bool = False,
@@ -487,17 +428,8 @@ class ModelClient:
         }
         if json_mode:
             config["response_mime_type"] = "application/json"
-        if thinking:
-            # thinking_budget = -1 means "dynamic" (model self-paces).
-            # 0 = no thinking. Positive = fixed budget. None/unset = default 16384.
-            if thinking_budget is None or thinking_budget == 0:
-                budget = 16384
-            else:
-                budget = thinking_budget  # may be -1 (dynamic) or positive
-            config["thinking_config"] = {
-                "include_thoughts": True,
-                "thinking_budget": budget,
-            }
+        if wire.gemini_thinking_config is not None:
+            config["thinking_config"] = dict(wire.gemini_thinking_config)
 
         # Gemini has no server-side prompt cache wired here; the cacheable
         # head is concatenated into the prompt, which is semantically
@@ -573,9 +505,7 @@ class ModelClient:
         json_mode,
         max_tokens,
         timeout,
-        thinking=False,
-        thinking_budget=0,
-        reasoning_effort: str = "",
+        wire: WireThinking,
         images=None,
         cacheable_prefix: str | None = None,
         stream: bool = False,
@@ -604,8 +534,8 @@ class ModelClient:
         }
         if json_mode:
             kwargs["response_format"] = {"type": "json_object"}
-        if reasoning_effort:
-            kwargs["reasoning_effort"] = reasoning_effort
+        if wire.openai_reasoning_effort:
+            kwargs["reasoning_effort"] = wire.openai_reasoning_effort
 
         if stream:
             return self._stream_openai_compatible(kwargs, inline_think=False)
@@ -721,10 +651,7 @@ class ModelClient:
         json_mode,
         max_tokens,
         timeout,
-        thinking=False,
-        thinking_budget=0,
-        reasoning_effort="",
-        effort="",
+        wire: WireThinking,
         images=None,
         enable_cache=False,
         output_schema: dict | None = None,
@@ -772,13 +699,12 @@ class ModelClient:
         else:
             content = prompt
 
-        # Clamp max_tokens to the model's per-model output cap (Haiku 4.5 and
-        # Sonnet 4.6 max out at 64K -- requests above the cap are rejected).
+        # Clamp max_tokens to the model's per-model output cap (requests above
+        # the cap are rejected by the API; caps live in the model registry).
         capped_max = max_tokens
-        for prefix, cap in _ANTHROPIC_MAX_OUTPUT_CAP.items():
-            if self.model and self.model.startswith(prefix):
-                capped_max = min(capped_max, cap)
-                break
+        cap = max_output_cap(self.model)
+        if cap is not None:
+            capped_max = min(capped_max, cap)
         kwargs = {
             "model": self.model,
             "max_tokens": capped_max,
@@ -787,8 +713,8 @@ class ModelClient:
         }
         if system_parts:
             kwargs["system"] = "\n".join(system_parts)
-        if thinking:
-            kwargs["thinking"] = _anthropic_thinking_param(self.model, thinking_budget)
+        if wire.anthropic_thinking is not None:
+            kwargs["thinking"] = dict(wire.anthropic_thinking)
             if kwargs["thinking"].get("type") == "enabled":
                 # Legacy enabled mode needs max_tokens >= budget + headroom.
                 budget = kwargs["thinking"]["budget_tokens"]
@@ -796,14 +722,14 @@ class ModelClient:
                     kwargs["max_tokens"] = budget + 64
 
         # effort and structured-output format both live under output_config.
-        # effort is only valid on adaptive-thinking models that support it
-        # (Haiku 4.5 400s if effort is sent -- skip there). output_schema
-        # constrains the response via output_config.format (json_schema).
+        # The registry only emits effort for families that support it, so no
+        # per-model exclusions are needed here. output_schema constrains the
+        # response via output_config.format (json_schema).
         # SDK <= 0.71 doesn't expose output_config as a top-level kwarg, so
         # we forward it via extra_body. The server accepts it either way.
         output_config: dict = {}
-        if effort and self.model and not self.model.startswith("claude-haiku-4-5"):
-            output_config["effort"] = effort
+        if wire.anthropic_effort:
+            output_config["effort"] = wire.anthropic_effort
         if output_schema is not None:
             output_config["format"] = {"type": "json_schema", "schema": output_schema}
         if output_config:
@@ -821,6 +747,7 @@ class ModelClient:
             text = _strip_json_fences(text)
 
         usage = _anthropic_usage(response.usage, model=self.model, endpoint="sync")
+        usage["thinking_blocks"] = _count_thinking_blocks(response.content)
         return ModelResponse(text=text, usage=usage)
 
     def _stream_anthropic(self, kwargs: dict, *, json_mode: bool):
@@ -857,6 +784,7 @@ class ModelClient:
             text = _strip_json_fences(text)
 
         usage = _anthropic_usage(message.usage, model=self.model, endpoint="stream")
+        usage["thinking_blocks"] = _count_thinking_blocks(message.content)
         return ModelResponse(
             text=text,
             usage=usage,
@@ -919,9 +847,9 @@ def resolve_max_tokens(client: "ModelClient", max_tokens: int) -> int:
     if max_tokens <= 0:
         max_tokens = MAX_OUTPUT_TOKENS.get(client.provider, 8192)
     model = getattr(client, "model", "") or ""
-    for prefix, cap in _ANTHROPIC_MAX_OUTPUT_CAP.items():
-        if model.startswith(prefix):
-            return min(max_tokens, cap)
+    cap = max_output_cap(model)
+    if cap is not None:
+        return min(max_tokens, cap)
     return max_tokens
 
 
@@ -931,17 +859,6 @@ MAX_OUTPUT_TOKENS = {
     "openai": 128000,
     "anthropic": 128000,
     "together": 16384,  # open-weight reasoners (DeepSeek/Kimi) need room to think
-}
-
-
-# Per-model max output token caps. Requests above the cap are rejected by the
-# API, so this clamps rather than lets the call fail. Keys match by startswith().
-# Verified against the Models API (`client.models.retrieve(id).max_tokens`) on
-# 2026-08-17; re-check there rather than trusting this table if a model 400s on
-# max_tokens. Sonnet 4.6 was previously listed at 64000 and is now 128000, i.e.
-# the provider table's default -- no entry needed.
-_ANTHROPIC_MAX_OUTPUT_CAP = {
-    "claude-haiku-4-5": 64000,
 }
 
 
@@ -1192,6 +1109,17 @@ def _gemini_stream_parts(chunk):
     return getattr(content, "parts", None) or []
 
 
+def _count_thinking_blocks(content) -> int:
+    """Count thinking blocks in an Anthropic response's content list.
+
+    Anthropic usage carries no separate reasoning-token count, so block
+    presence is the only wire-level evidence that thinking actually happened.
+    Recorded additively as usage["thinking_blocks"]; `tutormoments smoke`
+    reads it to catch silently-ignored thinking knobs.
+    """
+    return sum(1 for block in content if getattr(block, "type", "") == "thinking")
+
+
 def _extract_anthropic_text(content) -> str:
     """Concatenate all text blocks from an Anthropic response/message.
 
@@ -1428,10 +1356,13 @@ def run_sync_entries(
     entries: list[dict],
     json_mode: bool = True,
     max_tokens: int = 0,
+    thinking=None,
 ) -> dict:
     """Run entries synchronously one at a time.
 
-    Returns {key: {text, usage}} dict (same shape as run_batch).
+    Returns {key: {text, usage}} dict (same shape as run_batch). `thinking`
+    takes the same ladder level run_batch does, so a caller switching between
+    the two paths keeps the same benchmark condition.
     """
     raw_entries = {}
     total = len(entries)
@@ -1449,6 +1380,7 @@ def run_sync_entries(
                 images=images or None,
                 json_mode=entry_json_mode if json_mode else False,
                 max_tokens=entry_max_tokens,
+                thinking=thinking,
             )
             raw_entries[key] = {
                 "text": response.text,
@@ -1475,15 +1407,16 @@ def run_batch(
     json_mode: bool = True,
     display_name: str = "batch",
     poll_interval: int = 60,
-    thinking: bool = False,
-    thinking_budget: int = 0,
-    reasoning_effort: str = "",
-    effort: str = "",
+    thinking=None,
     enable_cache: bool = False,
     existing_batch_id: str | None = None,
     on_batch_created=None,
 ) -> dict:
     """Run entries as a batch job via the provider's batch API.
+
+    thinking: the same canonical ladder level generate() takes; the registry
+    translates it per provider and rejects levels the model cannot honor
+    (before anything is uploaded).
 
     Resume support: if `existing_batch_id` is set, skip submission and resume
     polling on that batch (the entries list still drives result parsing, so
@@ -1493,6 +1426,8 @@ def run_batch(
     this to persist the id for ctrl-C recovery.
     """
     provider = client.provider
+    # Before anything is uploaded: a config error must fail once, up front.
+    wire = resolve_thinking(client.model, thinking)
     if existing_batch_id:
         logger.info(
             "Resuming in-flight %s batch %s (%d entries)",
@@ -1509,45 +1444,74 @@ def run_batch(
         )
 
     if provider == "gemini":
-        return _run_batch_gemini(
-            client,
-            entries,
-            json_mode,
-            display_name,
-            poll_interval,
-            thinking,
-            thinking_budget,
-            existing_batch_id=existing_batch_id,
-            on_batch_created=on_batch_created,
-        )
+        batch_id = existing_batch_id
+        if batch_id is None:
+            batch_id = _submit_batch_gemini(client, entries, display_name, wire)
+            if on_batch_created:
+                on_batch_created(batch_id)
+        return _await_batch_gemini(client, batch_id, poll_interval)
     elif provider == "openai":
-        return _run_batch_openai(
-            client,
-            entries,
-            json_mode,
-            display_name,
-            poll_interval,
-            thinking,
-            thinking_budget,
-            reasoning_effort,
-            existing_batch_id=existing_batch_id,
-            on_batch_created=on_batch_created,
-        )
+        batch_id = existing_batch_id
+        if batch_id is None:
+            batch_id = _submit_batch_openai(
+                client, entries, json_mode, display_name, wire
+            )
+            if on_batch_created:
+                on_batch_created(batch_id)
+        return _await_batch_openai(client, batch_id, poll_interval)
     elif provider == "anthropic":
-        return _run_batch_anthropic(
-            client,
-            entries,
-            json_mode,
-            display_name,
-            poll_interval,
-            thinking,
-            thinking_budget,
-            reasoning_effort,
-            effort=effort,
-            enable_cache=enable_cache,
-            existing_batch_id=existing_batch_id,
-            on_batch_created=on_batch_created,
+        batch_id = existing_batch_id
+        if batch_id is None:
+            batch_id = _submit_batch_anthropic(
+                client, entries, json_mode, wire, enable_cache=enable_cache
+            )
+            if on_batch_created:
+                on_batch_created(batch_id)
+        return _await_batch_anthropic(
+            client, batch_id, entries, json_mode, poll_interval
         )
+    else:
+        raise ValueError(f"Batch API not supported for provider: {provider}")
+
+
+def submit_batch(
+    client: "ModelClient",
+    entries: list[dict],
+    json_mode: bool = True,
+    display_name: str = "batch",
+    thinking=None,
+) -> str:
+    """Submit a batch job without polling for results; returns the batch id.
+
+    The submission half of run_batch, exposed for `tutormoments smoke`:
+    verifying that a provider ACCEPTS the batch wire format does not require
+    paying for (or waiting on) the batch's completion -- pair with
+    cancel_batch. The same thinking ladder contract as run_batch applies.
+    """
+    wire = resolve_thinking(client.model, thinking)
+    provider = client.provider
+    if provider == "gemini":
+        return _submit_batch_gemini(client, entries, display_name, wire)
+    elif provider == "openai":
+        return _submit_batch_openai(client, entries, json_mode, display_name, wire)
+    elif provider == "anthropic":
+        return _submit_batch_anthropic(client, entries, json_mode, wire)
+    raise ValueError(f"Batch API not supported for provider: {provider}")
+
+
+def cancel_batch(client: "ModelClient", batch_id: str) -> None:
+    """Cancel an in-flight batch job on the client's provider.
+
+    Used by `tutormoments smoke` to verify batch submission formats without
+    paying for (or waiting on) a full batch run.
+    """
+    provider = client.provider
+    if provider == "gemini":
+        client._client.batches.cancel(name=batch_id)
+    elif provider == "openai":
+        client._client.batches.cancel(batch_id)
+    elif provider == "anthropic":
+        client._client.messages.batches.cancel(batch_id)
     else:
         raise ValueError(f"Batch API not supported for provider: {provider}")
 
@@ -1557,63 +1521,61 @@ def run_batch(
 # ===================================================================
 
 
-def _run_batch_gemini(
-    client,
-    entries,
-    json_mode,
-    display_name,
-    poll_interval,
-    thinking=False,
-    thinking_budget=0,
-    existing_batch_id=None,
-    on_batch_created=None,
-):
-    """Gemini batch: upload JSONL, submit, poll, download.
+def _gemini_text_from_parts(parts: list[dict]) -> str:
+    """Concatenate visible text from Gemini batch result parts.
 
-    If existing_batch_id is set, skip upload+submit and retrieve that job.
+    Thought summaries arrive as parts flagged `thought: true` when
+    include_thoughts is set; they are reasoning, not the answer, and on the
+    sync path `response.text` already excludes them. Skipping them here (and
+    joining the rest -- long answers can split across parts) keeps batch text
+    identical to sync text.
     """
+    return "".join(p.get("text", "") for p in parts if not p.get("thought", False))
+
+
+def _submit_batch_gemini(client, entries, display_name, wire: WireThinking) -> str:
+    """Upload the JSONL for a Gemini batch and create the job; returns its id."""
     import tempfile
 
-    from tutormoments.config import get_batch_timeout
-
     gemini_client = client._client
-    jsonl_path = None
+    thinking_config = wire.gemini_thinking_config
 
-    if existing_batch_id:
-        batch_job = gemini_client.batches.get(name=existing_batch_id)
-    else:
-        # Write Gemini-format JSONL to temp file
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
-        ) as f:
-            for entry in entries:
-                key, prompt_text, entry_json_mode, entry_max_tokens, images = (
-                    _extract_entry(entry)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+    ) as f:
+        for entry in entries:
+            key, prompt_text, entry_json_mode, entry_max_tokens, images = (
+                _extract_entry(entry)
+            )
+            # Gemini has no explicit batch cache API; concatenate prefix (auto-cache).
+            cacheable_prefix = entry.get("cacheable_prefix")
+            effective_prompt = (cacheable_prefix or "") + prompt_text
+            if images:
+                image_blocks = _build_image_blocks_gemini(images)
+                parts = _interleave_text_and_images(
+                    effective_prompt,
+                    image_blocks,
+                    lambda s: {"text": s},
                 )
-                # Gemini has no explicit batch cache API; concatenate prefix (auto-cache).
-                cacheable_prefix = entry.get("cacheable_prefix")
-                effective_prompt = (cacheable_prefix or "") + prompt_text
-                if images:
-                    image_blocks = _build_image_blocks_gemini(images)
-                    parts = _interleave_text_and_images(
-                        effective_prompt,
-                        image_blocks,
-                        lambda s: {"text": s},
-                    )
-                else:
-                    parts = [{"text": effective_prompt}]
-                gem_entry = {
-                    "key": key,
-                    "request": {
-                        "contents": [{"parts": parts, "role": "user"}],
-                        "generation_config": entry["request"].get(
-                            "generation_config", {}
-                        ),
-                    },
-                }
-                f.write(json.dumps(gem_entry, ensure_ascii=False) + "\n")
-            jsonl_path = f.name
+            else:
+                parts = [{"text": effective_prompt}]
+            # Copy the entry's generation_config before adding thinking_config:
+            # entries can be re-submitted (resume flows), so the shared dict
+            # must not be mutated.
+            gen_config = dict(entry["request"].get("generation_config", {}))
+            if thinking_config is not None:
+                gen_config["thinking_config"] = dict(thinking_config)
+            gem_entry = {
+                "key": key,
+                "request": {
+                    "contents": [{"parts": parts, "role": "user"}],
+                    "generation_config": gen_config,
+                },
+            }
+            f.write(json.dumps(gem_entry, ensure_ascii=False) + "\n")
+        jsonl_path = f.name
 
+    try:
         logger.info("Uploading batch request file...")
         uploaded_file = gemini_client.files.upload(
             file=jsonl_path,
@@ -1628,75 +1590,80 @@ def _run_batch_gemini(
             config={"display_name": display_name},
         )
         logger.info("Batch job created: %s", batch_job.name)
-        if on_batch_created:
-            on_batch_created(batch_job.name)
-
-    try:
-        poll_start = time.monotonic()
-        batch_timeout = get_batch_timeout()
-        completed_states = {
-            "JOB_STATE_SUCCEEDED",
-            "JOB_STATE_FAILED",
-            "JOB_STATE_CANCELLED",
-            "JOB_STATE_EXPIRED",
-        }
-        while batch_job.state.name not in completed_states:
-            if time.monotonic() - poll_start > batch_timeout:
-                raise RuntimeError(
-                    f"Gemini batch timed out after {batch_timeout}s "
-                    f"(state: {batch_job.state.name})"
-                )
-            logger.info(
-                "Batch in progress: %s (%dm elapsed, next poll in %ds)",
-                batch_job.state.name,
-                int(time.monotonic() - poll_start) // 60,
-                poll_interval,
-            )
-            time.sleep(poll_interval)
-            batch_job = gemini_client.batches.get(name=batch_job.name)
-
-        logger.info("Batch job finished: %s", batch_job.state.name)
-        if batch_job.state.name != "JOB_STATE_SUCCEEDED":
-            raise RuntimeError(f"Gemini batch failed: {batch_job.state.name}")
-
-        if not batch_job.dest or not batch_job.dest.file_name:
-            raise RuntimeError("No output file in batch job result")
-
-        logger.info("Downloading results from: %s", batch_job.dest.file_name)
-        result_bytes = gemini_client.files.download(file=batch_job.dest.file_name)
-        result_text = result_bytes.decode("utf-8")
-
-        raw_entries = {}
-        for line in result_text.strip().split("\n"):
-            if not line.strip():
-                continue
-            result = json.loads(line)
-            key = result.get("key")
-            response = result.get("response")
-
-            if response:
-                candidates = response.get("candidates", [])
-                text = ""
-                if candidates:
-                    parts = candidates[0].get("content", {}).get("parts", [])
-                    if parts:
-                        text = parts[0].get("text", "")
-                usage_meta = response.get("usageMetadata", {})
-                raw_entries[key] = {
-                    "text": text,
-                    "usage": _gemini_batch_usage(usage_meta, model=client.model),
-                }
-            else:
-                error = result.get("error")
-                raw_entries[key] = {
-                    "text": "",
-                    "error": str(error) if error else "No response",
-                    "usage": _zero_usage("gemini", client.model, "batch"),
-                }
-        return raw_entries
+        return batch_job.name
     finally:
-        if jsonl_path:
-            os.unlink(jsonl_path)
+        os.unlink(jsonl_path)
+
+
+def _await_batch_gemini(client, batch_id, poll_interval) -> dict:
+    """Poll a Gemini batch to completion and parse its result file."""
+    from tutormoments.config import get_batch_timeout
+
+    gemini_client = client._client
+    batch_job = gemini_client.batches.get(name=batch_id)
+
+    poll_start = time.monotonic()
+    batch_timeout = get_batch_timeout()
+    completed_states = {
+        "JOB_STATE_SUCCEEDED",
+        "JOB_STATE_FAILED",
+        "JOB_STATE_CANCELLED",
+        "JOB_STATE_EXPIRED",
+    }
+    while batch_job.state.name not in completed_states:
+        if time.monotonic() - poll_start > batch_timeout:
+            raise RuntimeError(
+                f"Gemini batch timed out after {batch_timeout}s "
+                f"(state: {batch_job.state.name})"
+            )
+        logger.info(
+            "Batch in progress: %s (%dm elapsed, next poll in %ds)",
+            batch_job.state.name,
+            int(time.monotonic() - poll_start) // 60,
+            poll_interval,
+        )
+        time.sleep(poll_interval)
+        batch_job = gemini_client.batches.get(name=batch_job.name)
+
+    logger.info("Batch job finished: %s", batch_job.state.name)
+    if batch_job.state.name != "JOB_STATE_SUCCEEDED":
+        raise RuntimeError(f"Gemini batch failed: {batch_job.state.name}")
+
+    if not batch_job.dest or not batch_job.dest.file_name:
+        raise RuntimeError("No output file in batch job result")
+
+    logger.info("Downloading results from: %s", batch_job.dest.file_name)
+    result_bytes = gemini_client.files.download(file=batch_job.dest.file_name)
+    result_text = result_bytes.decode("utf-8")
+
+    raw_entries = {}
+    for line in result_text.strip().split("\n"):
+        if not line.strip():
+            continue
+        result = json.loads(line)
+        key = result.get("key")
+        response = result.get("response")
+
+        if response:
+            candidates = response.get("candidates", [])
+            text = ""
+            if candidates:
+                parts = candidates[0].get("content", {}).get("parts", [])
+                if parts:
+                    text = _gemini_text_from_parts(parts)
+            usage_meta = response.get("usageMetadata", {})
+            raw_entries[key] = {
+                "text": text,
+                "usage": _gemini_batch_usage(usage_meta, model=client.model),
+            }
+        else:
+            error = result.get("error")
+            raw_entries[key] = {
+                "text": "",
+                "error": str(error) if error else "No response",
+                "usage": _zero_usage("gemini", client.model, "batch"),
+            }
+    return raw_entries
 
 
 # ===================================================================
@@ -1704,80 +1671,62 @@ def _run_batch_gemini(
 # ===================================================================
 
 
-def _run_batch_openai(
-    client,
-    entries,
-    json_mode,
-    display_name,
-    poll_interval,
-    thinking=False,
-    thinking_budget=0,
-    reasoning_effort="",
-    existing_batch_id=None,
-    on_batch_created=None,
-):
-    """OpenAI batch: upload JSONL, create batch, poll, download results.
-
-    If existing_batch_id is set, skip upload+create and retrieve that batch.
-    """
+def _submit_batch_openai(
+    client, entries, json_mode, display_name, wire: WireThinking
+) -> str:
+    """Upload the JSONL for an OpenAI batch and create the job; returns its id."""
     import tempfile
-
-    from tutormoments.config import get_batch_timeout
 
     openai_client = client._client
     max_tokens = MAX_OUTPUT_TOKENS["openai"]
-    jsonl_path = None
 
-    if existing_batch_id:
-        batch_job = openai_client.batches.retrieve(existing_batch_id)
-    else:
-        # Write OpenAI-format JSONL
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
-        ) as f:
-            for entry in entries:
-                key, prompt_text, entry_json_mode, entry_max_tokens, images = (
-                    _extract_entry(entry)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+    ) as f:
+        for entry in entries:
+            key, prompt_text, entry_json_mode, entry_max_tokens, images = (
+                _extract_entry(entry)
+            )
+            if not entry_max_tokens or entry_max_tokens > max_tokens:
+                entry_max_tokens = max_tokens
+
+            # OpenAI uses automatic prefix caching; concatenate the prefix so the
+            # same static head is always at the front of the message.
+            cacheable_prefix = entry.get("cacheable_prefix")
+            effective_prompt = (cacheable_prefix or "") + prompt_text
+
+            if images:
+                image_blocks = _build_image_blocks_openai(
+                    images,
+                    use_url=_should_use_presigned_url(),
                 )
-                if not entry_max_tokens or entry_max_tokens > max_tokens:
-                    entry_max_tokens = max_tokens
+                content = _interleave_text_and_images(
+                    effective_prompt,
+                    image_blocks,
+                    lambda s: {"type": "text", "text": s},
+                )
+            else:
+                content = effective_prompt
 
-                # OpenAI uses automatic prefix caching; concatenate the prefix so the
-                # same static head is always at the front of the message.
-                cacheable_prefix = entry.get("cacheable_prefix")
-                effective_prompt = (cacheable_prefix or "") + prompt_text
+            body = {
+                "model": client.model,
+                "messages": [{"role": "user", "content": content}],
+                "max_completion_tokens": entry_max_tokens,
+            }
+            if json_mode and entry_json_mode:
+                body["response_format"] = {"type": "json_object"}
+            if wire.openai_reasoning_effort:
+                body["reasoning_effort"] = wire.openai_reasoning_effort
+            line = {
+                "custom_id": key,
+                "method": "POST",
+                "url": "/v1/chat/completions",
+                "body": body,
+            }
+            f.write(json.dumps(line, ensure_ascii=False) + "\n")
+        jsonl_path = f.name
 
-                if images:
-                    image_blocks = _build_image_blocks_openai(
-                        images,
-                        use_url=_should_use_presigned_url(),
-                    )
-                    content = _interleave_text_and_images(
-                        effective_prompt,
-                        image_blocks,
-                        lambda s: {"type": "text", "text": s},
-                    )
-                else:
-                    content = effective_prompt
-
-                body = {
-                    "model": client.model,
-                    "messages": [{"role": "user", "content": content}],
-                    "max_completion_tokens": entry_max_tokens,
-                }
-                if json_mode and entry_json_mode:
-                    body["response_format"] = {"type": "json_object"}
-                if reasoning_effort:
-                    body["reasoning_effort"] = reasoning_effort
-                line = {
-                    "custom_id": key,
-                    "method": "POST",
-                    "url": "/v1/chat/completions",
-                    "body": body,
-                }
-                f.write(json.dumps(line, ensure_ascii=False) + "\n")
-            jsonl_path = f.name
-
+    try:
         logger.info("Uploading batch request file...")
         with open(jsonl_path, "rb") as f:
             uploaded_file = openai_client.files.create(file=f, purpose="batch")
@@ -1791,70 +1740,75 @@ def _run_batch_openai(
             metadata={"description": display_name},
         )
         logger.info("Batch job created: %s", batch_job.id)
-        if on_batch_created:
-            on_batch_created(batch_job.id)
-
-    try:
-        poll_start = time.monotonic()
-        batch_timeout = get_batch_timeout()
-        terminal_states = {"completed", "failed", "expired", "cancelled"}
-        while batch_job.status not in terminal_states:
-            if time.monotonic() - poll_start > batch_timeout:
-                raise RuntimeError(
-                    f"OpenAI batch timed out after {batch_timeout}s "
-                    f"(state: {batch_job.status})"
-                )
-            logger.info(
-                "Batch in progress: %s (%dm elapsed, next poll in %ds)",
-                batch_job.status,
-                int(time.monotonic() - poll_start) // 60,
-                poll_interval,
-            )
-            time.sleep(poll_interval)
-            batch_job = openai_client.batches.retrieve(batch_job.id)
-
-        logger.info("Batch job finished: %s", batch_job.status)
-        if batch_job.status != "completed":
-            raise RuntimeError(f"OpenAI batch failed: {batch_job.status}")
-
-        if not batch_job.output_file_id:
-            raise RuntimeError("No output file in batch job result")
-
-        logger.info("Downloading results from: %s", batch_job.output_file_id)
-        result_bytes = openai_client.files.content(batch_job.output_file_id).content
-        result_text = result_bytes.decode("utf-8")
-
-        raw_entries = {}
-        for line in result_text.strip().split("\n"):
-            if not line.strip():
-                continue
-            result = json.loads(line)
-            key = result.get("custom_id")
-            error = result.get("error")
-
-            if error:
-                raw_entries[key] = {
-                    "text": "",
-                    "error": str(error),
-                    "usage": _zero_usage("openai", client.model, "batch"),
-                }
-                continue
-
-            response_body = result.get("response", {}).get("body", {})
-            choices = response_body.get("choices", [])
-            text = ""
-            if choices:
-                text = choices[0].get("message", {}).get("content", "")
-
-            usage = response_body.get("usage", {})
-            raw_entries[key] = {
-                "text": text,
-                "usage": _openai_batch_usage(usage, model=client.model),
-            }
-        return raw_entries
+        return batch_job.id
     finally:
-        if jsonl_path:
-            os.unlink(jsonl_path)
+        os.unlink(jsonl_path)
+
+
+def _await_batch_openai(client, batch_id, poll_interval) -> dict:
+    """Poll an OpenAI batch to completion and parse its result file."""
+    from tutormoments.config import get_batch_timeout
+
+    openai_client = client._client
+    batch_job = openai_client.batches.retrieve(batch_id)
+
+    poll_start = time.monotonic()
+    batch_timeout = get_batch_timeout()
+    terminal_states = {"completed", "failed", "expired", "cancelled"}
+    while batch_job.status not in terminal_states:
+        if time.monotonic() - poll_start > batch_timeout:
+            raise RuntimeError(
+                f"OpenAI batch timed out after {batch_timeout}s "
+                f"(state: {batch_job.status})"
+            )
+        logger.info(
+            "Batch in progress: %s (%dm elapsed, next poll in %ds)",
+            batch_job.status,
+            int(time.monotonic() - poll_start) // 60,
+            poll_interval,
+        )
+        time.sleep(poll_interval)
+        batch_job = openai_client.batches.retrieve(batch_job.id)
+
+    logger.info("Batch job finished: %s", batch_job.status)
+    if batch_job.status != "completed":
+        raise RuntimeError(f"OpenAI batch failed: {batch_job.status}")
+
+    if not batch_job.output_file_id:
+        raise RuntimeError("No output file in batch job result")
+
+    logger.info("Downloading results from: %s", batch_job.output_file_id)
+    result_bytes = openai_client.files.content(batch_job.output_file_id).content
+    result_text = result_bytes.decode("utf-8")
+
+    raw_entries = {}
+    for line in result_text.strip().split("\n"):
+        if not line.strip():
+            continue
+        result = json.loads(line)
+        key = result.get("custom_id")
+        error = result.get("error")
+
+        if error:
+            raw_entries[key] = {
+                "text": "",
+                "error": str(error),
+                "usage": _zero_usage("openai", client.model, "batch"),
+            }
+            continue
+
+        response_body = result.get("response", {}).get("body", {})
+        choices = response_body.get("choices", [])
+        text = ""
+        if choices:
+            text = choices[0].get("message", {}).get("content", "")
+
+        usage = response_body.get("usage", {})
+        raw_entries[key] = {
+            "text": text,
+            "usage": _openai_batch_usage(usage, model=client.model),
+        }
+    return raw_entries
 
 
 # ===================================================================
@@ -1862,155 +1816,138 @@ def _run_batch_openai(
 # ===================================================================
 
 
-def _run_batch_anthropic(
-    client,
-    entries,
-    json_mode,
-    display_name,
-    poll_interval,
-    thinking=False,
-    thinking_budget=0,
-    reasoning_effort="",
-    effort="",
-    enable_cache=False,
-    existing_batch_id=None,
-    on_batch_created=None,
-):
-    """Anthropic batch: create message batch, poll, stream results.
+def _submit_batch_anthropic(
+    client, entries, json_mode, wire: WireThinking, enable_cache=False
+) -> str:
+    """Create an Anthropic message batch; returns its id.
 
-    If existing_batch_id is set, skip submission and retrieve that batch.
-    The id_to_key mapping is rebuilt deterministically from `entries` order
-    (so callers must pass the same entries that were originally submitted).
+    custom_ids are short indexed IDs (r0, r1, ...) deterministic in entries
+    order (Anthropic custom_id has a 64-char limit); _await_batch_anthropic
+    rebuilds the id->key mapping from the same entries.
     """
     from anthropic.types.message_create_params import MessageCreateParamsNonStreaming
     from anthropic.types.messages.batch_create_params import Request
 
-    from tutormoments.config import get_batch_timeout, get_retry_config
+    from tutormoments.config import get_retry_config
 
     anthropic_client = client._client
     max_tokens = MAX_OUTPUT_TOKENS["anthropic"]
-    # Apply per-model output cap (e.g. Haiku 4.5 / Sonnet 4.6 cap at 64K).
-    for prefix, cap in _ANTHROPIC_MAX_OUTPUT_CAP.items():
-        if client.model and client.model.startswith(prefix):
-            max_tokens = min(max_tokens, cap)
-            break
+    # Apply the per-model output cap from the model registry.
+    cap = max_output_cap(client.model)
+    if cap is not None:
+        max_tokens = min(max_tokens, cap)
 
-    # id_to_key mapping is deterministic in entries order, so it can be rebuilt
-    # on resume without re-submitting. Anthropic custom_id has a 64-char limit,
-    # so we use short indexed IDs.
-    id_to_key = {f"r{i}": _extract_entry(e)[0] for i, e in enumerate(entries)}
+    thinking_param = wire.anthropic_thinking
+    thinking_min = 0
+    if thinking_param is not None and thinking_param.get("type") == "enabled":
+        # Legacy enabled mode needs max_tokens >= budget + headroom.
+        thinking_min = thinking_param["budget_tokens"] + 64
 
-    if existing_batch_id:
-        message_batch = anthropic_client.messages.batches.retrieve(existing_batch_id)
-    else:
-        thinking_param = (
-            _anthropic_thinking_param(client.model, thinking_budget)
-            if thinking
-            else None
+    requests = []
+    for i, entry in enumerate(entries):
+        key, prompt_text, entry_json_mode, entry_max_tokens, images = _extract_entry(
+            entry
         )
-        thinking_min = 0
-        if thinking_param is not None and thinking_param.get("type") == "enabled":
-            # Legacy enabled mode needs max_tokens >= budget + headroom.
-            thinking_min = thinking_param["budget_tokens"] + 64
+        if not entry_max_tokens or entry_max_tokens > max_tokens:
+            entry_max_tokens = max_tokens
+        if thinking_min and entry_max_tokens < thinking_min:
+            entry_max_tokens = thinking_min
 
-        requests = []
-        for i, entry in enumerate(entries):
-            key, prompt_text, entry_json_mode, entry_max_tokens, images = (
-                _extract_entry(entry)
+        cacheable_prefix = entry.get("cacheable_prefix")
+
+        if images:
+            image_blocks = _build_image_blocks_anthropic(
+                images,
+                use_url=_should_use_presigned_url(),
+                enable_cache=enable_cache,
             )
-            if not entry_max_tokens or entry_max_tokens > max_tokens:
-                entry_max_tokens = max_tokens
-            if thinking_min and entry_max_tokens < thinking_min:
-                entry_max_tokens = thinking_min
-
-            cacheable_prefix = entry.get("cacheable_prefix")
-
-            if images:
-                image_blocks = _build_image_blocks_anthropic(
-                    images,
-                    use_url=_should_use_presigned_url(),
-                    enable_cache=enable_cache,
-                )
-                content = _interleave_text_and_images(
-                    prompt_text,
-                    image_blocks,
-                    lambda s: {"type": "text", "text": s},
-                )
-                if cacheable_prefix is not None:
-                    content = [
-                        {
-                            "type": "text",
-                            "text": cacheable_prefix,
-                            "cache_control": {"type": "ephemeral"},
-                        },
-                    ] + content
-            elif cacheable_prefix is not None:
+            content = _interleave_text_and_images(
+                prompt_text,
+                image_blocks,
+                lambda s: {"type": "text", "text": s},
+            )
+            if cacheable_prefix is not None:
                 content = [
                     {
                         "type": "text",
                         "text": cacheable_prefix,
                         "cache_control": {"type": "ephemeral"},
                     },
-                    {"type": "text", "text": prompt_text},
-                ]
-            else:
-                content = prompt_text
+                ] + content
+        elif cacheable_prefix is not None:
+            content = [
+                {
+                    "type": "text",
+                    "text": cacheable_prefix,
+                    "cache_control": {"type": "ephemeral"},
+                },
+                {"type": "text", "text": prompt_text},
+            ]
+        else:
+            content = prompt_text
 
-            params = {
-                "model": client.model,
-                "max_tokens": entry_max_tokens,
-                "messages": [{"role": "user", "content": content}],
-            }
-            if json_mode and entry_json_mode:
-                params["system"] = (
-                    "You must respond with valid JSON only. "
-                    "Do not include markdown code fences, explanations, or any text "
-                    "outside the JSON object."
-                )
-            if thinking_param is not None:
-                params["thinking"] = thinking_param
-            # effort goes inside output_config, mirroring the sync path
-            # (_generate_anthropic). Haiku 4.5 rejects effort -- skip there.
-            if (
-                effort
-                and client.model
-                and not client.model.startswith("claude-haiku-4-5")
-            ):
-                params["output_config"] = {"effort": effort}
-
-            requests.append(
-                Request(
-                    custom_id=f"r{i}",
-                    params=MessageCreateParamsNonStreaming(**params),
-                )
+        params = {
+            "model": client.model,
+            "max_tokens": entry_max_tokens,
+            "messages": [{"role": "user", "content": content}],
+        }
+        if json_mode and entry_json_mode:
+            params["system"] = (
+                "You must respond with valid JSON only. "
+                "Do not include markdown code fences, explanations, or any text "
+                "outside the JSON object."
             )
+        if thinking_param is not None:
+            params["thinking"] = dict(thinking_param)
+        # effort goes inside output_config, mirroring the sync path
+        # (_generate_anthropic). The registry only emits effort for families
+        # that support it.
+        if wire.anthropic_effort:
+            params["output_config"] = {"effort": wire.anthropic_effort}
 
-        logger.info("Submitting batch (%d requests)...", len(requests))
-        retry_cfg = get_retry_config()
-        max_retries = retry_cfg.get("max_retries", 5)
-        base_delay = retry_cfg.get("base_delay", 5)
-        for attempt in range(max_retries):
-            try:
-                message_batch = anthropic_client.messages.batches.create(
-                    requests=requests
+        requests.append(
+            Request(
+                custom_id=f"r{i}",
+                params=MessageCreateParamsNonStreaming(**params),
+            )
+        )
+
+    logger.info("Submitting batch (%d requests)...", len(requests))
+    retry_cfg = get_retry_config()
+    max_retries = retry_cfg.get("max_retries", 5)
+    base_delay = retry_cfg.get("base_delay", 5)
+    for attempt in range(max_retries):
+        try:
+            message_batch = anthropic_client.messages.batches.create(requests=requests)
+            break
+        except Exception as e:
+            if attempt < max_retries - 1:
+                delay = base_delay * (2**attempt)
+                logger.warning(
+                    "Batch submit error (attempt %d/%d): %s. Retrying in %ds...",
+                    attempt + 1,
+                    max_retries,
+                    e,
+                    delay,
                 )
-                break
-            except Exception as e:
-                if attempt < max_retries - 1:
-                    delay = base_delay * (2**attempt)
-                    logger.warning(
-                        "Batch submit error (attempt %d/%d): %s. Retrying in %ds...",
-                        attempt + 1,
-                        max_retries,
-                        e,
-                        delay,
-                    )
-                    time.sleep(delay)
-                else:
-                    raise
-        logger.info("Batch created: %s", message_batch.id)
-        if on_batch_created:
-            on_batch_created(message_batch.id)
+                time.sleep(delay)
+            else:
+                raise
+    logger.info("Batch created: %s", message_batch.id)
+    return message_batch.id
+
+
+def _await_batch_anthropic(client, batch_id, entries, json_mode, poll_interval) -> dict:
+    """Poll an Anthropic message batch to completion and parse its results.
+
+    The id_to_key mapping is rebuilt deterministically from `entries` order,
+    so callers must pass the same entries that were originally submitted.
+    """
+    from tutormoments.config import get_batch_timeout
+
+    anthropic_client = client._client
+    id_to_key = {f"r{i}": _extract_entry(e)[0] for i, e in enumerate(entries)}
+    message_batch = anthropic_client.messages.batches.retrieve(batch_id)
 
     poll_start = time.monotonic()
     batch_timeout = get_batch_timeout()
@@ -2047,6 +1984,7 @@ def _run_batch_anthropic(
             usage = _anthropic_usage(
                 message.usage, model=client.model, endpoint="batch"
             )
+            usage["thinking_blocks"] = _count_thinking_blocks(message.content)
             raw_entries[key] = {"text": text, "usage": usage}
         else:
             error_msg = f"{result.result.type}"

--- a/src/tutormoments/client.py
+++ b/src/tutormoments/client.py
@@ -80,11 +80,21 @@ class ModelResponse:
     """Unified response from any provider."""
 
     text: str
+    # Zero legacy counters plus the canonical cost vector (see
+    # normalize_usage). No provenance here: this default is only used where
+    # no real API call happened (e.g. registered/callable tutors), so there
+    # is no provider/model/endpoint to attribute the zeros to.
     usage: dict = field(
         default_factory=lambda: {
             "input_tokens": 0,
             "output_tokens": 0,
             "total_tokens": 0,
+            "input_uncached": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+            "output": 0,
+            "reasoning": 0,
+            "total": 0,
         }
     )
     # Wall-clock seconds from the start of the successful generate() attempt
@@ -514,12 +524,9 @@ class ModelClient:
         )
 
         text = response.text or ""
-        usage_meta = response.usage_metadata
-        usage = {
-            "input_tokens": getattr(usage_meta, "prompt_token_count", 0) or 0,
-            "output_tokens": getattr(usage_meta, "candidates_token_count", 0) or 0,
-            "total_tokens": getattr(usage_meta, "total_token_count", 0) or 0,
-        }
+        usage = _gemini_usage(
+            response.usage_metadata, model=self.model, endpoint="sync"
+        )
         return ModelResponse(text=text, usage=usage)
 
     def _stream_gemini(self, contents, config):
@@ -551,11 +558,7 @@ class ModelClient:
             if not saw_visible:
                 timer.chunk()
 
-        usage = {
-            "input_tokens": getattr(usage_meta, "prompt_token_count", 0) or 0,
-            "output_tokens": getattr(usage_meta, "candidates_token_count", 0) or 0,
-            "total_tokens": getattr(usage_meta, "total_token_count", 0) or 0,
-        }
+        usage = _gemini_usage(usage_meta, model=self.model, endpoint="stream")
         return ModelResponse(
             text="".join(pieces),
             usage=usage,
@@ -610,16 +613,9 @@ class ModelClient:
         response = self._client.chat.completions.create(**kwargs)
 
         text = response.choices[0].message.content or ""
-        cached = 0
-        details = getattr(response.usage, "prompt_tokens_details", None)
-        if details is not None:
-            cached = getattr(details, "cached_tokens", 0) or 0
-        usage = {
-            "input_tokens": response.usage.prompt_tokens or 0,
-            "output_tokens": response.usage.completion_tokens or 0,
-            "total_tokens": response.usage.total_tokens or 0,
-            "cached_tokens": cached,
-        }
+        usage = _openai_style_usage(
+            response.usage, provider=self.provider, model=self.model, endpoint="sync"
+        )
         return ModelResponse(text=text, usage=usage)
 
     def _generate_together(
@@ -636,8 +632,10 @@ class ModelClient:
         Together uses `max_tokens` (not `max_completion_tokens`) and does not
         accept `reasoning_effort`. Open-weight reasoners (DeepSeek-V4, Kimi)
         produce their own chain-of-thought internally; there's no depth knob
-        to pass. Caching isn't supported, so the cacheable head is just
-        concatenated into the prompt (same as the Gemini path).
+        to pass. There is no cache_control-style API, so the cacheable head is
+        just concatenated into the prompt (same as the Gemini path); Together
+        still reports server-side cache hits via cached_tokens (observed live
+        on DeepSeek-V4-Pro), whether or not a billing discount applies.
         """
         content = (cacheable_prefix or "") + prompt
         kwargs = {
@@ -660,12 +658,9 @@ class ModelClient:
         text = response.choices[0].message.content or ""
         if json_mode:
             text = _strip_json_fences(text)
-        u = response.usage
-        usage = {
-            "input_tokens": getattr(u, "prompt_tokens", 0) or 0,
-            "output_tokens": getattr(u, "completion_tokens", 0) or 0,
-            "total_tokens": getattr(u, "total_tokens", 0) or 0,
-        }
+        usage = _openai_style_usage(
+            response.usage, provider=self.provider, model=self.model, endpoint="sync"
+        )
         return ModelResponse(text=text, usage=usage)
 
     def _stream_openai_compatible(self, kwargs: dict, *, inline_think: bool):
@@ -708,22 +703,15 @@ class ModelClient:
             if piece:
                 pieces.append(piece)
 
-        cached = 0
-        details = getattr(usage_obj, "prompt_tokens_details", None)
-        if details is not None:
-            cached = getattr(details, "cached_tokens", 0) or 0
-        usage = {
-            "input_tokens": getattr(usage_obj, "prompt_tokens", 0) or 0,
-            "output_tokens": getattr(usage_obj, "completion_tokens", 0) or 0,
-            "total_tokens": getattr(usage_obj, "total_tokens", 0) or 0,
-            "cached_tokens": cached,
-        }
+        usage = _openai_style_usage(
+            usage_obj, provider=self.provider, model=self.model, endpoint="stream"
+        )
         return ModelResponse(
             text="".join(pieces),
             usage=usage,
             timing=timer.as_dict(
                 output_tokens=usage["output_tokens"] or None,
-                cache_read_input_tokens=cached,
+                cache_read_input_tokens=usage["cached_tokens"],
             ),
         )
 
@@ -832,7 +820,7 @@ class ModelClient:
         if json_mode:
             text = _strip_json_fences(text)
 
-        usage = _anthropic_usage(response.usage)
+        usage = _anthropic_usage(response.usage, model=self.model, endpoint="sync")
         return ModelResponse(text=text, usage=usage)
 
     def _stream_anthropic(self, kwargs: dict, *, json_mode: bool):
@@ -868,7 +856,7 @@ class ModelClient:
         if json_mode:
             text = _strip_json_fences(text)
 
-        usage = _anthropic_usage(message.usage)
+        usage = _anthropic_usage(message.usage, model=self.model, endpoint="stream")
         return ModelResponse(
             text=text,
             usage=usage,
@@ -986,20 +974,206 @@ def _strip_json_fences(text: str) -> str:
     return stripped.strip()
 
 
-def _anthropic_usage(usage) -> dict:
+# ===================================================================
+# Usage normalization (canonical cost vector)
+# ===================================================================
+#
+# Every LLM call records the same five-bucket vector, built from the exact
+# cached/uncached split the provider reported -- never estimated. `total` is
+# derived from the buckets so there is exactly one definition of "total".
+# Provenance (provider/model/endpoint) rides alongside as strings; only the
+# integer-valued keys are meaningful to sum. The legacy per-provider keys
+# (input_tokens/output_tokens/total_tokens, cached_tokens, cache_*_input_tokens)
+# stay alongside so existing readers and old transcripts keep working.
+
+
+def normalize_usage(
+    provider: str,
+    model: str,
+    endpoint: str,
+    *,
+    input_uncached: int = 0,
+    cache_read: int = 0,
+    cache_write: int = 0,
+    output: int = 0,
+    reasoning: int = 0,
+) -> dict:
+    """Build the canonical usage vector + provenance for one LLM call.
+
+    input_uncached: prompt tokens billed at the full input rate.
+    cache_read: tokens served from the provider's prompt cache.
+    cache_write: tokens written to cache (Anthropic; 0 elsewhere today).
+    output: completion tokens, excluding reasoning where separable.
+    reasoning: thinking tokens billed at the output rate (Gemini reports
+        them separately; other providers fold them into output).
+    endpoint: "sync" | "stream" | "batch" -- batch-tagged usage is what the
+        batch discount applies to in cost computation.
+    """
+    return {
+        "input_uncached": input_uncached,
+        "cache_read": cache_read,
+        "cache_write": cache_write,
+        "output": output,
+        "reasoning": reasoning,
+        "total": input_uncached + cache_read + cache_write + output + reasoning,
+        "provider": provider,
+        "model": model,
+        "endpoint": endpoint,
+    }
+
+
+def _gemini_usage(usage_meta, *, model: str, endpoint: str) -> dict:
+    """Normalize a Gemini usage_metadata object (sync and stream paths).
+
+    prompt_token_count includes the cached share, so the uncached part is the
+    difference. thoughts_token_count is disjoint from candidates_token_count
+    (their sum plus the prompt is total_token_count), which is why the legacy
+    provider total disagrees with input+output on thinking models.
+    """
+    prompt = getattr(usage_meta, "prompt_token_count", 0) or 0
+    candidates = getattr(usage_meta, "candidates_token_count", 0) or 0
+    total = getattr(usage_meta, "total_token_count", 0) or 0
+    cached = getattr(usage_meta, "cached_content_token_count", 0) or 0
+    thoughts = getattr(usage_meta, "thoughts_token_count", 0) or 0
+    return {
+        "input_tokens": prompt,
+        "output_tokens": candidates,
+        "total_tokens": total,
+        **normalize_usage(
+            "gemini",
+            model,
+            endpoint,
+            input_uncached=prompt - cached,
+            cache_read=cached,
+            output=candidates,
+            reasoning=thoughts,
+        ),
+    }
+
+
+def _gemini_batch_usage(usage_meta: dict, *, model: str) -> dict:
+    """Normalize the camelCase usageMetadata dict from a Gemini batch result."""
+    prompt = usage_meta.get("promptTokenCount", 0) or 0
+    candidates = usage_meta.get("candidatesTokenCount", 0) or 0
+    total = usage_meta.get("totalTokenCount", 0) or 0
+    cached = usage_meta.get("cachedContentTokenCount", 0) or 0
+    thoughts = usage_meta.get("thoughtsTokenCount", 0) or 0
+    return {
+        "input_tokens": prompt,
+        "output_tokens": candidates,
+        "total_tokens": total,
+        **normalize_usage(
+            "gemini",
+            model,
+            "batch",
+            input_uncached=prompt - cached,
+            cache_read=cached,
+            output=candidates,
+            reasoning=thoughts,
+        ),
+    }
+
+
+def _openai_style_usage(usage_obj, *, provider: str, model: str, endpoint: str) -> dict:
+    """Normalize an OpenAI-shaped usage object (OpenAI + Together, sync/stream).
+
+    prompt_tokens includes the cached share, reported under
+    prompt_tokens_details.cached_tokens. Together populates it too (observed
+    live on DeepSeek-V4-Pro); whether Together discounts those tokens is a
+    pricing-table question, not a capture question. GPT-5.6-generation models
+    additionally meter cache writes (billed at 1.25x input) under
+    prompt_tokens_details.cache_write_tokens -- also a subset of
+    prompt_tokens, disjoint from cached_tokens (verified live on
+    gpt-5.6-luna: prompt 1120 = 1117 written + 3 uncached). usage_obj may be
+    None (Together streams sometimes never deliver the usage chunk): every
+    bucket records 0 rather than a guess.
+    """
+    prompt = getattr(usage_obj, "prompt_tokens", 0) or 0
+    completion = getattr(usage_obj, "completion_tokens", 0) or 0
+    total = getattr(usage_obj, "total_tokens", 0) or 0
+    details = getattr(usage_obj, "prompt_tokens_details", None)
+    cached = (getattr(details, "cached_tokens", 0) or 0) if details is not None else 0
+    written = (
+        (getattr(details, "cache_write_tokens", 0) or 0) if details is not None else 0
+    )
+    return {
+        "input_tokens": prompt,
+        "output_tokens": completion,
+        "total_tokens": total,
+        "cached_tokens": cached,
+        **normalize_usage(
+            provider,
+            model,
+            endpoint,
+            input_uncached=prompt - cached - written,
+            cache_read=cached,
+            cache_write=written,
+            output=completion,
+        ),
+    }
+
+
+def _openai_batch_usage(usage: dict, *, model: str) -> dict:
+    """Normalize the usage dict from an OpenAI batch result line.
+
+    Prompt caching does not apply on the OpenAI Batch API, so the whole prompt
+    is uncached by construction -- cache_read is forced to 0 even if a
+    cached_tokens field ever appears in a batch response body.
+    """
+    prompt = usage.get("prompt_tokens", 0) or 0
+    completion = usage.get("completion_tokens", 0) or 0
+    total = usage.get("total_tokens", 0) or 0
+    return {
+        "input_tokens": prompt,
+        "output_tokens": completion,
+        "total_tokens": total,
+        **normalize_usage(
+            "openai",
+            model,
+            "batch",
+            input_uncached=prompt,
+            output=completion,
+        ),
+    }
+
+
+def _anthropic_usage(usage, *, model: str, endpoint: str) -> dict:
     """Normalize an Anthropic usage object into the shared usage dict.
 
-    Shared by the streamed and non-streamed paths so both report identically.
+    Shared by the sync, streamed, and batch paths so all report identically.
+    Anthropic's input_tokens already excludes the cache buckets (the three are
+    disjoint), so it maps straight to input_uncached -- the cache buckets must
+    never be re-added at the base input rate.
     """
     input_tokens = usage.input_tokens or 0
     output_tokens = usage.output_tokens or 0
+    cache_write = getattr(usage, "cache_creation_input_tokens", 0) or 0
+    cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "total_tokens": input_tokens + output_tokens,
-        "cache_creation_input_tokens": getattr(usage, "cache_creation_input_tokens", 0)
-        or 0,
-        "cache_read_input_tokens": getattr(usage, "cache_read_input_tokens", 0) or 0,
+        "cache_creation_input_tokens": cache_write,
+        "cache_read_input_tokens": cache_read,
+        **normalize_usage(
+            "anthropic",
+            model,
+            endpoint,
+            input_uncached=input_tokens,
+            cache_read=cache_read,
+            cache_write=cache_write,
+            output=output_tokens,
+        ),
+    }
+
+
+def _zero_usage(provider: str, model: str, endpoint: str) -> dict:
+    """Zeroed usage row for failed calls -- keeps the canonical keys present."""
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        **normalize_usage(provider, model, endpoint),
     }
 
 
@@ -1285,7 +1459,7 @@ def run_sync_entries(
             raw_entries[key] = {
                 "text": "",
                 "error": str(e),
-                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "usage": _zero_usage(client.provider, client.model, "sync"),
             }
     return raw_entries
 
@@ -1507,21 +1681,17 @@ def _run_batch_gemini(
                     parts = candidates[0].get("content", {}).get("parts", [])
                     if parts:
                         text = parts[0].get("text", "")
-                usage = response.get("usageMetadata", {})
+                usage_meta = response.get("usageMetadata", {})
                 raw_entries[key] = {
                     "text": text,
-                    "usage": {
-                        "input_tokens": usage.get("promptTokenCount", 0),
-                        "output_tokens": usage.get("candidatesTokenCount", 0),
-                        "total_tokens": usage.get("totalTokenCount", 0),
-                    },
+                    "usage": _gemini_batch_usage(usage_meta, model=client.model),
                 }
             else:
                 error = result.get("error")
                 raw_entries[key] = {
                     "text": "",
                     "error": str(error) if error else "No response",
-                    "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    "usage": _zero_usage("gemini", client.model, "batch"),
                 }
         return raw_entries
     finally:
@@ -1666,7 +1836,7 @@ def _run_batch_openai(
                 raw_entries[key] = {
                     "text": "",
                     "error": str(error),
-                    "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    "usage": _zero_usage("openai", client.model, "batch"),
                 }
                 continue
 
@@ -1679,11 +1849,7 @@ def _run_batch_openai(
             usage = response_body.get("usage", {})
             raw_entries[key] = {
                 "text": text,
-                "usage": {
-                    "input_tokens": usage.get("prompt_tokens", 0),
-                    "output_tokens": usage.get("completion_tokens", 0),
-                    "total_tokens": usage.get("total_tokens", 0),
-                },
+                "usage": _openai_batch_usage(usage, model=client.model),
             }
         return raw_entries
     finally:
@@ -1878,12 +2044,9 @@ def _run_batch_anthropic(
             text = _extract_anthropic_text(message.content)
             if json_mode:
                 text = _strip_json_fences(text)
-            usage = {
-                "input_tokens": message.usage.input_tokens or 0,
-                "output_tokens": message.usage.output_tokens or 0,
-                "total_tokens": (message.usage.input_tokens or 0)
-                + (message.usage.output_tokens or 0),
-            }
+            usage = _anthropic_usage(
+                message.usage, model=client.model, endpoint="batch"
+            )
             raw_entries[key] = {"text": text, "usage": usage}
         else:
             error_msg = f"{result.result.type}"
@@ -1892,7 +2055,7 @@ def _run_batch_anthropic(
             raw_entries[key] = {
                 "text": "",
                 "error": error_msg,
-                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "usage": _zero_usage("anthropic", client.model, "batch"),
             }
 
     return raw_entries

--- a/src/tutormoments/client.py
+++ b/src/tutormoments/client.py
@@ -28,30 +28,6 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["ModelClient", "ModelResponse", "infer_provider"]
 
-VISION_CAPABLE_PREFIXES = (
-    "claude-opus-4",
-    "claude-sonnet-4",
-    "claude-sonnet-5",
-    "claude-fable-5",
-    "gemini-2",
-    "gemini-3",
-    "gpt-4o",
-    "gpt-4.1",
-    "gpt-5",
-    "o4",
-)
-
-
-def validate_vision_support(model: str) -> None:
-    """Raise ValueError if the model is not known to support vision input."""
-    m = model.lower()
-    if not any(m.startswith(p) for p in VISION_CAPABLE_PREFIXES):
-        raise ValueError(
-            f"Model '{model}' is not in the vision-capable list. "
-            f"Vision-capable prefixes: {', '.join(VISION_CAPABLE_PREFIXES)}."
-        )
-
-
 
 @dataclass
 class ModelResponse:

--- a/src/tutormoments/config.py
+++ b/src/tutormoments/config.py
@@ -1,16 +1,20 @@
 """Config loading and tutor/student registries for tutormoments.
 
 The config boundary normalizes model-bearing blocks once, at load time, into
-frozen spec objects. ``benchmark_models:`` is the preferred tutor roster: each
-key is an auditable benchmark arm, ``model`` names the provider model id,
-provider-native thinking knobs state the exact request parameters, and
-``condition`` gives the result grouping label. The older ``models:`` ladder
-roster is still accepted for compatibility.
+frozen spec objects. ``benchmark_models:`` is the tutor roster: each key is an
+auditable benchmark arm, ``model`` names the provider model id, provider-
+native thinking knobs state the exact request parameters, and ``condition``
+gives the result grouping label. The student/scorer/taxonomy/groundtruth role
+blocks state their thinking parameters the same provider-native way -- every
+configured condition is readable in provider parlance without consulting a
+mapping.
 
-The student/scorer/taxonomy/groundtruth blocks still use the canonical
-``thinking`` ladder because they are benchmark infrastructure rather than the
-tutor conditions being reported. Downstream code consumes the frozen specs; it
-does not re-read raw YAML values.
+Every stated thinking config is validated through
+tutormoments.models.resolve_thinking HERE, so a malformed or provider-
+mismatched setting fails at config load -- before any tokens are spent -- for
+every block, not just the ones a particular run touches. Downstream code
+consumes the frozen specs; nothing re-reads or re-interprets the raw YAML
+values, so validation-time and request-time semantics cannot diverge.
 """
 
 import os
@@ -21,10 +25,9 @@ from typing import Optional
 import yaml
 
 from tutormoments.models import (
+    NATIVE_THINKING_KEYS,
     ThinkingConfigError,
-    ThinkingLevel,
     infer_provider,
-    resolve_native_thinking,
     resolve_thinking,
 )
 from tutormoments.resources import resource_text
@@ -36,21 +39,7 @@ _STUDENT_REGISTRY: dict[str, callable] = {}
 _CONFIG_ENV_VAR = "TUTORMOMENTS_CONFIG"
 _DEFAULT_CONFIG_RESOURCE = "default_config.yaml"
 
-# The retired per-provider knobs. Their meaning moved into the model registry
-# (src/tutormoments/models.yaml); config states a ladder level instead.
-_RAW_KNOB_KEYS = ("thinking_budget", "reasoning_effort", "effort")
 _COMMON_ARM_KEYS = {"model", "condition"}
-_NATIVE_ARM_KEYS = {
-    "anthropic": {"thinking", "effort"},
-    "gemini": {"thinking_budget", "thinking_level", "include_thoughts"},
-    "openai": {"reasoning"},
-    "together": set(),
-}
-_MIGRATION_HINT = (
-    "the raw provider knobs were replaced by the thinking ladder "
-    "(none/low/high/xhigh/dynamic); see README "
-    '"Configuring thinking".'
-)
 
 
 # ---------------------------------------------------------------------------
@@ -65,9 +54,8 @@ class ArmSpec:
     name: str
     model: str
     provider: str
-    # Exact provider-native thinking config for benchmark_models entries, or a
-    # legacy ThinkingLevel for models entries.
-    thinking: "dict | ThinkingLevel"
+    # Exact provider-native thinking config (the keys the config stated).
+    thinking: dict
     condition: str = ""
 
 
@@ -75,26 +63,28 @@ class ArmSpec:
 class StudentSpec:
     model: str
     mode: str
-    thinking: ThinkingLevel
+    # Provider-native thinking config; None for registered (scripted)
+    # students, which are code callables with no API wire form.
+    thinking: dict | None
 
 
 @dataclass(frozen=True)
 class ScorerSpec:
     model: str
-    thinking: ThinkingLevel
+    thinking: dict
 
 
 @dataclass(frozen=True)
 class TaxonomySpec:
     model: str
-    thinking: ThinkingLevel
+    thinking: dict
     batch_size: int
 
 
 @dataclass(frozen=True)
 class GroundtruthSpec:
     model: str
-    thinking: ThinkingLevel
+    thinking: dict
     poll_interval: int
     # Labeller template routing: {annotation_type: prompt_name} or a single
     # prompt name for all types. Routing data, not LM configuration.
@@ -129,9 +119,8 @@ def load_config(path: str | os.PathLike | None = None) -> dict:
     """Load, validate, and parse a Tutormoments config file, with caching.
 
     Model-bearing blocks are normalized and validated on first load (see
-    module docstring): a config with malformed provider-native arm params, an
-    unsatisfiable role thinking condition, a retired role raw knob, or a
-    missing required role `thinking:` raises here.
+    module docstring): a config with malformed or provider-mismatched
+    thinking parameters in any arm or role block raises here.
 
     Args:
         path: Optional explicit config path. If omitted, precedence is
@@ -178,69 +167,50 @@ def _reset_config_cache() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _reject_raw_knobs(block_name: str, entry: dict) -> None:
-    for knob in _RAW_KNOB_KEYS:
-        if knob in entry:
-            suggestion = _suggest_ladder(entry)
-            hint = (
-                f" (this entry maps to `thinking: {suggestion}`)" if suggestion else ""
-            )
-            raise ThinkingConfigError(
-                f"config {block_name}: `{knob}` is no longer a config key -- "
-                f"{_MIGRATION_HINT}{hint}"
-            )
-
-
-def _suggest_ladder(entry: dict) -> str | None:
-    """Best-effort migration suggestion for a raw-knob entry."""
-    thinking = entry.get("thinking")
-    if thinking is False:
-        return "none"
-    effort = entry.get("effort") or entry.get("reasoning_effort")
-    if isinstance(effort, str) and effort:
-        return effort
-    if entry.get("thinking_budget") == -1:
-        return "dynamic"
-    if thinking is True or thinking == "adaptive":
-        return "dynamic"
-    return None
-
-
-def _require_thinking(block_name: str, entry: dict) -> ThinkingLevel:
-    """Coerce the block's required `thinking:` value to a ladder level."""
-    if "thinking" not in entry:
-        raise ThinkingConfigError(
-            f"config {block_name}: `thinking` is required -- every benchmarked "
-            f"condition must be stated explicitly "
-            f"(none/low/high/xhigh/dynamic)."
-        )
+def _block_provider(block_name: str, model: str) -> str:
     try:
-        level = ThinkingLevel.coerce(entry["thinking"])
-    except ThinkingConfigError as e:
+        return infer_provider(model)
+    except ValueError as e:
         raise ThinkingConfigError(f"config {block_name}: {e}") from None
-    return level
 
 
-def _check_keys(block_name: str, entry: dict, allowed: set[str]) -> None:
-    _reject_raw_knobs(block_name, entry)
+def _native_thinking(
+    block_name: str, model: str, entry: dict, extra_keys: set[str]
+) -> dict:
+    """Extract and validate the entry's provider-native thinking keys.
+
+    Every model-bearing block states its thinking parameters in the provider's
+    own parlance; the set of legal keys therefore depends on the model's
+    provider. Unknown keys and malformed or provider-mismatched settings fail
+    here, at config load.
+    """
+    provider = _block_provider(block_name, model)
+    allowed = extra_keys | NATIVE_THINKING_KEYS[provider]
     unknown = set(entry) - allowed
     if unknown:
         raise ThinkingConfigError(
-            f"config {block_name}: unknown key(s) {sorted(unknown)}. "
-            f"Allowed: {sorted(allowed)}."
+            f"config {block_name}: unknown key(s) {sorted(unknown)} for "
+            f"provider {provider}. Allowed: {sorted(allowed)}."
         )
-
-
-def _validate_wire(block_name: str, model: str, level: ThinkingLevel) -> None:
-    """Fail fast if the stated condition cannot be honored on this model."""
+    thinking = {k: entry[k] for k in NATIVE_THINKING_KEYS[provider] if k in entry}
     try:
-        resolve_thinking(model, level)
+        resolve_thinking(model, thinking)
     except ThinkingConfigError as e:
         raise ThinkingConfigError(f"config {block_name}: {e}") from None
+    return thinking
 
 
-def _condition(block_name: str, entry: dict, fallback=None) -> str:
-    condition = entry.get("condition", fallback)
+def _require_model(block_name: str, entry: dict, default: str | None = None) -> str:
+    model = entry.get("model", default)
+    if not isinstance(model, str) or not model:
+        raise ThinkingConfigError(
+            f"config {block_name}: `model` must be a non-empty string."
+        )
+    return model
+
+
+def _condition(block_name: str, entry: dict) -> str:
+    condition = entry.get("condition")
     if not isinstance(condition, str) or not condition:
         raise ThinkingConfigError(
             f"config {block_name}: `condition` must be a non-empty string."
@@ -248,50 +218,20 @@ def _condition(block_name: str, entry: dict, fallback=None) -> str:
     return condition
 
 
-def _normalize_native_arm(name: str, entry) -> ArmSpec:
+def _normalize_arm(name: str, entry) -> ArmSpec:
     block = f"benchmark_models.{name}"
     if entry is None:
         entry = {}
     if not isinstance(entry, dict):
         raise ThinkingConfigError(f"config {block}: expected a mapping")
-    model = entry.get("model", name)
-    if not isinstance(model, str) or not model:
-        raise ThinkingConfigError(f"config {block}: `model` must be a non-empty string.")
-    provider = infer_provider(model)
-    allowed = _COMMON_ARM_KEYS | _NATIVE_ARM_KEYS[provider]
-    unknown = set(entry) - allowed
-    if unknown:
-        raise ThinkingConfigError(
-            f"config {block}: unknown key(s) {sorted(unknown)} for provider "
-            f"{provider}. Allowed: {sorted(allowed)}."
-        )
-    thinking = {k: entry[k] for k in _NATIVE_ARM_KEYS[provider] if k in entry}
-    resolve_native_thinking(model, thinking)
-    return ArmSpec(
-        name=name,
-        model=model,
-        provider=provider,
-        condition=_condition(block, entry),
-        thinking=thinking,
-    )
-
-
-def _normalize_legacy_arm(name: str, entry) -> ArmSpec:
-    block = f"models.{name}"
-    if entry is None:
-        entry = {}
-    if not isinstance(entry, dict):
-        raise ThinkingConfigError(f"config {block}: expected a mapping")
-    _check_keys(block, entry, {"model", "thinking", "condition"})
-    model = entry.get("model", name)
-    level = _require_thinking(block, entry)
-    _validate_wire(block, model, level)
+    model = _require_model(block, entry, default=name)
+    thinking = _native_thinking(block, model, entry, _COMMON_ARM_KEYS)
     return ArmSpec(
         name=name,
         model=model,
         provider=infer_provider(model),
-        condition=_condition(block, entry, level.value),
-        thinking=level,
+        condition=_condition(block, entry),
+        thinking=thinking,
     )
 
 
@@ -299,58 +239,65 @@ def _normalize_config(raw: dict) -> dict:
     """Build the frozen spec bundle from a parsed config dict."""
     bundle: dict = {"arms": {}}
 
-    arm_roster = raw.get("benchmark_models")
-    if arm_roster is None:
-        arm_roster = raw.get("models") or {}
-        for name, entry in arm_roster.items():
-            bundle["arms"][name] = _normalize_legacy_arm(name, entry)
-    else:
-        for name, entry in arm_roster.items():
-            bundle["arms"][name] = _normalize_native_arm(name, entry)
+    if "models" in raw:
+        raise ThinkingConfigError(
+            "config: the `models:` roster was replaced by `benchmark_models:` "
+            "(each arm states provider-native thinking parameters plus a "
+            '`condition` label); see README "Running new tutor models".'
+        )
+
+    for name, entry in (raw.get("benchmark_models") or {}).items():
+        bundle["arms"][name] = _normalize_arm(name, entry)
 
     student = raw.get("student")
     if student is not None:
-        _check_keys("student", student, {"model", "mode", "thinking"})
-        level = _require_thinking("student", student)
-        model = student["model"]
+        model = _require_model("student", student)
         # A registered (scripted) student is a code callable, not an API
-        # model; its thinking level is stated but has no wire form to check.
-        if get_registered_student(model) is None:
-            _validate_wire("student", model, level)
+        # model; it has no provider wire form and takes no thinking keys.
+        if get_registered_student(model) is not None:
+            unknown = set(student) - {"model", "mode"}
+            if unknown:
+                raise ThinkingConfigError(
+                    f"config student: registered student '{model}' takes no "
+                    f"thinking keys; unknown key(s) {sorted(unknown)}."
+                )
+            thinking = None
+        else:
+            thinking = _native_thinking("student", model, student, {"model", "mode"})
         bundle["student"] = StudentSpec(
-            model=model, mode=student.get("mode", ""), thinking=level
+            model=model, mode=student.get("mode", ""), thinking=thinking
         )
 
     scorer = raw.get("scorer")
     if scorer is not None:
-        _check_keys("scorer", scorer, {"model", "thinking"})
-        level = _require_thinking("scorer", scorer)
-        _validate_wire("scorer", scorer["model"], level)
-        bundle["scorer"] = ScorerSpec(model=scorer["model"], thinking=level)
+        model = _require_model("scorer", scorer)
+        bundle["scorer"] = ScorerSpec(
+            model=model,
+            thinking=_native_thinking("scorer", model, scorer, {"model"}),
+        )
 
     taxonomy = raw.get("taxonomy")
     if taxonomy is not None:
-        _check_keys("taxonomy", taxonomy, {"model", "thinking", "batch_size"})
-        level = _require_thinking("taxonomy", taxonomy)
-        _validate_wire("taxonomy", taxonomy["model"], level)
+        model = _require_model("taxonomy", taxonomy)
         bundle["taxonomy"] = TaxonomySpec(
-            model=taxonomy["model"],
-            thinking=level,
+            model=model,
+            thinking=_native_thinking(
+                "taxonomy", model, taxonomy, {"model", "batch_size"}
+            ),
             batch_size=taxonomy.get("batch_size", 50),
         )
 
     groundtruth = raw.get("groundtruth")
     if groundtruth is not None:
-        _check_keys(
-            "groundtruth",
-            groundtruth,
-            {"model", "thinking", "poll_interval", "labeller"},
-        )
-        level = _require_thinking("groundtruth", groundtruth)
-        _validate_wire("groundtruth", groundtruth["model"], level)
+        model = _require_model("groundtruth", groundtruth)
         bundle["groundtruth"] = GroundtruthSpec(
-            model=groundtruth["model"],
-            thinking=level,
+            model=model,
+            thinking=_native_thinking(
+                "groundtruth",
+                model,
+                groundtruth,
+                {"model", "poll_interval", "labeller"},
+            ),
             poll_interval=groundtruth.get("poll_interval", 60),
             labeller=groundtruth.get("labeller"),
         )
@@ -442,7 +389,7 @@ def resolve_arm(arm_name: str, config_path: str | os.PathLike | None = None) -> 
     """Resolve an arm name to its normalized spec.
 
     Args:
-        arm_name: Arm identifier (a key of the config models roster).
+        arm_name: Arm identifier (a key of the config benchmark_models roster).
 
     Returns:
         The frozen ArmSpec (name, model, provider, thinking).

--- a/src/tutormoments/config.py
+++ b/src/tutormoments/config.py
@@ -1,4 +1,26 @@
-"""Config loading and tutor/student registries for tutormoments."""
+"""Config loading and tutor/student registries for tutormoments.
+
+The config boundary normalizes every model-bearing block exactly once, at
+load time, into frozen spec objects:
+
+- the `models:` roster is a map of ARMS -- benchmark conditions. The key is
+  the arm name; `model:` (defaulting to the key) names the provider model id;
+  `thinking:` (required) states the arm's reasoning condition as a canonical
+  ladder level. The same model may appear under several arms.
+- the student/scorer/taxonomy/groundtruth blocks each name a model and its
+  required `thinking:` level.
+
+Every stated level is translated through the model registry
+(tutormoments.models.resolve_thinking) HERE, so an unsatisfiable or
+unregistered condition fails at config load -- before any tokens are spent --
+for every block, not just the ones a particular run touches. The retired raw
+knobs (boolean `thinking`, `thinking_budget`, `reasoning_effort`, `effort`)
+are rejected with a migration hint.
+
+Downstream code consumes the frozen specs; nothing re-reads or re-interprets
+the raw YAML values, so validation-time and request-time semantics cannot
+diverge.
+"""
 
 import os
 from dataclasses import dataclass
@@ -7,14 +29,74 @@ from typing import Optional
 
 import yaml
 
-from tutormoments.client import infer_provider
+from tutormoments.models import (
+    ThinkingConfigError,
+    ThinkingLevel,
+    infer_provider,
+    resolve_thinking,
+)
 from tutormoments.resources import resource_text
 
 _CONFIG_CACHE = {}
+_NORMALIZED_CACHE = {}
 _TUTOR_REGISTRY: dict[str, callable] = {}
 _STUDENT_REGISTRY: dict[str, callable] = {}
 _CONFIG_ENV_VAR = "TUTORMOMENTS_CONFIG"
 _DEFAULT_CONFIG_RESOURCE = "default_config.yaml"
+
+# The retired per-provider knobs. Their meaning moved into the model registry
+# (src/tutormoments/models.yaml); config states a ladder level instead.
+_RAW_KNOB_KEYS = ("thinking_budget", "reasoning_effort", "effort")
+_MIGRATION_HINT = (
+    "the raw provider knobs were replaced by the thinking ladder "
+    "(none/minimal/low/medium/high/xhigh/max/dynamic); see README "
+    '"Configuring thinking".'
+)
+
+
+# ---------------------------------------------------------------------------
+# Normalized spec objects (frozen: shared safely from the config cache).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArmSpec:
+    """One benchmark arm: a model under a stated reasoning condition."""
+
+    name: str
+    model: str
+    provider: str
+    thinking: ThinkingLevel
+
+
+@dataclass(frozen=True)
+class StudentSpec:
+    model: str
+    mode: str
+    thinking: ThinkingLevel
+
+
+@dataclass(frozen=True)
+class ScorerSpec:
+    model: str
+    thinking: ThinkingLevel
+
+
+@dataclass(frozen=True)
+class TaxonomySpec:
+    model: str
+    thinking: ThinkingLevel
+    batch_size: int
+
+
+@dataclass(frozen=True)
+class GroundtruthSpec:
+    model: str
+    thinking: ThinkingLevel
+    poll_interval: int
+    # Labeller template routing: {annotation_type: prompt_name} or a single
+    # prompt name for all types. Routing data, not LM configuration.
+    labeller: "dict | str | None"
 
 
 def _config_source(path: str | os.PathLike | None = None) -> tuple[str, str]:
@@ -42,14 +124,19 @@ def describe_config_source(path: str | os.PathLike | None = None) -> str:
 
 
 def load_config(path: str | os.PathLike | None = None) -> dict:
-    """Load and parse a Tutormoments config file, with module-level caching.
+    """Load, validate, and parse a Tutormoments config file, with caching.
+
+    Model-bearing blocks are normalized and validated on first load (see
+    module docstring): a config with an unsatisfiable thinking condition, a
+    retired raw knob, or a missing required `thinking:` raises here.
 
     Args:
         path: Optional explicit config path. If omitted, precedence is
             TUTORMOMENTS_CONFIG, cwd/config.yaml, then packaged default_config.yaml.
 
     Returns:
-        Parsed dict from yaml.safe_load().
+        Parsed dict from yaml.safe_load() (the raw config; model-bearing
+        blocks are additionally available as frozen specs via the accessors).
     """
     source = _config_source(path)
     if source not in _CONFIG_CACHE:
@@ -63,13 +150,162 @@ def load_config(path: str | os.PathLike | None = None) -> dict:
                     f"Tutormoments config file not found: {file_path}"
                 )
             content = file_path.read_text(encoding="utf-8")
-        _CONFIG_CACHE[source] = yaml.safe_load(content)
+        raw = yaml.safe_load(content)
+        # Normalize BEFORE caching: a config that fails validation must not
+        # poison the cache as if it had loaded.
+        _NORMALIZED_CACHE[source] = _normalize_config(raw)
+        _CONFIG_CACHE[source] = raw
     return _CONFIG_CACHE[source]
+
+
+def _normalized(path: str | os.PathLike | None = None) -> dict:
+    """Return the normalized spec bundle for the active config."""
+    load_config(path)
+    return _NORMALIZED_CACHE[_config_source(path)]
 
 
 def _reset_config_cache() -> None:
     """Clear the config cache (for testing)."""
     _CONFIG_CACHE.clear()
+    _NORMALIZED_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Normalization: raw YAML -> frozen specs, exactly once.
+# ---------------------------------------------------------------------------
+
+
+def _reject_raw_knobs(block_name: str, entry: dict) -> None:
+    for knob in _RAW_KNOB_KEYS:
+        if knob in entry:
+            suggestion = _suggest_ladder(entry)
+            hint = (
+                f" (this entry maps to `thinking: {suggestion}`)" if suggestion else ""
+            )
+            raise ThinkingConfigError(
+                f"config {block_name}: `{knob}` is no longer a config key -- "
+                f"{_MIGRATION_HINT}{hint}"
+            )
+
+
+def _suggest_ladder(entry: dict) -> str | None:
+    """Best-effort migration suggestion for a raw-knob entry."""
+    thinking = entry.get("thinking")
+    if thinking is False:
+        return "none"
+    effort = entry.get("effort") or entry.get("reasoning_effort")
+    if isinstance(effort, str) and effort:
+        return effort
+    if entry.get("thinking_budget") == -1:
+        return "dynamic"
+    if thinking is True or thinking == "adaptive":
+        return "dynamic"
+    return None
+
+
+def _require_thinking(block_name: str, entry: dict) -> ThinkingLevel:
+    """Coerce the block's required `thinking:` value to a ladder level."""
+    if "thinking" not in entry:
+        raise ThinkingConfigError(
+            f"config {block_name}: `thinking` is required -- every benchmarked "
+            f"condition must be stated explicitly "
+            f"(none/minimal/low/medium/high/xhigh/max/dynamic)."
+        )
+    try:
+        level = ThinkingLevel.coerce(entry["thinking"])
+    except ThinkingConfigError as e:
+        raise ThinkingConfigError(f"config {block_name}: {e}") from None
+    return level
+
+
+def _check_keys(block_name: str, entry: dict, allowed: set[str]) -> None:
+    _reject_raw_knobs(block_name, entry)
+    unknown = set(entry) - allowed
+    if unknown:
+        raise ThinkingConfigError(
+            f"config {block_name}: unknown key(s) {sorted(unknown)}. "
+            f"Allowed: {sorted(allowed)}."
+        )
+
+
+def _validate_wire(block_name: str, model: str, level: ThinkingLevel) -> None:
+    """Fail fast if the stated condition cannot be honored on this model."""
+    try:
+        resolve_thinking(model, level)
+    except ThinkingConfigError as e:
+        raise ThinkingConfigError(f"config {block_name}: {e}") from None
+
+
+def _normalize_arm(name: str, entry) -> ArmSpec:
+    block = f"models.{name}"
+    if entry is None:
+        entry = {}
+    if not isinstance(entry, dict):
+        raise ThinkingConfigError(f"config {block}: expected a mapping")
+    _check_keys(block, entry, {"model", "thinking"})
+    model = entry.get("model", name)
+    level = _require_thinking(block, entry)
+    _validate_wire(block, model, level)
+    return ArmSpec(
+        name=name, model=model, provider=infer_provider(model), thinking=level
+    )
+
+
+def _normalize_config(raw: dict) -> dict:
+    """Build the frozen spec bundle from a parsed config dict."""
+    bundle: dict = {"arms": {}}
+
+    for name, entry in (raw.get("models") or {}).items():
+        bundle["arms"][name] = _normalize_arm(name, entry)
+
+    student = raw.get("student")
+    if student is not None:
+        _check_keys("student", student, {"model", "mode", "thinking"})
+        level = _require_thinking("student", student)
+        model = student["model"]
+        # A registered (scripted) student is a code callable, not an API
+        # model; its thinking level is stated but has no wire form to check.
+        if get_registered_student(model) is None:
+            _validate_wire("student", model, level)
+        bundle["student"] = StudentSpec(
+            model=model, mode=student.get("mode", ""), thinking=level
+        )
+
+    scorer = raw.get("scorer")
+    if scorer is not None:
+        _check_keys("scorer", scorer, {"model", "thinking"})
+        level = _require_thinking("scorer", scorer)
+        _validate_wire("scorer", scorer["model"], level)
+        bundle["scorer"] = ScorerSpec(model=scorer["model"], thinking=level)
+
+    taxonomy = raw.get("taxonomy")
+    if taxonomy is not None:
+        _check_keys("taxonomy", taxonomy, {"model", "thinking", "batch_size"})
+        level = _require_thinking("taxonomy", taxonomy)
+        _validate_wire("taxonomy", taxonomy["model"], level)
+        bundle["taxonomy"] = TaxonomySpec(
+            model=taxonomy["model"],
+            thinking=level,
+            batch_size=taxonomy.get("batch_size", 50),
+        )
+
+    groundtruth = raw.get("groundtruth")
+    if groundtruth is not None:
+        _check_keys(
+            "groundtruth",
+            groundtruth,
+            {"model", "thinking", "poll_interval", "labeller"},
+        )
+        level = _require_thinking("groundtruth", groundtruth)
+        _validate_wire("groundtruth", groundtruth["model"], level)
+        bundle["groundtruth"] = GroundtruthSpec(
+            model=groundtruth["model"],
+            thinking=level,
+            poll_interval=groundtruth.get("poll_interval", 60),
+            labeller=groundtruth.get("labeller"),
+        )
+
+    return bundle
 
 
 def register_tutor(name: str):
@@ -152,66 +388,65 @@ def get_batch_timeout(config_path: str | os.PathLike | None = None) -> int:
     return load_config(config_path)["batch"]["timeout"]
 
 
-def resolve_model(model_id: str, config_path: str | os.PathLike | None = None) -> dict:
-    """Resolve a model ID to provider, env var, and kwargs.
+def resolve_arm(arm_name: str, config_path: str | os.PathLike | None = None) -> ArmSpec:
+    """Resolve an arm name to its normalized spec.
 
     Args:
-        model_id: Model identifier (must be in the config models roster).
+        arm_name: Arm identifier (a key of the config models roster).
 
     Returns:
-        Dict with keys: provider (str), env (str), kwargs (dict).
+        The frozen ArmSpec (name, model, provider, thinking).
 
     Raises:
-        ValueError: If model_id is not in the roster.
+        ValueError: If arm_name is not in the roster.
     """
-    cfg = load_config(config_path)
-    if model_id not in cfg["models"]:
-        valid_ids = list(cfg["models"].keys())
+    arms = _normalized(config_path)["arms"]
+    if arm_name not in arms:
         raise ValueError(
-            f"Model '{model_id}' not in roster. Valid models: {', '.join(valid_ids)}"
+            f"Arm '{arm_name}' not in roster. Valid arms: {', '.join(arms)}"
         )
-    provider = infer_provider(model_id)
-    env = cfg["providers"][provider]["env"]
-    kwargs = cfg["models"][model_id]
-    return {"provider": provider, "env": env, "kwargs": kwargs}
+    return arms[arm_name]
 
 
-def student_spec(config_path: str | os.PathLike | None = None) -> dict:
-    """Return the student spec block from config.
+def student_spec(config_path: str | os.PathLike | None = None) -> StudentSpec:
+    """Return the normalized student spec from config."""
+    bundle = _normalized(config_path)
+    if "student" not in bundle:
+        raise ValueError("config has no student block")
+    return bundle["student"]
 
-    Returns:
-        Dict with model, mode, thinking keys.
+
+def scorer_spec(config_path: str | os.PathLike | None = None) -> ScorerSpec:
+    """Return the normalized scorer spec from config."""
+    bundle = _normalized(config_path)
+    if "scorer" not in bundle:
+        raise ValueError("config has no scorer block")
+    return bundle["scorer"]
+
+
+def taxonomy_spec(config_path: str | os.PathLike | None = None) -> TaxonomySpec:
+    """Return the normalized taxonomy classifier spec from config.
+
+    Used by the action classifier that runs on every run and by
+    `tutormoments taxonomy`.
     """
-    return load_config(config_path)["student"]
+    bundle = _normalized(config_path)
+    if "taxonomy" not in bundle:
+        raise ValueError("config has no taxonomy block")
+    return bundle["taxonomy"]
 
 
-def scorer_spec(config_path: str | os.PathLike | None = None) -> dict:
-    """Return the scorer spec block from config.
+def get_groundtruth_phase_config(
+    config_path: str | os.PathLike | None = None,
+) -> GroundtruthSpec:
+    """Return the normalized ground-truth build phase spec.
 
-    Returns:
-        Dict with model and thinking keys.
+    Used by the dev-only `tutormoments dataset build-ground-truth` pipeline.
     """
-    return load_config(config_path)["scorer"]
-
-
-def taxonomy_spec(config_path: str | os.PathLike | None = None) -> dict:
-    """Return the taxonomy classifier spec block from config.
-
-    Returns:
-        Dict with model, thinking, and batch_size keys. Used by the action
-        classifier that runs on every run and by `tutormoments taxonomy`.
-    """
-    return load_config(config_path)["taxonomy"]
-
-
-def get_groundtruth_phase_config(config_path: str | os.PathLike | None = None) -> dict:
-    """Return the ground-truth build phase config block.
-
-    Reads from config: groundtruth -> {model, poll_interval, thinking,
-    thinking_budget, reasoning_effort, labeller}. Used by the dev-only
-    `tutormoments dataset build-ground-truth` pipeline.
-    """
-    return load_config(config_path)["groundtruth"]
+    bundle = _normalized(config_path)
+    if "groundtruth" not in bundle:
+        raise ValueError("config has no groundtruth block")
+    return bundle["groundtruth"]
 
 
 def get_labeller_config(config_path: str | os.PathLike | None = None):
@@ -220,7 +455,7 @@ def get_labeller_config(config_path: str | os.PathLike | None = None):
     A dict ({annotation_type: prompt_name}) routes per type; a string loads a
     single template for all types. Reads from config: groundtruth -> labeller.
     """
-    return load_config(config_path)["groundtruth"]["labeller"]
+    return get_groundtruth_phase_config(config_path).labeller
 
 
 @dataclass
@@ -228,7 +463,7 @@ class RunConfig:
     """Configuration for a tutormoments run.
 
     Attributes:
-        tutors: List of tutor model IDs to run.
+        tutors: List of tutor arm names (or registered tutor names) to run.
         modes: List of evaluation modes (e.g., ["plain", "scaffolding_rigor"]).
         dataset: Hugging Face dataset id holding the released benchmark
             (None when running from a local release dir).
@@ -242,9 +477,10 @@ class RunConfig:
         max_turns: Maximum turns per conversation.
         replay_concurrency: Number of per-moment replays to run concurrently
             within a cell. Result-preserving (only overlaps network round-trips).
-        student: Student spec dict (model, mode, thinking).
-        scorer: Scorer spec dict (model, thinking).
-        resolved_tutors: Dict[model_id -> kwargs dict] for resolved tutors.
+        student: Normalized StudentSpec.
+        scorer: Normalized ScorerSpec.
+        resolved_tutors: Dict[arm name -> ArmSpec] for roster arms; a
+            registered tutor maps to None (it has no model spec).
         config_source: Where the config was loaded from.
     """
 
@@ -258,9 +494,9 @@ class RunConfig:
     trials: int
     max_turns: int
     replay_concurrency: int
-    student: dict
-    scorer: dict
-    resolved_tutors: dict[str, dict]
+    student: StudentSpec
+    scorer: ScorerSpec
+    resolved_tutors: dict[str, ArmSpec | None]
     config_source: str
 
 
@@ -281,7 +517,7 @@ def build_run_config(
     """Build a RunConfig from CLI arguments and config defaults.
 
     Args:
-        tutors: List of tutor model IDs (required).
+        tutors: List of tutor arm names (required).
         modes: Evaluation modes. Default: ["plain", "scaffolding_rigor"].
         dataset: Hugging Face dataset id. Default: config `dataset.id`.
         data_path: Local release dir with moments.jsonl (wins over dataset).
@@ -300,7 +536,7 @@ def build_run_config(
         RunConfig with all fields filled.
 
     Raises:
-        ValueError: If any tutor model_id is not in the roster.
+        ValueError: If any tutor arm name is not in the roster.
     """
     cfg = load_config(config_path)
     d = cfg["defaults"]
@@ -323,20 +559,14 @@ def build_run_config(
         # Fall back to 4 if the execution block is absent (older configs).
         replay_concurrency = (cfg.get("execution") or {}).get("replay_concurrency", 4)
 
-    # Resolve tutors (check registry first, then roster)
-    resolved_tutors = {}
+    # Resolve tutors (check registry first, then roster). All thinking
+    # validation already happened at load_config time.
+    resolved_tutors: dict[str, ArmSpec | None] = {}
     for tutor_id in tutors:
         if get_registered_tutor(tutor_id) is not None:
-            # Registered tutor: no kwargs needed
-            resolved_tutors[tutor_id] = {}
+            resolved_tutors[tutor_id] = None
         else:
-            # Resolve via roster
-            resolved = resolve_model(tutor_id, config_path=config_path)
-            resolved_tutors[tutor_id] = resolved["kwargs"]
-
-    # Get student and scorer specs
-    student = student_spec(config_path)
-    scorer = scorer_spec(config_path)
+            resolved_tutors[tutor_id] = resolve_arm(tutor_id, config_path=config_path)
 
     return RunConfig(
         tutors=tutors,
@@ -349,8 +579,8 @@ def build_run_config(
         trials=trials,
         max_turns=max_turns,
         replay_concurrency=replay_concurrency,
-        student=student,
-        scorer=scorer,
+        student=student_spec(config_path),
+        scorer=scorer_spec(config_path),
         resolved_tutors=resolved_tutors,
         config_source=describe_config_source(config_path),
     )

--- a/src/tutormoments/config.py
+++ b/src/tutormoments/config.py
@@ -49,7 +49,7 @@ _DEFAULT_CONFIG_RESOURCE = "default_config.yaml"
 _RAW_KNOB_KEYS = ("thinking_budget", "reasoning_effort", "effort")
 _MIGRATION_HINT = (
     "the raw provider knobs were replaced by the thinking ladder "
-    "(none/minimal/low/medium/high/xhigh/max/dynamic); see README "
+    "(none/low/high/xhigh/dynamic); see README "
     '"Configuring thinking".'
 )
 
@@ -209,7 +209,7 @@ def _require_thinking(block_name: str, entry: dict) -> ThinkingLevel:
         raise ThinkingConfigError(
             f"config {block_name}: `thinking` is required -- every benchmarked "
             f"condition must be stated explicitly "
-            f"(none/minimal/low/medium/high/xhigh/max/dynamic)."
+            f"(none/low/high/xhigh/dynamic)."
         )
     try:
         level = ThinkingLevel.coerce(entry["thinking"])

--- a/src/tutormoments/config.py
+++ b/src/tutormoments/config.py
@@ -1,25 +1,16 @@
 """Config loading and tutor/student registries for tutormoments.
 
-The config boundary normalizes every model-bearing block exactly once, at
-load time, into frozen spec objects:
+The config boundary normalizes model-bearing blocks once, at load time, into
+frozen spec objects. ``benchmark_models:`` is the preferred tutor roster: each
+key is an auditable benchmark arm, ``model`` names the provider model id,
+provider-native thinking knobs state the exact request parameters, and
+``condition`` gives the result grouping label. The older ``models:`` ladder
+roster is still accepted for compatibility.
 
-- the `models:` roster is a map of ARMS -- benchmark conditions. The key is
-  the arm name; `model:` (defaulting to the key) names the provider model id;
-  `thinking:` (required) states the arm's reasoning condition as a canonical
-  ladder level. The same model may appear under several arms.
-- the student/scorer/taxonomy/groundtruth blocks each name a model and its
-  required `thinking:` level.
-
-Every stated level is translated through the model registry
-(tutormoments.models.resolve_thinking) HERE, so an unsatisfiable or
-unregistered condition fails at config load -- before any tokens are spent --
-for every block, not just the ones a particular run touches. The retired raw
-knobs (boolean `thinking`, `thinking_budget`, `reasoning_effort`, `effort`)
-are rejected with a migration hint.
-
-Downstream code consumes the frozen specs; nothing re-reads or re-interprets
-the raw YAML values, so validation-time and request-time semantics cannot
-diverge.
+The student/scorer/taxonomy/groundtruth blocks still use the canonical
+``thinking`` ladder because they are benchmark infrastructure rather than the
+tutor conditions being reported. Downstream code consumes the frozen specs; it
+does not re-read raw YAML values.
 """
 
 import os
@@ -33,6 +24,7 @@ from tutormoments.models import (
     ThinkingConfigError,
     ThinkingLevel,
     infer_provider,
+    resolve_native_thinking,
     resolve_thinking,
 )
 from tutormoments.resources import resource_text
@@ -47,6 +39,13 @@ _DEFAULT_CONFIG_RESOURCE = "default_config.yaml"
 # The retired per-provider knobs. Their meaning moved into the model registry
 # (src/tutormoments/models.yaml); config states a ladder level instead.
 _RAW_KNOB_KEYS = ("thinking_budget", "reasoning_effort", "effort")
+_COMMON_ARM_KEYS = {"model", "condition"}
+_NATIVE_ARM_KEYS = {
+    "anthropic": {"thinking", "effort"},
+    "gemini": {"thinking_budget", "thinking_level", "include_thoughts"},
+    "openai": {"reasoning"},
+    "together": set(),
+}
 _MIGRATION_HINT = (
     "the raw provider knobs were replaced by the thinking ladder "
     "(none/low/high/xhigh/dynamic); see README "
@@ -66,7 +65,10 @@ class ArmSpec:
     name: str
     model: str
     provider: str
-    thinking: ThinkingLevel
+    # Exact provider-native thinking config for benchmark_models entries, or a
+    # legacy ThinkingLevel for models entries.
+    thinking: "dict | ThinkingLevel"
+    condition: str = ""
 
 
 @dataclass(frozen=True)
@@ -127,8 +129,9 @@ def load_config(path: str | os.PathLike | None = None) -> dict:
     """Load, validate, and parse a Tutormoments config file, with caching.
 
     Model-bearing blocks are normalized and validated on first load (see
-    module docstring): a config with an unsatisfiable thinking condition, a
-    retired raw knob, or a missing required `thinking:` raises here.
+    module docstring): a config with malformed provider-native arm params, an
+    unsatisfiable role thinking condition, a retired role raw knob, or a
+    missing required role `thinking:` raises here.
 
     Args:
         path: Optional explicit config path. If omitted, precedence is
@@ -236,18 +239,59 @@ def _validate_wire(block_name: str, model: str, level: ThinkingLevel) -> None:
         raise ThinkingConfigError(f"config {block_name}: {e}") from None
 
 
-def _normalize_arm(name: str, entry) -> ArmSpec:
+def _condition(block_name: str, entry: dict, fallback=None) -> str:
+    condition = entry.get("condition", fallback)
+    if not isinstance(condition, str) or not condition:
+        raise ThinkingConfigError(
+            f"config {block_name}: `condition` must be a non-empty string."
+        )
+    return condition
+
+
+def _normalize_native_arm(name: str, entry) -> ArmSpec:
+    block = f"benchmark_models.{name}"
+    if entry is None:
+        entry = {}
+    if not isinstance(entry, dict):
+        raise ThinkingConfigError(f"config {block}: expected a mapping")
+    model = entry.get("model", name)
+    if not isinstance(model, str) or not model:
+        raise ThinkingConfigError(f"config {block}: `model` must be a non-empty string.")
+    provider = infer_provider(model)
+    allowed = _COMMON_ARM_KEYS | _NATIVE_ARM_KEYS[provider]
+    unknown = set(entry) - allowed
+    if unknown:
+        raise ThinkingConfigError(
+            f"config {block}: unknown key(s) {sorted(unknown)} for provider "
+            f"{provider}. Allowed: {sorted(allowed)}."
+        )
+    thinking = {k: entry[k] for k in _NATIVE_ARM_KEYS[provider] if k in entry}
+    resolve_native_thinking(model, thinking)
+    return ArmSpec(
+        name=name,
+        model=model,
+        provider=provider,
+        condition=_condition(block, entry),
+        thinking=thinking,
+    )
+
+
+def _normalize_legacy_arm(name: str, entry) -> ArmSpec:
     block = f"models.{name}"
     if entry is None:
         entry = {}
     if not isinstance(entry, dict):
         raise ThinkingConfigError(f"config {block}: expected a mapping")
-    _check_keys(block, entry, {"model", "thinking"})
+    _check_keys(block, entry, {"model", "thinking", "condition"})
     model = entry.get("model", name)
     level = _require_thinking(block, entry)
     _validate_wire(block, model, level)
     return ArmSpec(
-        name=name, model=model, provider=infer_provider(model), thinking=level
+        name=name,
+        model=model,
+        provider=infer_provider(model),
+        condition=_condition(block, entry, level.value),
+        thinking=level,
     )
 
 
@@ -255,8 +299,14 @@ def _normalize_config(raw: dict) -> dict:
     """Build the frozen spec bundle from a parsed config dict."""
     bundle: dict = {"arms": {}}
 
-    for name, entry in (raw.get("models") or {}).items():
-        bundle["arms"][name] = _normalize_arm(name, entry)
+    arm_roster = raw.get("benchmark_models")
+    if arm_roster is None:
+        arm_roster = raw.get("models") or {}
+        for name, entry in arm_roster.items():
+            bundle["arms"][name] = _normalize_legacy_arm(name, entry)
+    else:
+        for name, entry in arm_roster.items():
+            bundle["arms"][name] = _normalize_native_arm(name, entry)
 
     student = raw.get("student")
     if student is not None:

--- a/src/tutormoments/default_config.yaml
+++ b/src/tutormoments/default_config.yaml
@@ -14,26 +14,23 @@ providers:
   together:  { env: TOGETHER_API_KEY }
 
 # Tutor roster: each key is an ARM -- a benchmark condition. `model` names the
-# provider model id (default: the key itself, so an arm that just runs a model
-# under one condition needs no model field). `thinking` is REQUIRED and states
-# the arm's reasoning condition on the canonical ladder
-# (none/low/high/xhigh/dynamic); the model registry
-# (models.yaml) translates it to the provider's wire knob and rejects
-# conditions the model cannot honor. The same model may appear under several
-# arms, e.g.:
-#   gpt-5.5-no-thinking: { model: gpt-5.5-2026-04-23, thinking: none }
-models:
-  claude-opus-4-8:             { thinking: xhigh }
-  claude-sonnet-4-6:           { thinking: high }
-  # Sonnet 5: first Sonnet model with an xhigh effort option
-  claude-sonnet-5:             { thinking: xhigh }
-  # Gemini and DeepSeek arms run model-paced thinking (dynamic): Gemini sends
+# provider model id, provider-native keys state the exact request parameters,
+# and `condition` is the grouping label written into run outputs. The same
+# model may appear under several arms with different parameters, e.g.:
+#   gemini-2.5-low: { model: gemini-2.5-pro, thinking_budget: 4096, condition: low }
+#   gpt-5.5-low:   { model: gpt-5.5-2026-04-23, reasoning: low, condition: low }
+benchmark_models:
+  claude-opus-4-8:         { model: claude-opus-4-8, thinking: { type: adaptive }, effort: xhigh, condition: xhigh }
+  claude-sonnet-4-6:       { model: claude-sonnet-4-6, thinking: { type: adaptive }, effort: high, condition: high }
+  # Sonnet 5: first Sonnet model with an xhigh effort option.
+  claude-sonnet-5:         { model: claude-sonnet-5, thinking: { type: adaptive }, effort: xhigh, condition: xhigh }
+  # Gemini and DeepSeek arms run model-paced thinking: Gemini sends
   # thinking_budget -1; DeepSeek-V4-Pro reasons internally with no wire knob.
-  gemini-2.5-pro:              { thinking: dynamic }
-  gemini-3.5-flash:            { thinking: dynamic }
-  gpt-5.4-mini-2026-03-17:     { thinking: high }
-  gpt-5.5-2026-04-23:          { thinking: high }
-  deepseek-ai/DeepSeek-V4-Pro: { thinking: dynamic }
+  gemini-2.5-pro:          { model: gemini-2.5-pro, include_thoughts: true, thinking_budget: -1, condition: dynamic }
+  gemini-3.5-flash:        { model: gemini-3.5-flash, include_thoughts: true, thinking_budget: -1, condition: dynamic }
+  gpt-5.4-mini-2026-03-17: { model: gpt-5.4-mini-2026-03-17, reasoning: high, condition: high }
+  gpt-5.5-2026-04-23:      { model: gpt-5.5-2026-04-23, reasoning: high, condition: high }
+  deepseek-v4-pro:         { model: deepseek-ai/DeepSeek-V4-Pro, condition: dynamic }
 
 student: { model: claude-opus-4-6, mode: oracle, thinking: none }
 scorer:  { model: claude-opus-4-6, thinking: dynamic }

--- a/src/tutormoments/default_config.yaml
+++ b/src/tutormoments/default_config.yaml
@@ -13,25 +13,36 @@ providers:
   gemini:    { env: GEMINI_API_KEY }
   together:  { env: TOGETHER_API_KEY }
 
-models:          # tutor roster; provider inferred from id
-  claude-opus-4-8:             { thinking: true, effort: xhigh }
-  claude-sonnet-4-6:           { thinking: true, effort: high }
-  # Introduce Sonnet 5: first Sonnet model with an xhigh effort option
-  claude-sonnet-5:             { thinking: adaptive, effort: xhigh }
-  gemini-2.5-pro:              { thinking: true, thinking_budget: -1 }
-  gemini-3.5-flash:            { thinking: true, thinking_budget: -1 }
-  gpt-5.4-mini-2026-03-17:     { thinking: true, reasoning_effort: high }
-  gpt-5.5-2026-04-23:          { thinking: true, reasoning_effort: high }
-  deepseek-ai/DeepSeek-V4-Pro: {}
+# Tutor roster: each key is an ARM -- a benchmark condition. `model` names the
+# provider model id (default: the key itself, so an arm that just runs a model
+# under one condition needs no model field). `thinking` is REQUIRED and states
+# the arm's reasoning condition on the canonical ladder
+# (none/minimal/low/medium/high/xhigh/max/dynamic); the model registry
+# (models.yaml) translates it to the provider's wire knob and rejects
+# conditions the model cannot honor. The same model may appear under several
+# arms, e.g.:
+#   gpt-5.5-no-thinking: { model: gpt-5.5-2026-04-23, thinking: none }
+models:
+  claude-opus-4-8:             { thinking: xhigh }
+  claude-sonnet-4-6:           { thinking: high }
+  # Sonnet 5: first Sonnet model with an xhigh effort option
+  claude-sonnet-5:             { thinking: xhigh }
+  # Gemini and DeepSeek arms run model-paced thinking (dynamic): Gemini sends
+  # thinking_budget -1; DeepSeek-V4-Pro reasons internally with no wire knob.
+  gemini-2.5-pro:              { thinking: dynamic }
+  gemini-3.5-flash:            { thinking: dynamic }
+  gpt-5.4-mini-2026-03-17:     { thinking: high }
+  gpt-5.5-2026-04-23:          { thinking: high }
+  deepseek-ai/DeepSeek-V4-Pro: { thinking: dynamic }
 
-student: { model: claude-opus-4-6, mode: oracle, thinking: false }
-scorer:  { model: claude-opus-4-6, thinking: adaptive }
+student: { model: claude-opus-4-6, mode: oracle, thinking: none }
+scorer:  { model: claude-opus-4-6, thinking: dynamic }
 
 # Action-taxonomy classification. Runs on every `tutormoments run` (writes
 # results/<run_id>/taxonomy/classified.csv + a taxonomy block in summary.json)
 # and backs the dev `tutormoments taxonomy` command. Pinned to opus-4-8 with
-# thinking disabled for reproducibility of the published action distribution.
-taxonomy: { model: claude-opus-4-8, thinking: false, batch_size: 50 }
+# thinking off for reproducibility of the published action distribution.
+taxonomy: { model: claude-opus-4-8, thinking: none, batch_size: 50 }
 
 defaults: { trials: 1, max_turns: 5 }
 retry:    { max_retries: 5, base_delay: 5 }
@@ -44,15 +55,13 @@ batch:    { timeout: 86400 }
 execution: { replay_concurrency: 4 }
 
 # Ground-truth build phase (dev-only `tutormoments dataset build-ground-truth`).
-# opus-4-8 uses adaptive thinking only: the Anthropic client sends {type: adaptive}
-# and ignores thinking_budget/reasoning_effort. The paper's ground truth was built
-# on opus-4-8 with adaptive thinking -- keep this pinned for reproducibility.
+# The paper's ground truth was built on opus-4-8 with adaptive (model-paced)
+# thinking -- `dynamic` sends the same {type: adaptive} wire shape; keep this
+# pinned for reproducibility.
 groundtruth:
   model: claude-opus-4-8
   poll_interval: 60
-  thinking: adaptive
-  thinking_budget: 0
-  reasoning_effort: ""
+  thinking: dynamic
   labeller:                 # per-annotation_type effectiveness templates (hybrid routing)
     scaffolding: classify_scaffolding
     rapport: classify_rapport

--- a/src/tutormoments/default_config.yaml
+++ b/src/tutormoments/default_config.yaml
@@ -32,14 +32,19 @@ benchmark_models:
   gpt-5.5-2026-04-23:      { model: gpt-5.5-2026-04-23, reasoning: high, condition: high }
   deepseek-v4-pro:         { model: deepseek-ai/DeepSeek-V4-Pro, condition: dynamic }
 
-student: { model: claude-opus-4-6, mode: oracle, thinking: none }
-scorer:  { model: claude-opus-4-6, thinking: dynamic }
+# Role blocks state provider-native thinking parameters the same way arms do.
+# "Off" is stated explicitly ({type: disabled}) rather than by omitting the
+# param: what omission means depends on the model generation (no thinking on
+# Anthropic 4.x, adaptive on Sonnet 5+), so an explicit block keeps the
+# condition stable under model swaps and lets smoke assert it.
+student: { model: claude-opus-4-6, mode: oracle, thinking: { type: disabled } }
+scorer:  { model: claude-opus-4-6, thinking: { type: adaptive } }
 
 # Action-taxonomy classification. Runs on every `tutormoments run` (writes
 # results/<run_id>/taxonomy/classified.csv + a taxonomy block in summary.json)
 # and backs the dev `tutormoments taxonomy` command. Pinned to opus-4-8 with
 # thinking off for reproducibility of the published action distribution.
-taxonomy: { model: claude-opus-4-8, thinking: none, batch_size: 50 }
+taxonomy: { model: claude-opus-4-8, thinking: { type: disabled }, batch_size: 50 }
 
 defaults: { trials: 1, max_turns: 5 }
 retry:    { max_retries: 5, base_delay: 5 }
@@ -53,12 +58,11 @@ execution: { replay_concurrency: 4 }
 
 # Ground-truth build phase (dev-only `tutormoments dataset build-ground-truth`).
 # The paper's ground truth was built on opus-4-8 with adaptive (model-paced)
-# thinking -- `dynamic` sends the same {type: adaptive} wire shape; keep this
-# pinned for reproducibility.
+# thinking; keep this pinned for reproducibility.
 groundtruth:
   model: claude-opus-4-8
   poll_interval: 60
-  thinking: dynamic
+  thinking: { type: adaptive }
   labeller:                 # per-annotation_type effectiveness templates (hybrid routing)
     scaffolding: classify_scaffolding
     rapport: classify_rapport

--- a/src/tutormoments/default_config.yaml
+++ b/src/tutormoments/default_config.yaml
@@ -17,7 +17,7 @@ providers:
 # provider model id (default: the key itself, so an arm that just runs a model
 # under one condition needs no model field). `thinking` is REQUIRED and states
 # the arm's reasoning condition on the canonical ladder
-# (none/minimal/low/medium/high/xhigh/max/dynamic); the model registry
+# (none/low/high/xhigh/dynamic); the model registry
 # (models.yaml) translates it to the provider's wire knob and rejects
 # conditions the model cannot honor. The same model may appear under several
 # arms, e.g.:

--- a/src/tutormoments/latency.py
+++ b/src/tutormoments/latency.py
@@ -474,8 +474,8 @@ def run_probe(
                 moment,
                 tutor_id=tutor,
                 tutor_mode=mode or None,
-                student_id=(cfg.student or {}).get("model"),
-                student_mode=(cfg.student or {}).get("mode", "oracle"),
+                student_id=cfg.student.model,
+                student_mode=cfg.student.mode or "oracle",
                 max_turns=cfg.max_turns,
             )
         except Exception as e:  # noqa: BLE001 -- one bad moment must not
@@ -488,9 +488,11 @@ def run_probe(
         for t in getattr(transcript, "student_timings", []) or []:
             student_timings.append({**t, "moment_id": moment.id})
 
+    arm_spec = cfg.resolved_tutors.get(tutor)
     block = {
         "source": "probe",
         "tutor_model": tutor,
+        "model": arm_spec.model if arm_spec is not None else None,
         "mode": mode,
         "tutor": aggregate_timings(tutor_timings),
         "student": aggregate_timings(student_timings),

--- a/src/tutormoments/latency.py
+++ b/src/tutormoments/latency.py
@@ -493,6 +493,7 @@ def run_probe(
         "source": "probe",
         "tutor_model": tutor,
         "model": arm_spec.model if arm_spec is not None else None,
+        "condition": arm_spec.condition if arm_spec is not None else None,
         "mode": mode,
         "tutor": aggregate_timings(tutor_timings),
         "student": aggregate_timings(student_timings),

--- a/src/tutormoments/models.py
+++ b/src/tutormoments/models.py
@@ -1,19 +1,20 @@
-"""The model registry: provider routing and thinking-ladder wire translation.
+"""Provider routing plus thinking-parameter validation/translation.
 
-This module is the single source of truth for per-model facts. The data lives
-in the packaged ``models.yaml`` (families = capability shapes, models =
-per-model entries with pricing); this module loads it, validates it, and
-translates the canonical thinking ladder into each provider's wire knob.
+The packaged ``models.yaml`` stores stable per-model facts (families, pricing,
+output caps) and the legacy/role thinking ladder. Tutor benchmark arms can
+also pass provider-native thinking mappings from ``benchmark_models`` so the
+run config remains auditable in provider parlance.
 
-The translation is fail-closed: an explicit thinking level on a model that is
-not registered, or a rung the model's family does not support, raises
+Validation is fail-closed: malformed native mappings, an explicit ladder level
+on an unregistered model, or a rung the model's family does not support raises
 ThinkingConfigError at config-load time rather than letting a run proceed
-under a condition the provider cannot honor (or would silently ignore).
+under parameters the provider cannot honor or would silently ignore.
 
 Deliberately SDK-free: config loading must not drag provider SDKs in.
 """
 
 import threading
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 
@@ -52,6 +53,10 @@ _KNOWN_MECHANISMS = {
 _ANTHROPIC_ADAPTIVE_SPECIALS = {"omit", "disabled", "adaptive"}
 _ANTHROPIC_EFFORT_LEVELS = {"low", "high", "xhigh"}
 _LADDER_DOC = "none/low/high/xhigh/dynamic"
+_GEMINI_NATIVE_KEYS = {"thinking_budget", "thinking_level", "include_thoughts"}
+_OPENAI_NATIVE_KEYS = {"reasoning"}
+_ANTHROPIC_NATIVE_KEYS = {"thinking", "effort"}
+_TOGETHER_NATIVE_KEYS: set[str] = set()
 
 
 class ThinkingConfigError(ValueError):
@@ -59,7 +64,7 @@ class ThinkingConfigError(ValueError):
 
 
 class ThinkingLevel(str, Enum):
-    """The canonical thinking ladder.
+    """The canonical thinking ladder for roles and legacy roster entries.
 
     `none` means thinking verifiably off; `low`/`high`/`xhigh` are explicit
     depth rungs; `dynamic` means the model decides (provider auto mechanisms).
@@ -79,10 +84,9 @@ class ThinkingLevel(str, Enum):
     def coerce(cls, value) -> "ThinkingLevel | None":
         """Coerce a config value to a ladder level (None passes through).
 
-        Rejects the retired raw-knob spellings with a migration hint. Booleans
-        are called out specially because YAML 1.1 parses no/on/off as bools --
-        a user who wrote `thinking: off` meant the string and needs the quoted
-        ladder spelling instead.
+        Booleans are called out specially because YAML 1.1 parses no/on/off
+        as bools -- a user who wrote `thinking: off` meant the string and
+        needs the quoted ladder spelling instead.
         """
         if value is None or isinstance(value, cls):
             return value
@@ -327,16 +331,19 @@ def get_pricing(model: str) -> dict:
 
 
 def resolve_thinking(model: str, level) -> WireThinking:
-    """Translate a thinking level into the wire fragment for `model`.
+    """Translate configured thinking parameters into the wire fragment for `model`.
 
-    THE fail-closed chokepoint: called at config load (so unsatisfiable
-    conditions die before any tokens are spent) and again by the client before
-    the retry loop (so direct callers get the same contract).
+    Accepts either a legacy canonical ladder level or a provider-native config
+    mapping from ``benchmark_models``. The native mapping is the preferred
+    benchmark path because it keeps exact run parameters in the config YAML.
 
     level=None means no stated condition -- nothing is sent and nothing is
     checked. That path exists for non-benchmark direct calls only; every
     config-driven path passes an explicit level (config requires one).
     """
+    if isinstance(level, dict):
+        return resolve_native_thinking(model, level)
+
     level = ThinkingLevel.coerce(level)
     if level is None:
         return WireThinking(provider=infer_provider(model), level=None)
@@ -419,3 +426,132 @@ def resolve_thinking(model: str, level) -> WireThinking:
         )
     # noop
     return WireThinking(provider=provider, level=level)
+
+
+def resolve_native_thinking(model: str, params: dict | None) -> WireThinking:
+    """Validate and translate provider-native thinking params from config.
+
+    The mapping is intentionally small and mirrors the knobs this client knows
+    how to send today:
+
+    - Gemini: ``thinking_budget`` or ``thinking_level`` plus optional
+      ``include_thoughts``.
+    - OpenAI: ``reasoning`` (forwarded by the chat adapter as
+      ``reasoning_effort``).
+    - Anthropic: ``thinking`` plus optional ``effort``.
+    - Together/open-weight reasoners: no exposed knobs.
+    """
+    provider = infer_provider(model)
+    params = dict(params or {})
+    if provider == "gemini":
+        return _resolve_native_gemini(params)
+    if provider == "openai":
+        return _resolve_native_openai(params)
+    if provider == "anthropic":
+        return _resolve_native_anthropic(params)
+    if provider == "together":
+        _check_native_keys(provider, params, _TOGETHER_NATIVE_KEYS)
+        return WireThinking(provider=provider, level=None)
+    raise ValueError(f"Unsupported provider: {provider}")
+
+
+def _check_native_keys(provider: str, params: dict, allowed: set[str]) -> None:
+    unknown = set(params) - allowed
+    if unknown:
+        raise ThinkingConfigError(
+            f"{provider} thinking config has unknown key(s) {sorted(unknown)}. "
+            f"Allowed: {sorted(allowed)}."
+        )
+
+
+def _resolve_native_gemini(params: dict) -> WireThinking:
+    _check_native_keys("gemini", params, _GEMINI_NATIVE_KEYS)
+    if "thinking_budget" in params and "thinking_level" in params:
+        raise ThinkingConfigError(
+            "gemini thinking config cannot set both thinking_budget and "
+            "thinking_level."
+        )
+    if "thinking_budget" not in params and "thinking_level" not in params:
+        raise ThinkingConfigError(
+            "gemini thinking config must set thinking_budget or thinking_level."
+        )
+    if "include_thoughts" in params and not isinstance(params["include_thoughts"], bool):
+        raise ThinkingConfigError("gemini include_thoughts must be true or false.")
+    config: dict = {}
+    if "include_thoughts" in params:
+        config["include_thoughts"] = params["include_thoughts"]
+    if "thinking_budget" in params:
+        budget = params["thinking_budget"]
+        if not isinstance(budget, int) or isinstance(budget, bool):
+            raise ThinkingConfigError("gemini thinking_budget must be an integer.")
+        config["thinking_budget"] = budget
+        config.setdefault("include_thoughts", budget != 0)
+    else:
+        level = params["thinking_level"]
+        if not isinstance(level, str) or not level:
+            raise ThinkingConfigError("gemini thinking_level must be a non-empty string.")
+        config["thinking_level"] = level
+        config.setdefault("include_thoughts", True)
+    return WireThinking(
+        provider="gemini",
+        level=None,
+        gemini_thinking_config=config,
+    )
+
+
+def _resolve_native_openai(params: dict) -> WireThinking:
+    _check_native_keys("openai", params, _OPENAI_NATIVE_KEYS)
+    if "reasoning" not in params:
+        raise ThinkingConfigError("openai thinking config must set reasoning.")
+    reasoning = params["reasoning"]
+    if not isinstance(reasoning, str) or not reasoning:
+        raise ThinkingConfigError("openai reasoning must be a non-empty string.")
+    return WireThinking(
+        provider="openai",
+        level=None,
+        openai_reasoning_effort=reasoning,
+    )
+
+
+def _resolve_native_anthropic(params: dict) -> WireThinking:
+    _check_native_keys("anthropic", params, _ANTHROPIC_NATIVE_KEYS)
+    if "thinking" not in params:
+        raise ThinkingConfigError("anthropic thinking config must set thinking.")
+    thinking = params["thinking"]
+    if thinking is None:
+        thinking_config = None
+    elif isinstance(thinking, dict):
+        thinking_config = deepcopy(thinking)
+    else:
+        raise ThinkingConfigError("anthropic thinking must be a mapping or null.")
+    effort = params.get("effort")
+    if effort is not None and (not isinstance(effort, str) or not effort):
+        raise ThinkingConfigError("anthropic effort must be a non-empty string.")
+    if thinking_config is None:
+        if effort is not None:
+            raise ThinkingConfigError("anthropic effort requires thinking.type adaptive.")
+    else:
+        kind = thinking_config.get("type")
+        if kind not in {"adaptive", "enabled", "disabled"}:
+            raise ThinkingConfigError(
+                "anthropic thinking.type must be adaptive, enabled, or disabled."
+            )
+        if kind == "enabled":
+            budget = thinking_config.get("budget_tokens")
+            if not isinstance(budget, int) or isinstance(budget, bool) or budget <= 0:
+                raise ThinkingConfigError(
+                    "anthropic enabled thinking requires a positive integer "
+                    "budget_tokens."
+                )
+        elif "budget_tokens" in thinking_config:
+            raise ThinkingConfigError(
+                "anthropic budget_tokens is only valid with thinking.type enabled."
+            )
+        if effort is not None and kind != "adaptive":
+            raise ThinkingConfigError("anthropic effort requires thinking.type adaptive.")
+    return WireThinking(
+        provider="anthropic",
+        level=None,
+        anthropic_thinking=thinking_config,
+        anthropic_effort=effort,
+    )

--- a/src/tutormoments/models.py
+++ b/src/tutormoments/models.py
@@ -50,8 +50,8 @@ _KNOWN_MECHANISMS = {
     "noop",
 }
 _ANTHROPIC_ADAPTIVE_SPECIALS = {"omit", "disabled", "adaptive"}
-_ANTHROPIC_EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
-_LADDER_DOC = "none/minimal/low/medium/high/xhigh/max/dynamic"
+_ANTHROPIC_EFFORT_LEVELS = {"low", "high", "xhigh"}
+_LADDER_DOC = "none/low/high/xhigh/dynamic"
 
 
 class ThinkingConfigError(ValueError):
@@ -61,19 +61,18 @@ class ThinkingConfigError(ValueError):
 class ThinkingLevel(str, Enum):
     """The canonical thinking ladder.
 
-    `none` means thinking verifiably off; `minimal`..`max` are explicit depth
-    rungs; `dynamic` means the model decides (provider auto mechanisms).
+    `none` means thinking verifiably off; `low`/`high`/`xhigh` are explicit
+    depth rungs; `dynamic` means the model decides (provider auto mechanisms).
     Each family maps the rungs it supports to its own wire knob in models.yaml;
-    a missing rung is unsatisfiable there and rejected.
+    a missing rung is unsatisfiable there and rejected. Deliberately small:
+    a rung exists only when an experiment needs it (adding one is a reviewed
+    registry line plus a `tutormoments smoke` verification).
     """
 
     NONE = "none"
-    MINIMAL = "minimal"
     LOW = "low"
-    MEDIUM = "medium"
     HIGH = "high"
     XHIGH = "xhigh"
-    MAX = "max"
     DYNAMIC = "dynamic"
 
     @classmethod

--- a/src/tutormoments/models.py
+++ b/src/tutormoments/models.py
@@ -1,0 +1,422 @@
+"""The model registry: provider routing and thinking-ladder wire translation.
+
+This module is the single source of truth for per-model facts. The data lives
+in the packaged ``models.yaml`` (families = capability shapes, models =
+per-model entries with pricing); this module loads it, validates it, and
+translates the canonical thinking ladder into each provider's wire knob.
+
+The translation is fail-closed: an explicit thinking level on a model that is
+not registered, or a rung the model's family does not support, raises
+ThinkingConfigError at config-load time rather than letting a run proceed
+under a condition the provider cannot honor (or would silently ignore).
+
+Deliberately SDK-free: config loading must not drag provider SDKs in.
+"""
+
+import threading
+from dataclasses import dataclass
+from enum import Enum
+
+import yaml
+
+from tutormoments.resources import resource_text
+
+_REGISTRY_RESOURCE = "models.yaml"
+
+# Provider routing fallback for model ids that are not registered. Routing is
+# deliberately permissive (a dev can point a ModelClient at any claude-* id);
+# thinking translation below is strict. Order matters (first match wins).
+_PROVIDER_PREFIXES = [
+    ("gemini", "gemini"),
+    ("gpt", "openai"),
+    ("o1", "openai"),
+    ("o3", "openai"),
+    ("o4", "openai"),
+    ("claude", "anthropic"),
+    ("deepseek-ai/", "together"),
+    ("moonshotai/", "together"),
+    ("minimaxai/", "together"),
+    ("google/gemma", "together"),
+    ("meta-llama/", "together"),
+    ("qwen/", "together"),
+]
+
+_KNOWN_PROVIDERS = {"anthropic", "gemini", "openai", "together"}
+_KNOWN_MECHANISMS = {
+    "anthropic-adaptive",
+    "anthropic-budget",
+    "gemini",
+    "openai-effort",
+    "noop",
+}
+_ANTHROPIC_ADAPTIVE_SPECIALS = {"omit", "disabled", "adaptive"}
+_ANTHROPIC_EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
+_LADDER_DOC = "none/minimal/low/medium/high/xhigh/max/dynamic"
+
+
+class ThinkingConfigError(ValueError):
+    """A thinking condition that cannot be honored or expressed."""
+
+
+class ThinkingLevel(str, Enum):
+    """The canonical thinking ladder.
+
+    `none` means thinking verifiably off; `minimal`..`max` are explicit depth
+    rungs; `dynamic` means the model decides (provider auto mechanisms).
+    Each family maps the rungs it supports to its own wire knob in models.yaml;
+    a missing rung is unsatisfiable there and rejected.
+    """
+
+    NONE = "none"
+    MINIMAL = "minimal"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    XHIGH = "xhigh"
+    MAX = "max"
+    DYNAMIC = "dynamic"
+
+    @classmethod
+    def coerce(cls, value) -> "ThinkingLevel | None":
+        """Coerce a config value to a ladder level (None passes through).
+
+        Rejects the retired raw-knob spellings with a migration hint. Booleans
+        are called out specially because YAML 1.1 parses no/on/off as bools --
+        a user who wrote `thinking: off` meant the string and needs the quoted
+        ladder spelling instead.
+        """
+        if value is None or isinstance(value, cls):
+            return value
+        if isinstance(value, bool):
+            raise ThinkingConfigError(
+                f"thinking: {str(value).lower()} is not a valid thinking level. "
+                f"Raw on/off knobs were replaced by the ladder ({_LADDER_DOC}); "
+                "note YAML parses unquoted no/on/off as booleans, so spell the "
+                "level as a plain word (e.g. thinking: none, thinking: high)."
+            )
+        if isinstance(value, str):
+            try:
+                return cls(value.lower())
+            except ValueError:
+                raise ThinkingConfigError(
+                    f"thinking: {value!r} is not a valid thinking level. "
+                    f"Valid levels: {_LADDER_DOC}."
+                ) from None
+        raise ThinkingConfigError(
+            f"thinking: {value!r} is not a valid thinking level (got "
+            f"{type(value).__name__}). Numeric budgets and provider knobs "
+            f"moved into the model registry (models.yaml); config states one "
+            f"of: {_LADDER_DOC}."
+        )
+
+
+@dataclass(frozen=True)
+class WireThinking:
+    """The provider wire fragment one resolved thinking level produces.
+
+    Exactly one provider-specific field is populated (or none, for the
+    omit/noop cases). Consumers copy fields into their request kwargs; the
+    dicts are freshly built per resolve call, never shared.
+    """
+
+    provider: str
+    level: "ThinkingLevel | None"
+    # {"type": "adaptive"} | {"type": "disabled"} | {"type": "enabled",
+    # "budget_tokens": N} | None (omit the param entirely).
+    anthropic_thinking: dict | None = None
+    # output_config.effort value; only ever set alongside adaptive thinking.
+    anthropic_effort: str | None = None
+    # thinking_config dict for generation_config | None (omit).
+    gemini_thinking_config: dict | None = None
+    # reasoning_effort value | None (omit).
+    openai_reasoning_effort: str | None = None
+
+    def describe(self) -> str:
+        """Human-readable wire form, for logs and the smoke report."""
+        if self.anthropic_thinking is not None:
+            parts = [f"thinking={self.anthropic_thinking}"]
+            if self.anthropic_effort:
+                parts.append(f"effort={self.anthropic_effort}")
+            return " ".join(parts)
+        if self.gemini_thinking_config is not None:
+            return f"thinking_config={self.gemini_thinking_config}"
+        if self.openai_reasoning_effort is not None:
+            return f"reasoning_effort={self.openai_reasoning_effort}"
+        return "(none sent)"
+
+
+_REGISTRY_LOCK = threading.Lock()
+_REGISTRY: dict | None = None
+
+
+def _load_registry() -> dict:
+    """Load and validate models.yaml once (module-level cache)."""
+    global _REGISTRY
+    if _REGISTRY is None:
+        with _REGISTRY_LOCK:
+            if _REGISTRY is None:
+                _REGISTRY = _validate_registry(
+                    yaml.safe_load(resource_text(_REGISTRY_RESOURCE))
+                )
+    return _REGISTRY
+
+
+def _reset_registry_cache() -> None:
+    """Clear the registry cache (for testing)."""
+    global _REGISTRY
+    _REGISTRY = None
+
+
+def _validate_registry(raw: dict) -> dict:
+    """Validate the registry shape; raise ValueError naming the defect."""
+    families = raw.get("families") or {}
+    models = raw.get("models") or {}
+    if not families or not models:
+        raise ValueError("models.yaml must define non-empty families: and models:")
+
+    for fam_name, fam in families.items():
+        provider = fam.get("provider")
+        if provider not in _KNOWN_PROVIDERS:
+            raise ValueError(
+                f"models.yaml family '{fam_name}': unknown provider {provider!r}"
+            )
+        thinking = fam.get("thinking") or {}
+        mechanism = thinking.get("mechanism")
+        if mechanism not in _KNOWN_MECHANISMS:
+            raise ValueError(
+                f"models.yaml family '{fam_name}': unknown mechanism {mechanism!r}"
+            )
+        rungs = thinking.get("rungs") or {}
+        if not rungs:
+            raise ValueError(f"models.yaml family '{fam_name}': empty rungs map")
+        for rung_name, wire_value in rungs.items():
+            try:
+                ThinkingLevel(rung_name)
+            except ValueError:
+                raise ValueError(
+                    f"models.yaml family '{fam_name}': '{rung_name}' is not a "
+                    f"ladder level ({_LADDER_DOC})"
+                ) from None
+            _check_rung_value(fam_name, mechanism, rung_name, wire_value)
+        for rung_name in thinking.get("unverified") or []:
+            if rung_name not in rungs:
+                raise ValueError(
+                    f"models.yaml family '{fam_name}': unverified rung "
+                    f"'{rung_name}' is not in the rungs map"
+                )
+
+    for model_key, entry in models.items():
+        fam_name = (entry or {}).get("family")
+        if fam_name not in families:
+            raise ValueError(
+                f"models.yaml model '{model_key}': unknown family {fam_name!r}"
+            )
+        cap = entry.get("max_output_cap")
+        if cap is not None and (not isinstance(cap, int) or cap <= 0):
+            raise ValueError(
+                f"models.yaml model '{model_key}': max_output_cap must be a "
+                f"positive integer, got {cap!r}"
+            )
+
+    return raw
+
+
+def _check_rung_value(fam_name, mechanism, rung_name, wire_value) -> None:
+    ctx = f"models.yaml family '{fam_name}' rung '{rung_name}'"
+    if mechanism == "anthropic-adaptive":
+        if (
+            wire_value not in _ANTHROPIC_ADAPTIVE_SPECIALS
+            and wire_value not in _ANTHROPIC_EFFORT_LEVELS
+        ):
+            raise ValueError(
+                f"{ctx}: anthropic-adaptive values must be omit/disabled/"
+                f"adaptive or an effort level, got {wire_value!r}"
+            )
+    elif mechanism == "anthropic-budget":
+        if wire_value != "omit" and not (
+            isinstance(wire_value, int)
+            and not isinstance(wire_value, bool)
+            and wire_value > 0
+        ):
+            raise ValueError(
+                f"{ctx}: anthropic-budget values must be 'omit' or a positive "
+                f"integer budget, got {wire_value!r}"
+            )
+    elif mechanism == "gemini":
+        is_budget = isinstance(wire_value, int) and not isinstance(wire_value, bool)
+        if not (is_budget or isinstance(wire_value, str)):
+            raise ValueError(
+                f"{ctx}: gemini values must be an integer thinking_budget or a "
+                f"thinking_level string, got {wire_value!r}"
+            )
+    elif mechanism == "openai-effort":
+        if not isinstance(wire_value, str):
+            raise ValueError(
+                f"{ctx}: openai-effort values must be reasoning_effort "
+                f"strings, got {wire_value!r}"
+            )
+    elif mechanism == "noop":
+        if wire_value is not None:
+            raise ValueError(f"{ctx}: noop rungs must map to null")
+
+
+def _find_model_entry(model: str) -> tuple[str, dict] | None:
+    """Find the registry entry for a model id.
+
+    Exact (case-insensitive) key match first, then the LONGEST matching
+    prefix -- so a dated point release resolves to its base entry, and
+    gemini-2.5-flash-lite would prefer a gemini-2.5-flash-lite entry over
+    gemini-2.5-flash if both existed.
+    """
+    registry = _load_registry()
+    models = registry["models"]
+    model_lower = model.lower()
+    by_lower = {key.lower(): (key, entry) for key, entry in models.items()}
+    if model_lower in by_lower:
+        return by_lower[model_lower]
+    best = None
+    for key_lower, (key, entry) in by_lower.items():
+        if model_lower.startswith(key_lower):
+            if best is None or len(key_lower) > len(best[0].lower()):
+                best = (key, entry)
+    return best
+
+
+def _family_for(model: str) -> tuple[str, dict] | None:
+    found = _find_model_entry(model)
+    if found is None:
+        return None
+    _, entry = found
+    fam_name = entry["family"]
+    return fam_name, _load_registry()["families"][fam_name]
+
+
+def infer_provider(model: str) -> str:
+    """Infer provider from a model id.
+
+    Registered models answer from the registry; unregistered ids fall back to
+    the generic prefix table so routing (dev/direct client use) stays
+    permissive while thinking translation stays strict.
+    """
+    family = _family_for(model)
+    if family is not None:
+        return family[1]["provider"]
+    model_lower = model.lower()
+    for prefix, provider in _PROVIDER_PREFIXES:
+        if model_lower.startswith(prefix):
+            return provider
+    raise ValueError(
+        f"Cannot infer provider for model '{model}'. "
+        f"Expected prefix: {', '.join(p for p, _ in _PROVIDER_PREFIXES)}"
+    )
+
+
+def max_output_cap(model: str) -> int | None:
+    """Per-model max output token cap, or None when the provider default rules."""
+    found = _find_model_entry(model)
+    if found is None:
+        return None
+    return found[1].get("max_output_cap")
+
+
+def get_pricing(model: str) -> dict:
+    """Per-model pricing grid (per-MTok rates). Empty = not priced yet."""
+    found = _find_model_entry(model)
+    if found is None:
+        return {}
+    return dict(found[1].get("pricing") or {})
+
+
+def resolve_thinking(model: str, level) -> WireThinking:
+    """Translate a thinking level into the wire fragment for `model`.
+
+    THE fail-closed chokepoint: called at config load (so unsatisfiable
+    conditions die before any tokens are spent) and again by the client before
+    the retry loop (so direct callers get the same contract).
+
+    level=None means no stated condition -- nothing is sent and nothing is
+    checked. That path exists for non-benchmark direct calls only; every
+    config-driven path passes an explicit level (config requires one).
+    """
+    level = ThinkingLevel.coerce(level)
+    if level is None:
+        return WireThinking(provider=infer_provider(model), level=None)
+
+    family = _family_for(model)
+    if family is None:
+        raise ThinkingConfigError(
+            f"Model '{model}' is not in the model registry, so "
+            f"thinking: {level.value} cannot be translated to a wire format. "
+            "Add an entry for it in src/tutormoments/models.yaml (family + "
+            "pricing) before benchmarking it."
+        )
+    fam_name, fam = family
+    thinking = fam["thinking"]
+    rungs = thinking["rungs"]
+
+    if level.value not in rungs:
+        notes = fam.get("notes")
+        reason = f" {notes.strip()}" if notes else ""
+        raise ThinkingConfigError(
+            f"Model '{model}' (family {fam_name}) does not support "
+            f"thinking: {level.value}.{reason} Supported levels: "
+            f"{', '.join(rungs)}."
+        )
+    if level.value in (thinking.get("unverified") or []):
+        raise ThinkingConfigError(
+            f"thinking: {level.value} on '{model}' (family {fam_name}) has a "
+            "documented wire form that has not been verified against the live "
+            "API from this codebase. Verify it with `tutormoments smoke`, "
+            "then remove the rung from the family's `unverified` list in "
+            "src/tutormoments/models.yaml."
+        )
+
+    provider = fam["provider"]
+    mechanism = thinking["mechanism"]
+    wire_value = rungs[level.value]
+
+    if mechanism == "anthropic-adaptive":
+        if wire_value == "omit":
+            return WireThinking(provider=provider, level=level)
+        if wire_value == "disabled":
+            return WireThinking(
+                provider=provider,
+                level=level,
+                anthropic_thinking={"type": "disabled"},
+            )
+        if wire_value == "adaptive":
+            return WireThinking(
+                provider=provider,
+                level=level,
+                anthropic_thinking={"type": "adaptive"},
+            )
+        return WireThinking(
+            provider=provider,
+            level=level,
+            anthropic_thinking={"type": "adaptive"},
+            anthropic_effort=wire_value,
+        )
+    if mechanism == "anthropic-budget":
+        if wire_value == "omit":
+            return WireThinking(provider=provider, level=level)
+        return WireThinking(
+            provider=provider,
+            level=level,
+            anthropic_thinking={"type": "enabled", "budget_tokens": wire_value},
+        )
+    if mechanism == "gemini":
+        if isinstance(wire_value, str):
+            config = {"include_thoughts": True, "thinking_level": wire_value}
+        elif wire_value == 0:
+            config = {"include_thoughts": False, "thinking_budget": 0}
+        else:
+            config = {"include_thoughts": True, "thinking_budget": wire_value}
+        return WireThinking(
+            provider=provider, level=level, gemini_thinking_config=config
+        )
+    if mechanism == "openai-effort":
+        return WireThinking(
+            provider=provider, level=level, openai_reasoning_effort=wire_value
+        )
+    # noop
+    return WireThinking(provider=provider, level=level)

--- a/src/tutormoments/models.py
+++ b/src/tutormoments/models.py
@@ -1,14 +1,16 @@
-"""Provider routing plus thinking-parameter validation/translation.
+"""Provider routing, per-model facts, and thinking-parameter translation.
 
-The packaged ``models.yaml`` stores stable per-model facts (families, pricing,
-output caps) and the legacy/role thinking ladder. Tutor benchmark arms can
-also pass provider-native thinking mappings from ``benchmark_models`` so the
-run config remains auditable in provider parlance.
+The packaged ``models.yaml`` stores stable per-model facts: provider, pricing,
+and output caps. It says nothing about reasoning conditions -- those are
+stated explicitly, in provider parlance, wherever a model is configured
+(``benchmark_models:`` arms and the role blocks), so the run config is
+auditable without consulting a mapping.
 
-Validation is fail-closed: malformed native mappings, an explicit ladder level
-on an unregistered model, or a rung the model's family does not support raises
+Validation is fail-closed: a malformed provider-native thinking mapping raises
 ThinkingConfigError at config-load time rather than letting a run proceed
-under parameters the provider cannot honor or would silently ignore.
+under parameters the provider cannot honor or would silently ignore. Values
+the provider vocabulary may extend (effort tiers, reasoning levels) are
+shape-checked here and proven live with `tutormoments smoke`.
 
 Deliberately SDK-free: config loading must not drag provider SDKs in.
 """
@@ -16,7 +18,6 @@ Deliberately SDK-free: config loading must not drag provider SDKs in.
 import threading
 from copy import deepcopy
 from dataclasses import dataclass
-from enum import Enum
 
 import yaml
 
@@ -43,79 +44,25 @@ _PROVIDER_PREFIXES = [
 ]
 
 _KNOWN_PROVIDERS = {"anthropic", "gemini", "openai", "together"}
-_KNOWN_MECHANISMS = {
-    "anthropic-adaptive",
-    "anthropic-budget",
-    "gemini",
-    "openai-effort",
-    "noop",
+
+# The provider-native thinking keys config may state, per provider. These
+# mirror exactly the knobs the client knows how to send; an unknown key is a
+# config error, not a passthrough.
+NATIVE_THINKING_KEYS = {
+    "anthropic": {"thinking", "effort"},
+    "gemini": {"thinking_budget", "thinking_level", "include_thoughts"},
+    "openai": {"reasoning"},
+    "together": set(),
 }
-_ANTHROPIC_ADAPTIVE_SPECIALS = {"omit", "disabled", "adaptive"}
-_ANTHROPIC_EFFORT_LEVELS = {"low", "high", "xhigh"}
-_LADDER_DOC = "none/low/high/xhigh/dynamic"
-_GEMINI_NATIVE_KEYS = {"thinking_budget", "thinking_level", "include_thoughts"}
-_OPENAI_NATIVE_KEYS = {"reasoning"}
-_ANTHROPIC_NATIVE_KEYS = {"thinking", "effort"}
-_TOGETHER_NATIVE_KEYS: set[str] = set()
 
 
 class ThinkingConfigError(ValueError):
     """A thinking condition that cannot be honored or expressed."""
 
 
-class ThinkingLevel(str, Enum):
-    """The canonical thinking ladder for roles and legacy roster entries.
-
-    `none` means thinking verifiably off; `low`/`high`/`xhigh` are explicit
-    depth rungs; `dynamic` means the model decides (provider auto mechanisms).
-    Each family maps the rungs it supports to its own wire knob in models.yaml;
-    a missing rung is unsatisfiable there and rejected. Deliberately small:
-    a rung exists only when an experiment needs it (adding one is a reviewed
-    registry line plus a `tutormoments smoke` verification).
-    """
-
-    NONE = "none"
-    LOW = "low"
-    HIGH = "high"
-    XHIGH = "xhigh"
-    DYNAMIC = "dynamic"
-
-    @classmethod
-    def coerce(cls, value) -> "ThinkingLevel | None":
-        """Coerce a config value to a ladder level (None passes through).
-
-        Booleans are called out specially because YAML 1.1 parses no/on/off
-        as bools -- a user who wrote `thinking: off` meant the string and
-        needs the quoted ladder spelling instead.
-        """
-        if value is None or isinstance(value, cls):
-            return value
-        if isinstance(value, bool):
-            raise ThinkingConfigError(
-                f"thinking: {str(value).lower()} is not a valid thinking level. "
-                f"Raw on/off knobs were replaced by the ladder ({_LADDER_DOC}); "
-                "note YAML parses unquoted no/on/off as booleans, so spell the "
-                "level as a plain word (e.g. thinking: none, thinking: high)."
-            )
-        if isinstance(value, str):
-            try:
-                return cls(value.lower())
-            except ValueError:
-                raise ThinkingConfigError(
-                    f"thinking: {value!r} is not a valid thinking level. "
-                    f"Valid levels: {_LADDER_DOC}."
-                ) from None
-        raise ThinkingConfigError(
-            f"thinking: {value!r} is not a valid thinking level (got "
-            f"{type(value).__name__}). Numeric budgets and provider knobs "
-            f"moved into the model registry (models.yaml); config states one "
-            f"of: {_LADDER_DOC}."
-        )
-
-
 @dataclass(frozen=True)
 class WireThinking:
-    """The provider wire fragment one resolved thinking level produces.
+    """The provider wire fragment one resolved thinking config produces.
 
     Exactly one provider-specific field is populated (or none, for the
     omit/noop cases). Consumers copy fields into their request kwargs; the
@@ -123,7 +70,6 @@ class WireThinking:
     """
 
     provider: str
-    level: "ThinkingLevel | None"
     # {"type": "adaptive"} | {"type": "disabled"} | {"type": "enabled",
     # "budget_tokens": N} | None (omit the param entirely).
     anthropic_thinking: dict | None = None
@@ -172,47 +118,16 @@ def _reset_registry_cache() -> None:
 
 def _validate_registry(raw: dict) -> dict:
     """Validate the registry shape; raise ValueError naming the defect."""
-    families = raw.get("families") or {}
-    models = raw.get("models") or {}
-    if not families or not models:
-        raise ValueError("models.yaml must define non-empty families: and models:")
-
-    for fam_name, fam in families.items():
-        provider = fam.get("provider")
-        if provider not in _KNOWN_PROVIDERS:
-            raise ValueError(
-                f"models.yaml family '{fam_name}': unknown provider {provider!r}"
-            )
-        thinking = fam.get("thinking") or {}
-        mechanism = thinking.get("mechanism")
-        if mechanism not in _KNOWN_MECHANISMS:
-            raise ValueError(
-                f"models.yaml family '{fam_name}': unknown mechanism {mechanism!r}"
-            )
-        rungs = thinking.get("rungs") or {}
-        if not rungs:
-            raise ValueError(f"models.yaml family '{fam_name}': empty rungs map")
-        for rung_name, wire_value in rungs.items():
-            try:
-                ThinkingLevel(rung_name)
-            except ValueError:
-                raise ValueError(
-                    f"models.yaml family '{fam_name}': '{rung_name}' is not a "
-                    f"ladder level ({_LADDER_DOC})"
-                ) from None
-            _check_rung_value(fam_name, mechanism, rung_name, wire_value)
-        for rung_name in thinking.get("unverified") or []:
-            if rung_name not in rungs:
-                raise ValueError(
-                    f"models.yaml family '{fam_name}': unverified rung "
-                    f"'{rung_name}' is not in the rungs map"
-                )
+    models = (raw or {}).get("models") or {}
+    if not models:
+        raise ValueError("models.yaml must define a non-empty models: map")
 
     for model_key, entry in models.items():
-        fam_name = (entry or {}).get("family")
-        if fam_name not in families:
+        entry = entry or {}
+        provider = entry.get("provider")
+        if provider not in _KNOWN_PROVIDERS:
             raise ValueError(
-                f"models.yaml model '{model_key}': unknown family {fam_name!r}"
+                f"models.yaml model '{model_key}': unknown provider {provider!r}"
             )
         cap = entry.get("max_output_cap")
         if cap is not None and (not isinstance(cap, int) or cap <= 0):
@@ -220,47 +135,14 @@ def _validate_registry(raw: dict) -> dict:
                 f"models.yaml model '{model_key}': max_output_cap must be a "
                 f"positive integer, got {cap!r}"
             )
+        pricing = entry.get("pricing")
+        if pricing is not None and not isinstance(pricing, dict):
+            raise ValueError(
+                f"models.yaml model '{model_key}': pricing must be a mapping, "
+                f"got {pricing!r}"
+            )
 
     return raw
-
-
-def _check_rung_value(fam_name, mechanism, rung_name, wire_value) -> None:
-    ctx = f"models.yaml family '{fam_name}' rung '{rung_name}'"
-    if mechanism == "anthropic-adaptive":
-        if (
-            wire_value not in _ANTHROPIC_ADAPTIVE_SPECIALS
-            and wire_value not in _ANTHROPIC_EFFORT_LEVELS
-        ):
-            raise ValueError(
-                f"{ctx}: anthropic-adaptive values must be omit/disabled/"
-                f"adaptive or an effort level, got {wire_value!r}"
-            )
-    elif mechanism == "anthropic-budget":
-        if wire_value != "omit" and not (
-            isinstance(wire_value, int)
-            and not isinstance(wire_value, bool)
-            and wire_value > 0
-        ):
-            raise ValueError(
-                f"{ctx}: anthropic-budget values must be 'omit' or a positive "
-                f"integer budget, got {wire_value!r}"
-            )
-    elif mechanism == "gemini":
-        is_budget = isinstance(wire_value, int) and not isinstance(wire_value, bool)
-        if not (is_budget or isinstance(wire_value, str)):
-            raise ValueError(
-                f"{ctx}: gemini values must be an integer thinking_budget or a "
-                f"thinking_level string, got {wire_value!r}"
-            )
-    elif mechanism == "openai-effort":
-        if not isinstance(wire_value, str):
-            raise ValueError(
-                f"{ctx}: openai-effort values must be reasoning_effort "
-                f"strings, got {wire_value!r}"
-            )
-    elif mechanism == "noop":
-        if wire_value is not None:
-            raise ValueError(f"{ctx}: noop rungs must map to null")
 
 
 def _find_model_entry(model: str) -> tuple[str, dict] | None:
@@ -285,15 +167,6 @@ def _find_model_entry(model: str) -> tuple[str, dict] | None:
     return best
 
 
-def _family_for(model: str) -> tuple[str, dict] | None:
-    found = _find_model_entry(model)
-    if found is None:
-        return None
-    _, entry = found
-    fam_name = entry["family"]
-    return fam_name, _load_registry()["families"][fam_name]
-
-
 def infer_provider(model: str) -> str:
     """Infer provider from a model id.
 
@@ -301,9 +174,9 @@ def infer_provider(model: str) -> str:
     the generic prefix table so routing (dev/direct client use) stays
     permissive while thinking translation stays strict.
     """
-    family = _family_for(model)
-    if family is not None:
-        return family[1]["provider"]
+    found = _find_model_entry(model)
+    if found is not None:
+        return found[1]["provider"]
     model_lower = model.lower()
     for prefix, provider in _PROVIDER_PREFIXES:
         if model_lower.startswith(prefix):
@@ -330,106 +203,12 @@ def get_pricing(model: str) -> dict:
     return dict(found[1].get("pricing") or {})
 
 
-def resolve_thinking(model: str, level) -> WireThinking:
-    """Translate configured thinking parameters into the wire fragment for `model`.
-
-    Accepts either a legacy canonical ladder level or a provider-native config
-    mapping from ``benchmark_models``. The native mapping is the preferred
-    benchmark path because it keeps exact run parameters in the config YAML.
-
-    level=None means no stated condition -- nothing is sent and nothing is
-    checked. That path exists for non-benchmark direct calls only; every
-    config-driven path passes an explicit level (config requires one).
-    """
-    if isinstance(level, dict):
-        return resolve_native_thinking(model, level)
-
-    level = ThinkingLevel.coerce(level)
-    if level is None:
-        return WireThinking(provider=infer_provider(model), level=None)
-
-    family = _family_for(model)
-    if family is None:
-        raise ThinkingConfigError(
-            f"Model '{model}' is not in the model registry, so "
-            f"thinking: {level.value} cannot be translated to a wire format. "
-            "Add an entry for it in src/tutormoments/models.yaml (family + "
-            "pricing) before benchmarking it."
-        )
-    fam_name, fam = family
-    thinking = fam["thinking"]
-    rungs = thinking["rungs"]
-
-    if level.value not in rungs:
-        notes = fam.get("notes")
-        reason = f" {notes.strip()}" if notes else ""
-        raise ThinkingConfigError(
-            f"Model '{model}' (family {fam_name}) does not support "
-            f"thinking: {level.value}.{reason} Supported levels: "
-            f"{', '.join(rungs)}."
-        )
-    if level.value in (thinking.get("unverified") or []):
-        raise ThinkingConfigError(
-            f"thinking: {level.value} on '{model}' (family {fam_name}) has a "
-            "documented wire form that has not been verified against the live "
-            "API from this codebase. Verify it with `tutormoments smoke`, "
-            "then remove the rung from the family's `unverified` list in "
-            "src/tutormoments/models.yaml."
-        )
-
-    provider = fam["provider"]
-    mechanism = thinking["mechanism"]
-    wire_value = rungs[level.value]
-
-    if mechanism == "anthropic-adaptive":
-        if wire_value == "omit":
-            return WireThinking(provider=provider, level=level)
-        if wire_value == "disabled":
-            return WireThinking(
-                provider=provider,
-                level=level,
-                anthropic_thinking={"type": "disabled"},
-            )
-        if wire_value == "adaptive":
-            return WireThinking(
-                provider=provider,
-                level=level,
-                anthropic_thinking={"type": "adaptive"},
-            )
-        return WireThinking(
-            provider=provider,
-            level=level,
-            anthropic_thinking={"type": "adaptive"},
-            anthropic_effort=wire_value,
-        )
-    if mechanism == "anthropic-budget":
-        if wire_value == "omit":
-            return WireThinking(provider=provider, level=level)
-        return WireThinking(
-            provider=provider,
-            level=level,
-            anthropic_thinking={"type": "enabled", "budget_tokens": wire_value},
-        )
-    if mechanism == "gemini":
-        if isinstance(wire_value, str):
-            config = {"include_thoughts": True, "thinking_level": wire_value}
-        elif wire_value == 0:
-            config = {"include_thoughts": False, "thinking_budget": 0}
-        else:
-            config = {"include_thoughts": True, "thinking_budget": wire_value}
-        return WireThinking(
-            provider=provider, level=level, gemini_thinking_config=config
-        )
-    if mechanism == "openai-effort":
-        return WireThinking(
-            provider=provider, level=level, openai_reasoning_effort=wire_value
-        )
-    # noop
-    return WireThinking(provider=provider, level=level)
-
-
-def resolve_native_thinking(model: str, params: dict | None) -> WireThinking:
+def resolve_thinking(model: str, thinking: dict | None) -> WireThinking:
     """Validate and translate provider-native thinking params from config.
+
+    THE fail-closed chokepoint: called at config load (so malformed or
+    unsupported settings die before any tokens are spent) and again by the
+    client before the retry loop (so direct callers get the same contract).
 
     The mapping is intentionally small and mirrors the knobs this client knows
     how to send today:
@@ -438,20 +217,34 @@ def resolve_native_thinking(model: str, params: dict | None) -> WireThinking:
       ``include_thoughts``.
     - OpenAI: ``reasoning`` (forwarded by the chat adapter as
       ``reasoning_effort``).
-    - Anthropic: ``thinking`` plus optional ``effort``.
+    - Anthropic: ``thinking`` (a provider thinking block, or null to omit the
+      param) plus optional ``effort``.
     - Together/open-weight reasoners: no exposed knobs.
+
+    thinking=None means "no stated condition": nothing is sent and nothing is
+    checked. That path exists for non-benchmark direct calls only; every
+    config-driven path passes an explicit mapping (config requires one).
     """
+    if thinking is None:
+        return WireThinking(provider=infer_provider(model))
+    if not isinstance(thinking, dict):
+        raise ThinkingConfigError(
+            f"thinking config for '{model}' must be a mapping of provider-"
+            f"native keys (or None for direct calls), got "
+            f"{type(thinking).__name__}: {thinking!r}. The thinking-ladder "
+            "levels were removed; state the provider's own parameters."
+        )
     provider = infer_provider(model)
-    params = dict(params or {})
+    params = dict(thinking)
     if provider == "gemini":
-        return _resolve_native_gemini(params)
+        return _resolve_gemini(params)
     if provider == "openai":
-        return _resolve_native_openai(params)
+        return _resolve_openai(params)
     if provider == "anthropic":
-        return _resolve_native_anthropic(params)
+        return _resolve_anthropic(params)
     if provider == "together":
-        _check_native_keys(provider, params, _TOGETHER_NATIVE_KEYS)
-        return WireThinking(provider=provider, level=None)
+        _check_native_keys(provider, params, NATIVE_THINKING_KEYS["together"])
+        return WireThinking(provider=provider)
     raise ValueError(f"Unsupported provider: {provider}")
 
 
@@ -464,18 +257,19 @@ def _check_native_keys(provider: str, params: dict, allowed: set[str]) -> None:
         )
 
 
-def _resolve_native_gemini(params: dict) -> WireThinking:
-    _check_native_keys("gemini", params, _GEMINI_NATIVE_KEYS)
+def _resolve_gemini(params: dict) -> WireThinking:
+    _check_native_keys("gemini", params, NATIVE_THINKING_KEYS["gemini"])
     if "thinking_budget" in params and "thinking_level" in params:
         raise ThinkingConfigError(
-            "gemini thinking config cannot set both thinking_budget and "
-            "thinking_level."
+            "gemini thinking config cannot set both thinking_budget and thinking_level."
         )
     if "thinking_budget" not in params and "thinking_level" not in params:
         raise ThinkingConfigError(
             "gemini thinking config must set thinking_budget or thinking_level."
         )
-    if "include_thoughts" in params and not isinstance(params["include_thoughts"], bool):
+    if "include_thoughts" in params and not isinstance(
+        params["include_thoughts"], bool
+    ):
         raise ThinkingConfigError("gemini include_thoughts must be true or false.")
     config: dict = {}
     if "include_thoughts" in params:
@@ -489,34 +283,31 @@ def _resolve_native_gemini(params: dict) -> WireThinking:
     else:
         level = params["thinking_level"]
         if not isinstance(level, str) or not level:
-            raise ThinkingConfigError("gemini thinking_level must be a non-empty string.")
+            raise ThinkingConfigError(
+                "gemini thinking_level must be a non-empty string."
+            )
         config["thinking_level"] = level
         config.setdefault("include_thoughts", True)
-    return WireThinking(
-        provider="gemini",
-        level=None,
-        gemini_thinking_config=config,
-    )
+    return WireThinking(provider="gemini", gemini_thinking_config=config)
 
 
-def _resolve_native_openai(params: dict) -> WireThinking:
-    _check_native_keys("openai", params, _OPENAI_NATIVE_KEYS)
+def _resolve_openai(params: dict) -> WireThinking:
+    _check_native_keys("openai", params, NATIVE_THINKING_KEYS["openai"])
     if "reasoning" not in params:
         raise ThinkingConfigError("openai thinking config must set reasoning.")
     reasoning = params["reasoning"]
     if not isinstance(reasoning, str) or not reasoning:
         raise ThinkingConfigError("openai reasoning must be a non-empty string.")
-    return WireThinking(
-        provider="openai",
-        level=None,
-        openai_reasoning_effort=reasoning,
-    )
+    return WireThinking(provider="openai", openai_reasoning_effort=reasoning)
 
 
-def _resolve_native_anthropic(params: dict) -> WireThinking:
-    _check_native_keys("anthropic", params, _ANTHROPIC_NATIVE_KEYS)
+def _resolve_anthropic(params: dict) -> WireThinking:
+    _check_native_keys("anthropic", params, NATIVE_THINKING_KEYS["anthropic"])
     if "thinking" not in params:
-        raise ThinkingConfigError("anthropic thinking config must set thinking.")
+        raise ThinkingConfigError(
+            "anthropic thinking config must set thinking (a thinking block, "
+            "or null to send no thinking param)."
+        )
     thinking = params["thinking"]
     if thinking is None:
         thinking_config = None
@@ -529,7 +320,9 @@ def _resolve_native_anthropic(params: dict) -> WireThinking:
         raise ThinkingConfigError("anthropic effort must be a non-empty string.")
     if thinking_config is None:
         if effort is not None:
-            raise ThinkingConfigError("anthropic effort requires thinking.type adaptive.")
+            raise ThinkingConfigError(
+                "anthropic effort requires thinking.type adaptive."
+            )
     else:
         kind = thinking_config.get("type")
         if kind not in {"adaptive", "enabled", "disabled"}:
@@ -548,10 +341,11 @@ def _resolve_native_anthropic(params: dict) -> WireThinking:
                 "anthropic budget_tokens is only valid with thinking.type enabled."
             )
         if effort is not None and kind != "adaptive":
-            raise ThinkingConfigError("anthropic effort requires thinking.type adaptive.")
+            raise ThinkingConfigError(
+                "anthropic effort requires thinking.type adaptive."
+            )
     return WireThinking(
         provider="anthropic",
-        level=None,
         anthropic_thinking=thinking_config,
         anthropic_effort=effort,
     )

--- a/src/tutormoments/models.yaml
+++ b/src/tutormoments/models.yaml
@@ -1,255 +1,100 @@
-# Model registry: the single place a model is defined for this benchmark.
+# Model registry: stable per-model facts.
 #
-# BENCHMARK-DEFINING CONFIGURATION. The thinking-ladder wire mappings below
-# decide what is actually sent to each provider for every benchmarked
-# condition; changing a rung changes the experiment. Never edit without
-# consulting the benchmark owner (see AGENTS.md), and verify new or changed
-# rungs against the live API with `tutormoments smoke` before relying on them.
+# One entry per model. The key is matched against configured model ids
+# case-insensitively, exact id first, then longest matching prefix (so
+# `claude-haiku-4-5-20251001` resolves to the `claude-haiku-4-5` entry).
+# Each entry states:
 #
-# Two sections:
+#   provider: which API client and key the model routes to (unlisted models
+#     fall back to the prefix table in models.py).
+#   max_output_cap: per-model output token ceiling (requests above it are
+#     rejected by the API); omit when the provider default rules.
+#   pricing: per-MTok token costs -- populated by the cost-tracking
+#     workstream; empty means "not priced yet", never "free".
 #
-#   families: a capability *shape* shared by models -- which provider, which
-#     thinking mechanism the API exposes, and how each canonical ladder rung
-#     (none/low/high/xhigh/dynamic) translates to the wire.
-#     A rung that is absent is unsatisfiable on that family and is rejected at
-#     config load. `unverified` lists rungs whose wire form is documented but
-#     has not yet been proven against the live API -- they are rejected with a
-#     "not yet verified" error until someone runs `tutormoments smoke` on them
-#     and removes them from the list.
-#
-#   models: one entry per model. The key is matched against configured model
-#     ids case-insensitively, exact id first, then longest matching prefix
-#     (so `claude-haiku-4-5-20251001` resolves to the `claude-haiku-4-5`
-#     entry). Each entry names its family and carries per-model facts:
-#     `max_output_cap` (requests above it are rejected by the API) and
-#     `pricing` (per-MTok token costs -- populated by the cost-tracking
-#     workstream; empty means "not priced yet", never "free").
-#
-# Mechanisms (interpreted by models.py):
-#   anthropic-adaptive: rung values are `omit` (send no thinking param),
-#     `disabled` ({"type": "disabled"}), `adaptive` ({"type": "adaptive"}, no
-#     effort), or an effort level ({"type": "adaptive"} + output_config.effort).
-#   anthropic-budget: rung values are `omit` or an integer budget
-#     ({"type": "enabled", "budget_tokens": N}; the client keeps max_tokens at
-#     least N + 64 as the API requires).
-#   gemini: integer rung values map to thinking_config.thinking_budget
-#     (-1 = model-paced dynamic; 0 = off, sent with include_thoughts: false);
-#     string values map to thinking_config.thinking_level (Gemini 3.x --
-#     thinking_level and thinking_budget are mutually exclusive on the wire).
-#   openai-effort: rung values map to reasoning_effort.
-#   noop: the model reasons internally and exposes no knob; the only
-#     expressible condition is `dynamic`, which sends nothing.
-#
-# The shared budget ladder (low=4096, high=16384) is anchored in provider
-# guidance: 16k+ is Anthropic's complex-task guidance (and where the
-# literature finds diminishing returns). The ladder is deliberately small --
-# a rung exists only when an experiment needs it; add one as a reviewed
-# registry line verified with `tutormoments smoke`. See docs/thinking.md.
-
-families:
-  anthropic-adaptive-4-6:
-    provider: anthropic
-    thinking:
-      mechanism: anthropic-adaptive
-      # The 4.6 tier has no xhigh effort level.
-      rungs:
-        none: omit
-        low: low
-        high: high
-        dynamic: adaptive
-
-  anthropic-adaptive-4-7-plus:
-    provider: anthropic
-    thinking:
-      mechanism: anthropic-adaptive
-      rungs:
-        none: omit
-        low: low
-        high: high
-        xhigh: xhigh
-        dynamic: adaptive
-
-  anthropic-sonnet-5:
-    provider: anthropic
-    thinking:
-      mechanism: anthropic-adaptive
-      # Sonnet 5 defaults to adaptive thinking when the param is omitted, so
-      # "off" must be stated explicitly ({"type": "disabled"}), unlike the
-      # omit-means-off 4.x adaptive tiers.
-      rungs:
-        none: disabled
-        low: low
-        high: high
-        xhigh: xhigh
-        dynamic: adaptive
-
-  anthropic-legacy:
-    provider: anthropic
-    # Closed, frozen set of pre-adaptive models (extended thinking via
-    # enabled+budget_tokens only; the effort parameter is rejected).
-    thinking:
-      mechanism: anthropic-budget
-      rungs:
-        none: omit
-        low: 4096
-        high: 16384
-
-  gemini-2-5-pro:
-    provider: gemini
-    notes: >-
-      Always-thinking: the API rejects thinking_budget: 0, so `none` is
-      unsatisfiable.
-    thinking:
-      mechanism: gemini
-      rungs:
-        low: 4096
-        high: 16384
-        # 2x high, continuing the doubling ladder; also the model's budget cap
-        # and the >32k-needs-batch boundary. Pro only: Flash caps at 24576, so
-        # an xhigh there could not mean the same number.
-        xhigh: 32768
-        dynamic: -1
-
-  gemini-2-5-flash:
-    provider: gemini
-    thinking:
-      mechanism: gemini
-      rungs:
-        none: 0
-        low: 4096
-        high: 16384
-        dynamic: -1
-
-  gemini-3:
-    provider: gemini
-    notes: >-
-      The 3.x line replaced thinking_budget with thinking_level, whose floor
-      (minimal) does not guarantee thinking is off, so `none` is
-      unsatisfiable. `dynamic` keeps the budget -1 wire shape that every
-      published 3.x run has used.
-    thinking:
-      mechanism: gemini
-      rungs:
-        low: low
-        high: high
-        dynamic: -1
-      # thinking_level has not been exercised live from this codebase yet.
-      unverified: [low, high]
-
-  openai-gpt-5:
-    provider: openai
-    thinking:
-      mechanism: openai-effort
-      rungs:
-        none: none
-        low: low
-        high: high
-        xhigh: xhigh
-      # none/xhigh support varies by point release; unproven live here.
-      unverified: [none, xhigh]
-
-  openai-o-series:
-    provider: openai
-    notes: >-
-      The o-series exposes only a depth knob (reasoning_effort),
-      never an off switch, so `none` is unsatisfiable.
-    thinking:
-      mechanism: openai-effort
-      rungs:
-        low: low
-        high: high
-
-  together-internal-reasoner:
-    provider: together
-    notes: >-
-      Open-weight always-on reasoners (DeepSeek, Kimi): the chain of thought
-      is internal and there is no wire knob, so `dynamic` is the only
-      expressible condition and it sends nothing.
-    thinking:
-      mechanism: noop
-      rungs:
-        dynamic: null
+# Reasoning conditions do NOT live here: every configured arm and role states
+# its provider-native thinking parameters in the config YAML itself, so a
+# reviewer can read what was sent without consulting a mapping. See
+# docs/thinking.md.
 
 models:
-  # --- Anthropic, adaptive tiers ---
+  # --- Anthropic ---
   claude-opus-4-6:
-    family: anthropic-adaptive-4-6
+    provider: anthropic
     pricing: {}
   claude-sonnet-4-6:
-    family: anthropic-adaptive-4-6
+    provider: anthropic
     pricing: {}
   claude-opus-4-7:
-    family: anthropic-adaptive-4-7-plus
+    provider: anthropic
     pricing: {}
   claude-opus-4-8:
-    family: anthropic-adaptive-4-7-plus
+    provider: anthropic
     pricing: {}
   claude-sonnet-5:
-    family: anthropic-sonnet-5
+    provider: anthropic
     pricing: {}
-
-  # --- Anthropic, frozen legacy (enabled+budget) set ---
   claude-3-7-sonnet:
-    family: anthropic-legacy
+    provider: anthropic
     pricing: {}
   claude-haiku-4-5:
-    family: anthropic-legacy
+    provider: anthropic
     # Verified against the Models API (client.models.retrieve(id).max_tokens)
     # on 2026-08-17; re-check there rather than trusting this value if the
     # model 400s on max_tokens.
     max_output_cap: 64000
     pricing: {}
   claude-opus-4-0:
-    family: anthropic-legacy
+    provider: anthropic
     pricing: {}
   claude-opus-4-20250514:
-    family: anthropic-legacy
+    provider: anthropic
     pricing: {}
   claude-opus-4-1:
-    family: anthropic-legacy
+    provider: anthropic
     pricing: {}
   claude-opus-4-5:
-    family: anthropic-legacy
+    provider: anthropic
     pricing: {}
   claude-sonnet-4-0:
-    family: anthropic-legacy
+    provider: anthropic
     pricing: {}
   claude-sonnet-4-20250514:
-    family: anthropic-legacy
+    provider: anthropic
     pricing: {}
   claude-sonnet-4-5:
-    family: anthropic-legacy
+    provider: anthropic
     pricing: {}
 
   # --- Gemini ---
   gemini-2.5-pro:
-    family: gemini-2-5-pro
+    provider: gemini
     pricing: {}
   gemini-2.5-flash:
-    family: gemini-2-5-flash
+    provider: gemini
     pricing: {}
   gemini-3.5-flash:
-    family: gemini-3
+    provider: gemini
     pricing: {}
 
   # --- OpenAI ---
   gpt-5.4-mini:
-    family: openai-gpt-5
+    provider: openai
     pricing: {}
   gpt-5.5:
-    family: openai-gpt-5
+    provider: openai
     pricing: {}
   o1:
-    family: openai-o-series
+    provider: openai
     pricing: {}
   o3:
-    family: openai-o-series
+    provider: openai
     pricing: {}
   o4:
-    family: openai-o-series
+    provider: openai
     pricing: {}
 
   # --- Together (open-weight) ---
   deepseek-ai/DeepSeek-V4-Pro:
-    family: together-internal-reasoner
+    provider: together
     pricing: {}

--- a/src/tutormoments/models.yaml
+++ b/src/tutormoments/models.yaml
@@ -1,0 +1,271 @@
+# Model registry: the single place a model is defined for this benchmark.
+#
+# BENCHMARK-DEFINING CONFIGURATION. The thinking-ladder wire mappings below
+# decide what is actually sent to each provider for every benchmarked
+# condition; changing a rung changes the experiment. Never edit without
+# consulting the benchmark owner (see AGENTS.md), and verify new or changed
+# rungs against the live API with `tutormoments smoke` before relying on them.
+#
+# Two sections:
+#
+#   families: a capability *shape* shared by models -- which provider, which
+#     thinking mechanism the API exposes, and how each canonical ladder rung
+#     (none/minimal/low/medium/high/xhigh/max/dynamic) translates to the wire.
+#     A rung that is absent is unsatisfiable on that family and is rejected at
+#     config load. `unverified` lists rungs whose wire form is documented but
+#     has not yet been proven against the live API -- they are rejected with a
+#     "not yet verified" error until someone runs `tutormoments smoke` on them
+#     and removes them from the list.
+#
+#   models: one entry per model. The key is matched against configured model
+#     ids case-insensitively, exact id first, then longest matching prefix
+#     (so `claude-haiku-4-5-20251001` resolves to the `claude-haiku-4-5`
+#     entry). Each entry names its family and carries per-model facts:
+#     `max_output_cap` (requests above it are rejected by the API) and
+#     `pricing` (per-MTok token costs -- populated by the cost-tracking
+#     workstream; empty means "not priced yet", never "free").
+#
+# Mechanisms (interpreted by models.py):
+#   anthropic-adaptive: rung values are `omit` (send no thinking param),
+#     `disabled` ({"type": "disabled"}), `adaptive` ({"type": "adaptive"}, no
+#     effort), or an effort level ({"type": "adaptive"} + output_config.effort).
+#   anthropic-budget: rung values are `omit` or an integer budget
+#     ({"type": "enabled", "budget_tokens": N}; the client keeps max_tokens at
+#     least N + 64 as the API requires).
+#   gemini: integer rung values map to thinking_config.thinking_budget
+#     (-1 = model-paced dynamic; 0 = off, sent with include_thoughts: false);
+#     string values map to thinking_config.thinking_level (Gemini 3.x --
+#     thinking_level and thinking_budget are mutually exclusive on the wire).
+#   openai-effort: rung values map to reasoning_effort.
+#   noop: the model reasons internally and exposes no knob; the only
+#     expressible condition is `dynamic`, which sends nothing.
+#
+# The shared budget ladder (minimal=1024, low=4096, medium=8192, high=16384,
+# max=provider cap) is anchored in provider guidance: 1,024 is Anthropic's
+# documented minimum budget, 16k+ its complex-task guidance (and where the
+# literature finds diminishing returns), and >32k requires batch processing.
+# See docs/thinking.md for sources.
+
+families:
+  anthropic-adaptive-4-6:
+    provider: anthropic
+    thinking:
+      mechanism: anthropic-adaptive
+      # The 4.6 tier has no xhigh effort level.
+      rungs:
+        none: omit
+        low: low
+        medium: medium
+        high: high
+        max: max
+        dynamic: adaptive
+
+  anthropic-adaptive-4-7-plus:
+    provider: anthropic
+    thinking:
+      mechanism: anthropic-adaptive
+      rungs:
+        none: omit
+        low: low
+        medium: medium
+        high: high
+        xhigh: xhigh
+        max: max
+        dynamic: adaptive
+
+  anthropic-sonnet-5:
+    provider: anthropic
+    thinking:
+      mechanism: anthropic-adaptive
+      # Sonnet 5 defaults to adaptive thinking when the param is omitted, so
+      # "off" must be stated explicitly ({"type": "disabled"}), unlike the
+      # omit-means-off 4.x adaptive tiers.
+      rungs:
+        none: disabled
+        low: low
+        medium: medium
+        high: high
+        xhigh: xhigh
+        max: max
+        dynamic: adaptive
+
+  anthropic-legacy:
+    provider: anthropic
+    # Closed, frozen set of pre-adaptive models (extended thinking via
+    # enabled+budget_tokens only; the effort parameter is rejected).
+    thinking:
+      mechanism: anthropic-budget
+      rungs:
+        none: omit
+        minimal: 1024
+        low: 4096
+        medium: 8192
+        high: 16384
+        max: 32768
+
+  gemini-2-5-pro:
+    provider: gemini
+    notes: >-
+      Always-thinking: the API rejects thinking_budget: 0, so `none` is
+      unsatisfiable.
+    thinking:
+      mechanism: gemini
+      rungs:
+        minimal: 1024
+        low: 4096
+        medium: 8192
+        high: 16384
+        max: 32768
+        dynamic: -1
+
+  gemini-2-5-flash:
+    provider: gemini
+    thinking:
+      mechanism: gemini
+      rungs:
+        none: 0
+        minimal: 1024
+        low: 4096
+        medium: 8192
+        high: 16384
+        max: 24576
+        dynamic: -1
+
+  gemini-3:
+    provider: gemini
+    notes: >-
+      The 3.x line replaced thinking_budget with thinking_level, whose floor
+      (minimal) does not guarantee thinking is off, so `none` is
+      unsatisfiable. `dynamic` keeps the budget -1 wire shape that every
+      published 3.x run has used.
+    thinking:
+      mechanism: gemini
+      rungs:
+        minimal: minimal
+        low: low
+        medium: medium
+        high: high
+        dynamic: -1
+      # thinking_level has not been exercised live from this codebase yet.
+      unverified: [minimal, low, medium, high]
+
+  openai-gpt-5:
+    provider: openai
+    thinking:
+      mechanism: openai-effort
+      rungs:
+        none: none
+        minimal: minimal
+        low: low
+        medium: medium
+        high: high
+        xhigh: xhigh
+      # none/minimal/xhigh support varies by point release; unproven live here.
+      unverified: [none, minimal, xhigh]
+
+  openai-o-series:
+    provider: openai
+    notes: >-
+      The o-series exposes only a depth knob (reasoning_effort
+      low/medium/high), never an off switch, so `none` is unsatisfiable.
+    thinking:
+      mechanism: openai-effort
+      rungs:
+        low: low
+        medium: medium
+        high: high
+
+  together-internal-reasoner:
+    provider: together
+    notes: >-
+      Open-weight always-on reasoners (DeepSeek, Kimi): the chain of thought
+      is internal and there is no wire knob, so `dynamic` is the only
+      expressible condition and it sends nothing.
+    thinking:
+      mechanism: noop
+      rungs:
+        dynamic: null
+
+models:
+  # --- Anthropic, adaptive tiers ---
+  claude-opus-4-6:
+    family: anthropic-adaptive-4-6
+    pricing: {}
+  claude-sonnet-4-6:
+    family: anthropic-adaptive-4-6
+    pricing: {}
+  claude-opus-4-7:
+    family: anthropic-adaptive-4-7-plus
+    pricing: {}
+  claude-opus-4-8:
+    family: anthropic-adaptive-4-7-plus
+    pricing: {}
+  claude-sonnet-5:
+    family: anthropic-sonnet-5
+    pricing: {}
+
+  # --- Anthropic, frozen legacy (enabled+budget) set ---
+  claude-3-7-sonnet:
+    family: anthropic-legacy
+    pricing: {}
+  claude-haiku-4-5:
+    family: anthropic-legacy
+    # Verified against the Models API (client.models.retrieve(id).max_tokens)
+    # on 2026-08-17; re-check there rather than trusting this value if the
+    # model 400s on max_tokens.
+    max_output_cap: 64000
+    pricing: {}
+  claude-opus-4-0:
+    family: anthropic-legacy
+    pricing: {}
+  claude-opus-4-20250514:
+    family: anthropic-legacy
+    pricing: {}
+  claude-opus-4-1:
+    family: anthropic-legacy
+    pricing: {}
+  claude-opus-4-5:
+    family: anthropic-legacy
+    pricing: {}
+  claude-sonnet-4-0:
+    family: anthropic-legacy
+    pricing: {}
+  claude-sonnet-4-20250514:
+    family: anthropic-legacy
+    pricing: {}
+  claude-sonnet-4-5:
+    family: anthropic-legacy
+    pricing: {}
+
+  # --- Gemini ---
+  gemini-2.5-pro:
+    family: gemini-2-5-pro
+    pricing: {}
+  gemini-2.5-flash:
+    family: gemini-2-5-flash
+    pricing: {}
+  gemini-3.5-flash:
+    family: gemini-3
+    pricing: {}
+
+  # --- OpenAI ---
+  gpt-5.4-mini:
+    family: openai-gpt-5
+    pricing: {}
+  gpt-5.5:
+    family: openai-gpt-5
+    pricing: {}
+  o1:
+    family: openai-o-series
+    pricing: {}
+  o3:
+    family: openai-o-series
+    pricing: {}
+  o4:
+    family: openai-o-series
+    pricing: {}
+
+  # --- Together (open-weight) ---
+  deepseek-ai/DeepSeek-V4-Pro:
+    family: together-internal-reasoner
+    pricing: {}

--- a/src/tutormoments/models.yaml
+++ b/src/tutormoments/models.yaml
@@ -104,6 +104,10 @@ families:
       rungs:
         low: 4096
         high: 16384
+        # 2x high, continuing the doubling ladder; also the model's budget cap
+        # and the >32k-needs-batch boundary. Pro only: Flash caps at 24576, so
+        # an xhigh there could not mean the same number.
+        xhigh: 32768
         dynamic: -1
 
   gemini-2-5-flash:

--- a/src/tutormoments/models.yaml
+++ b/src/tutormoments/models.yaml
@@ -10,7 +10,7 @@
 #
 #   families: a capability *shape* shared by models -- which provider, which
 #     thinking mechanism the API exposes, and how each canonical ladder rung
-#     (none/minimal/low/medium/high/xhigh/max/dynamic) translates to the wire.
+#     (none/low/high/xhigh/dynamic) translates to the wire.
 #     A rung that is absent is unsatisfiable on that family and is rejected at
 #     config load. `unverified` lists rungs whose wire form is documented but
 #     has not yet been proven against the live API -- they are rejected with a
@@ -40,11 +40,11 @@
 #   noop: the model reasons internally and exposes no knob; the only
 #     expressible condition is `dynamic`, which sends nothing.
 #
-# The shared budget ladder (minimal=1024, low=4096, medium=8192, high=16384,
-# max=provider cap) is anchored in provider guidance: 1,024 is Anthropic's
-# documented minimum budget, 16k+ its complex-task guidance (and where the
-# literature finds diminishing returns), and >32k requires batch processing.
-# See docs/thinking.md for sources.
+# The shared budget ladder (low=4096, high=16384) is anchored in provider
+# guidance: 16k+ is Anthropic's complex-task guidance (and where the
+# literature finds diminishing returns). The ladder is deliberately small --
+# a rung exists only when an experiment needs it; add one as a reviewed
+# registry line verified with `tutormoments smoke`. See docs/thinking.md.
 
 families:
   anthropic-adaptive-4-6:
@@ -55,9 +55,7 @@ families:
       rungs:
         none: omit
         low: low
-        medium: medium
         high: high
-        max: max
         dynamic: adaptive
 
   anthropic-adaptive-4-7-plus:
@@ -67,10 +65,8 @@ families:
       rungs:
         none: omit
         low: low
-        medium: medium
         high: high
         xhigh: xhigh
-        max: max
         dynamic: adaptive
 
   anthropic-sonnet-5:
@@ -83,10 +79,8 @@ families:
       rungs:
         none: disabled
         low: low
-        medium: medium
         high: high
         xhigh: xhigh
-        max: max
         dynamic: adaptive
 
   anthropic-legacy:
@@ -97,11 +91,8 @@ families:
       mechanism: anthropic-budget
       rungs:
         none: omit
-        minimal: 1024
         low: 4096
-        medium: 8192
         high: 16384
-        max: 32768
 
   gemini-2-5-pro:
     provider: gemini
@@ -111,11 +102,8 @@ families:
     thinking:
       mechanism: gemini
       rungs:
-        minimal: 1024
         low: 4096
-        medium: 8192
         high: 16384
-        max: 32768
         dynamic: -1
 
   gemini-2-5-flash:
@@ -124,11 +112,8 @@ families:
       mechanism: gemini
       rungs:
         none: 0
-        minimal: 1024
         low: 4096
-        medium: 8192
         high: 16384
-        max: 24576
         dynamic: -1
 
   gemini-3:
@@ -141,13 +126,11 @@ families:
     thinking:
       mechanism: gemini
       rungs:
-        minimal: minimal
         low: low
-        medium: medium
         high: high
         dynamic: -1
       # thinking_level has not been exercised live from this codebase yet.
-      unverified: [minimal, low, medium, high]
+      unverified: [low, high]
 
   openai-gpt-5:
     provider: openai
@@ -155,24 +138,21 @@ families:
       mechanism: openai-effort
       rungs:
         none: none
-        minimal: minimal
         low: low
-        medium: medium
         high: high
         xhigh: xhigh
-      # none/minimal/xhigh support varies by point release; unproven live here.
-      unverified: [none, minimal, xhigh]
+      # none/xhigh support varies by point release; unproven live here.
+      unverified: [none, xhigh]
 
   openai-o-series:
     provider: openai
     notes: >-
-      The o-series exposes only a depth knob (reasoning_effort
-      low/medium/high), never an off switch, so `none` is unsatisfiable.
+      The o-series exposes only a depth knob (reasoning_effort),
+      never an off switch, so `none` is unsatisfiable.
     thinking:
       mechanism: openai-effort
       rungs:
         low: low
-        medium: medium
         high: high
 
   together-internal-reasoner:

--- a/src/tutormoments/prompts/smoke/ping.md
+++ b/src/tutormoments/prompts/smoke/ping.md
@@ -1,0 +1,3 @@
+A student has 3 boxes with 8 pencils each. They give away 5 pencils and then
+buy 2 more boxes. How many pencils do they have now? Think it through, then
+answer in one short sentence.

--- a/src/tutormoments/prompts/smoke/ping_json.md
+++ b/src/tutormoments/prompts/smoke/ping_json.md
@@ -1,0 +1,3 @@
+A student has 3 boxes with 8 pencils each. They give away 5 pencils and then
+buy 2 more boxes. Work out how many pencils they have now, then respond with
+exactly one JSON object of the form {"pencils": <integer>} and nothing else.

--- a/src/tutormoments/report.py
+++ b/src/tutormoments/report.py
@@ -187,6 +187,7 @@ def leaderboard_row(summary_or_metrics: dict) -> dict:
 _LEADERBOARD_COLS = [
     # (summary_key, header_label)
     ("tutor_model", "tutor_model"),
+    ("condition", "condition"),
     ("mode", "mode"),
     ("n", "n"),
     ("appropriate_scaffolding", "appropriate_scaffolding"),
@@ -235,6 +236,7 @@ def _extract_row(summary: dict, probes: dict | None = None) -> dict:
 
     return {
         "tutor_model": tutor_model,
+        "condition": summary.get("condition", ""),
         "mode": mode,
         "n": summary.get("n_scenarios", 0),
         "appropriate_scaffolding": cal_s.get("score"),
@@ -535,6 +537,8 @@ tr:hover td { background: #f9f9fc; }
 <div class="controls">
   <span><label>Filter model</label>
   <select id="model-filter"><option value="">All models</option></select></span>
+  <span><label>Filter condition</label>
+  <select id="condition-filter"><option value="">All conditions</option></select></span>
   <span><label>Filter mode</label>
   <select id="mode-filter"><option value="">All modes</option></select></span>
 </div>
@@ -542,6 +546,7 @@ tr:hover td { background: #f9f9fc; }
   <thead>
     <tr>
       <th>tutor_model</th>
+      <th>condition</th>
       <th>mode</th>
       <th class="num">n</th>
       <th class="num">appropriate_scaffolding</th>
@@ -585,6 +590,7 @@ function buildRow(r, isTop) {
   return (
     '<tr' + rowCls + '>' +
     '<td>' + (r.tutor_model || '') + '</td>' +
+    '<td>' + (r.condition || '') + '</td>' +
     '<td>' + (r.mode || '') + '</td>' +
     cell(r.n, '', 0) +
     cell(r.appropriate_scaffolding, '') +
@@ -599,9 +605,11 @@ function buildRow(r, isTop) {
 
 function render() {
   const mf = document.getElementById('model-filter').value;
+  const cf = document.getElementById('condition-filter').value;
   const pf = document.getElementById('mode-filter').value;
   const filtered = RUNS.filter(r =>
     (!mf || r.tutor_model === mf) &&
+    (!cf || r.condition === cf) &&
     (!pf || r.mode === pf)
   );
   // Sorted desc by appropriate_scaffolding (null last) -- already sorted
@@ -619,14 +627,19 @@ function render() {
 
 // Populate filter dropdowns
 const models = [...new Set(RUNS.map(r => r.tutor_model).filter(Boolean))].sort();
+const conditions = [...new Set(RUNS.map(r => r.condition).filter(Boolean))].sort();
 const modes  = [...new Set(RUNS.map(r => r.mode).filter(Boolean))].sort();
 models.forEach(m => {
   document.getElementById('model-filter').add(new Option(m, m));
+});
+conditions.forEach(c => {
+  document.getElementById('condition-filter').add(new Option(c, c));
 });
 modes.forEach(m => {
   document.getElementById('mode-filter').add(new Option(m, m));
 });
 document.getElementById('model-filter').addEventListener('change', render);
+document.getElementById('condition-filter').addEventListener('change', render);
 document.getElementById('mode-filter').addEventListener('change', render);
 
 render();

--- a/src/tutormoments/scoring.py
+++ b/src/tutormoments/scoring.py
@@ -817,7 +817,7 @@ def _build_structure_entries(
 #   Pass 3 (structure): build action entries in one batch,
 #                       assign action_label back onto the annotation dict
 #
-# Scorer model/params from config.scorer_spec() (claude-opus-4-6, thinking=dynamic).
+# Scorer model/params from config.scorer_spec() (claude-opus-4-6, adaptive thinking).
 # context_window=0 always (benchmark-only override; see annotate pass docstring).
 # Usage accumulated across all 3 passes is attached as Annotation.usage.
 # ---------------------------------------------------------------------------

--- a/src/tutormoments/scoring.py
+++ b/src/tutormoments/scoring.py
@@ -817,7 +817,7 @@ def _build_structure_entries(
 #   Pass 3 (structure): build action entries in one batch,
 #                       assign action_label back onto the annotation dict
 #
-# Scorer model/params from config.scorer_spec() (claude-opus-4-6, thinking=adaptive).
+# Scorer model/params from config.scorer_spec() (claude-opus-4-6, thinking=dynamic).
 # context_window=0 always (benchmark-only override; see annotate pass docstring).
 # Usage accumulated across all 3 passes is attached as Annotation.usage.
 # ---------------------------------------------------------------------------
@@ -848,9 +848,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
         return {}
 
     spec = scorer_spec()
-    scorer_model = spec["model"]
-    thinking_mode = spec.get("thinking", "adaptive")
-    use_thinking = thinking_mode in ("adaptive", "enabled", True)
+    scorer_model = spec.model
 
     client = ModelClient(scorer_model)
 
@@ -903,7 +901,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
         annotate_entries,
         display_name="scorer_annotate",
         poll_interval=60,
-        thinking=use_thinking,
+        thinking=spec.thinking,
     )
 
     parsed = _parse_and_merge(annotate_raw, dict(detections))
@@ -956,7 +954,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
             decompose_entries,
             display_name="scorer_decompose",
             poll_interval=60,
-            thinking=use_thinking,
+            thinking=spec.thinking,
         )
     else:
         logger.info("Classification pass 2/3 (decompose): skipped, no entries")
@@ -1008,7 +1006,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
             structure_entries,
             display_name="scorer_structure",
             poll_interval=60,
-            thinking=use_thinking,
+            thinking=spec.thinking,
         )
     else:
         logger.info("Classification pass 3/3 (structure): skipped, no entries")

--- a/src/tutormoments/smoke.py
+++ b/src/tutormoments/smoke.py
@@ -129,7 +129,9 @@ def build_smoke_plan(
         return providers is None or provider in providers
 
     if "tutor" in roles:
-        arm_names = arms if arms is not None else list(cfg.get("models") or {})
+        arm_names = arms if arms is not None else list(
+            cfg.get("benchmark_models") or cfg.get("models") or {}
+        )
         for name in arm_names:
             arm = resolve_arm(name, config_path)  # raises on unknown arm
             if _selected(arm.provider):

--- a/src/tutormoments/smoke.py
+++ b/src/tutormoments/smoke.py
@@ -1,0 +1,437 @@
+"""Live smoke checks: verify the active config's real wire formats.
+
+The offline test suite mocks every provider SDK, so it can prove the code
+agrees with itself but never that a provider accepts what we send. This
+module is the live half: one tiny real call per configured arm/role (and one
+submit-then-cancel batch per provider) with the arm's EXACT configured
+thinking condition. Run it via `tutormoments smoke` before merging changes to
+core API logic (see AGENTS.md).
+
+It deliberately calls only models already present in the active config --
+choosing models is the benchmark owner's job, never this tool's.
+
+Three layers, so the logic itself stays testable offline:
+  build_smoke_plan()  -- pure: config -> checks
+  run_smoke()         -- executes checks via an injectable client factory
+  format_smoke_report() / SmokeReport.to_json()
+"""
+
+import datetime
+import json
+import logging
+from dataclasses import dataclass, field
+
+from tutormoments.models import ThinkingLevel, resolve_thinking
+from tutormoments.resources import resource_text
+
+logger = logging.getLogger(__name__)
+
+_BATCH_PROVIDERS = ("gemini", "openai", "anthropic")
+
+PASS = "PASS"
+WARN = "WARN"
+FAIL = "FAIL"
+
+
+@dataclass(frozen=True)
+class SyncCheck:
+    label: str  # e.g. "arm:claude-opus-4-8" or "student"
+    model: str
+    provider: str
+    thinking: "ThinkingLevel | None"
+    json_mode: bool
+
+
+@dataclass(frozen=True)
+class BatchCheck:
+    provider: str
+    model: str
+    thinking: "ThinkingLevel | None"
+
+
+@dataclass
+class SmokePlan:
+    sync_checks: list
+    batch_checks: list
+    skipped: list  # (label, reason) pairs surfaced in the report
+
+
+@dataclass
+class CheckResult:
+    label: str
+    model: str
+    provider: str
+    wire: str
+    status: str
+    detail: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    thinking_evidence: str = ""
+    batch_id: str = ""
+
+
+@dataclass
+class SmokeReport:
+    results: list = field(default_factory=list)
+    started_at: str = ""
+    config_source: str = ""
+
+    @property
+    def failed(self) -> bool:
+        return any(r.status == FAIL for r in self.results)
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "started_at": self.started_at,
+                "config_source": self.config_source,
+                "results": [vars(r) for r in self.results],
+            },
+            indent=2,
+            default=str,
+        )
+
+
+def build_smoke_plan(
+    config_path=None,
+    arms: "list[str] | None" = None,
+    roles: "list[str] | None" = None,
+    providers: "list[str] | None" = None,
+    include_sync: bool = True,
+    include_batch: bool = True,
+) -> SmokePlan:
+    """Enumerate the checks for the active config (pure; no network).
+
+    arms/roles/providers narrow the selection. Roles are from
+    {tutor, student, scorer, taxonomy, groundtruth}. An unknown arm name
+    raises ValueError (exit code 2 territory -- a typo must not smoke-pass).
+    """
+    from tutormoments.config import (
+        get_groundtruth_phase_config,
+        get_registered_student,
+        load_config,
+        resolve_arm,
+        scorer_spec,
+        student_spec,
+        taxonomy_spec,
+    )
+
+    cfg = load_config(config_path)
+    roles = (
+        list(roles)
+        if roles
+        else ["tutor", "student", "scorer", "taxonomy", "groundtruth"]
+    )
+    sync_checks: list[SyncCheck] = []
+    skipped: list[tuple[str, str]] = []
+
+    def _selected(provider: str) -> bool:
+        return providers is None or provider in providers
+
+    if "tutor" in roles:
+        arm_names = arms if arms is not None else list(cfg.get("models") or {})
+        for name in arm_names:
+            arm = resolve_arm(name, config_path)  # raises on unknown arm
+            if _selected(arm.provider):
+                sync_checks.append(
+                    SyncCheck(
+                        label=f"arm:{name}",
+                        model=arm.model,
+                        provider=arm.provider,
+                        thinking=arm.thinking,
+                        json_mode=False,  # tutor turns run json_mode=False
+                    )
+                )
+    elif arms:
+        raise ValueError("--arms requires the tutor role in --roles")
+
+    def _role_check(role: str, model: str, thinking, json_mode: bool):
+        from tutormoments.models import infer_provider
+
+        provider = infer_provider(model)
+        if _selected(provider):
+            sync_checks.append(
+                SyncCheck(
+                    label=role,
+                    model=model,
+                    provider=provider,
+                    thinking=thinking,
+                    json_mode=json_mode,
+                )
+            )
+
+    if "student" in roles and cfg.get("student"):
+        spec = student_spec(config_path)
+        if get_registered_student(spec.model) is not None:
+            skipped.append(("student", f"registered student '{spec.model}' (no API)"))
+        else:
+            _role_check("student", spec.model, spec.thinking, json_mode=False)
+    if "scorer" in roles and cfg.get("scorer"):
+        spec = scorer_spec(config_path)
+        _role_check("scorer", spec.model, spec.thinking, json_mode=True)
+    if "taxonomy" in roles and cfg.get("taxonomy"):
+        spec = taxonomy_spec(config_path)
+        _role_check("taxonomy", spec.model, spec.thinking, json_mode=True)
+    if "groundtruth" in roles and cfg.get("groundtruth"):
+        spec = get_groundtruth_phase_config(config_path)
+        _role_check("groundtruth", spec.model, spec.thinking, json_mode=True)
+
+    batch_checks: list[BatchCheck] = []
+    if include_batch:
+        # One representative per provider present in the sync selection: the
+        # real batch consumers are the scorer/groundtruth paths, so prefer
+        # those models for their providers; else the provider's first check.
+        preferred: dict[str, SyncCheck] = {}
+        for check in sync_checks:
+            if (
+                check.label in ("scorer", "groundtruth")
+                or check.provider not in preferred
+            ):
+                if check.provider not in preferred or check.label in (
+                    "scorer",
+                    "groundtruth",
+                ):
+                    preferred[check.provider] = check
+        for provider, check in preferred.items():
+            if provider in _BATCH_PROVIDERS:
+                batch_checks.append(
+                    BatchCheck(
+                        provider=provider, model=check.model, thinking=check.thinking
+                    )
+                )
+            else:
+                skipped.append((f"batch:{provider}", "provider has no batch API"))
+
+    return SmokePlan(
+        sync_checks=sync_checks if include_sync else [],
+        batch_checks=batch_checks,
+        skipped=skipped,
+    )
+
+
+def _thinking_expectation(wire, level) -> str:
+    """What the wire fragment promises: required / optional / off / na."""
+    if level is None:
+        return "na"
+    if wire.gemini_thinking_config is not None:
+        cfgd = wire.gemini_thinking_config
+        budget = cfgd.get("thinking_budget")
+        if budget == 0:
+            return "off"
+        if budget == -1:
+            return "optional"
+        return "required"  # positive budget or thinking_level string
+    if wire.anthropic_thinking is not None:
+        kind = wire.anthropic_thinking.get("type")
+        if kind == "disabled":
+            return "off"
+        if kind == "enabled":
+            return "required"
+        return "optional"  # adaptive: the model decides
+    if wire.openai_reasoning_effort is not None:
+        return "off" if wire.openai_reasoning_effort == "none" else "required"
+    if level == ThinkingLevel.NONE:
+        return "off"  # omit-style off (anthropic 4.x tiers)
+    return "na"  # noop mechanism (together internal reasoners)
+
+
+def _thinking_evidence(usage: dict) -> "int | None":
+    """Wire-level evidence that thinking happened, or None when unobservable."""
+    reasoning = usage.get("reasoning", 0) or 0
+    if reasoning:
+        return int(reasoning)
+    if "thinking_blocks" in usage:
+        return int(usage.get("thinking_blocks") or 0)
+    # OpenAI/Gemini report reasoning tokens in the `reasoning` bucket; zero
+    # there IS the observation. Together never reports one.
+    if usage.get("provider") == "together":
+        return None
+    return int(reasoning)
+
+
+def _judge_thinking(expectation: str, evidence, strict: bool) -> tuple[str, str]:
+    """(status, note) from the expectation vs the observed evidence."""
+    if expectation == "na" or evidence is None:
+        return PASS, ""
+    if expectation == "required" and evidence == 0:
+        return FAIL, "thinking knob sent but no thinking observed"
+    if expectation == "off" and evidence > 0:
+        return FAIL, "thinking observed under a thinking-off condition"
+    if expectation == "optional" and evidence == 0:
+        status = FAIL if strict else WARN
+        return status, "model-paced thinking produced no observed thinking"
+    return PASS, ""
+
+
+def run_smoke(
+    plan: SmokePlan,
+    *,
+    client_factory=None,
+    submit_batch_fn=None,
+    cancel_batch_fn=None,
+    strict_thinking: bool = False,
+    max_tokens: int = 0,
+    config_source: str = "",
+) -> SmokeReport:
+    """Execute the plan. One check's failure never aborts the others."""
+    from tutormoments import client as client_mod
+
+    if client_factory is None:
+        client_factory = client_mod.get_client
+    if submit_batch_fn is None:
+        submit_batch_fn = client_mod.submit_batch
+    if cancel_batch_fn is None:
+        cancel_batch_fn = client_mod.cancel_batch
+
+    report = SmokeReport(
+        started_at=datetime.datetime.now().isoformat(timespec="seconds"),
+        config_source=config_source,
+    )
+
+    ping = resource_text("prompts/smoke/ping.md").strip()
+    ping_json = resource_text("prompts/smoke/ping_json.md").strip()
+
+    for check in plan.sync_checks:
+        wire = resolve_thinking(check.model, check.thinking)
+        row = CheckResult(
+            label=check.label,
+            model=check.model,
+            provider=check.provider,
+            wire=wire.describe(),
+            status=PASS,
+        )
+        try:
+            client = client_factory(check.model)
+            resp = client.generate(
+                ping_json if check.json_mode else ping,
+                json_mode=check.json_mode,
+                max_tokens=max_tokens,
+                thinking=check.thinking,
+            )
+            usage = resp.usage or {}
+            row.input_tokens = int(usage.get("input_tokens", 0) or 0)
+            row.output_tokens = int(usage.get("output_tokens", 0) or 0)
+            if not (resp.text or "").strip():
+                row.status = FAIL
+                row.detail = "empty response text"
+            elif not usage.get("total_tokens") and not usage.get("total"):
+                row.status = FAIL
+                row.detail = "no token usage recorded"
+            else:
+                expectation = _thinking_expectation(wire, check.thinking)
+                evidence = _thinking_evidence(usage)
+                row.thinking_evidence = "n/a" if evidence is None else str(evidence)
+                status, note = _judge_thinking(expectation, evidence, strict_thinking)
+                row.status = status
+                row.detail = note
+        except Exception as e:  # noqa: BLE001 -- isolate per check
+            row.status = FAIL
+            row.detail = f"{type(e).__name__}: {e}"
+        report.results.append(row)
+
+    for check in plan.batch_checks:
+        wire = resolve_thinking(check.model, check.thinking)
+        row = CheckResult(
+            label=f"batch:{check.provider}",
+            model=check.model,
+            provider=check.provider,
+            wire=wire.describe(),
+            status=PASS,
+        )
+        try:
+            client = client_factory(check.model)
+            entries = [
+                client_mod.build_batch_entry(f"smoke-{i}", ping_json, json_mode=True)
+                for i in range(2)
+            ]
+            batch_id = submit_batch_fn(
+                client,
+                entries,
+                json_mode=True,
+                display_name="tutormoments-smoke",
+                thinking=check.thinking,
+            )
+            row.batch_id = str(batch_id)
+            if not batch_id:
+                row.status = FAIL
+                row.detail = "submission returned no batch id"
+            else:
+                try:
+                    cancel_batch_fn(client, batch_id)
+                    row.detail = "submitted and cancelled"
+                except Exception as e:  # noqa: BLE001 -- submission already proven
+                    row.status = WARN
+                    row.detail = (
+                        f"submitted ok; cancel failed ({type(e).__name__}: {e}). "
+                        "Cancel it manually; provider batches expire in 24h."
+                    )
+        except Exception as e:  # noqa: BLE001 -- isolate per check
+            row.status = FAIL
+            row.detail = f"{type(e).__name__}: {e}"
+        report.results.append(row)
+
+    for label, reason in plan.skipped:
+        report.results.append(
+            CheckResult(
+                label=label,
+                model="",
+                provider="",
+                wire="",
+                status="SKIP",
+                detail=reason,
+            )
+        )
+
+    return report
+
+
+def format_smoke_report(report: SmokeReport) -> str:
+    """Render the report as an ASCII table (repo convention: no Unicode)."""
+    headers = (
+        "check",
+        "model",
+        "provider",
+        "wire knobs sent",
+        "in/out tok",
+        "thinking",
+        "result",
+    )
+    rows = []
+    for r in report.results:
+        tok = (
+            f"{r.input_tokens}/{r.output_tokens}"
+            if r.input_tokens or r.output_tokens
+            else ""
+        )
+        rows.append(
+            (
+                r.label,
+                r.model,
+                r.provider,
+                r.wire,
+                tok,
+                r.thinking_evidence,
+                r.status + (f"  {r.detail}" if r.detail else ""),
+            )
+        )
+    widths = [
+        max(len(headers[i]), *(len(row[i]) for row in rows))
+        if rows
+        else len(headers[i])
+        for i in range(len(headers))
+    ]
+    lines = [
+        f"config: {report.config_source}" if report.config_source else "",
+        "  ".join(h.ljust(widths[i]) for i, h in enumerate(headers)).rstrip(),
+        "  ".join("-" * widths[i] for i in range(len(headers))),
+    ]
+    for row in rows:
+        lines.append(
+            "  ".join(row[i].ljust(widths[i]) for i in range(len(row))).rstrip()
+        )
+    n_fail = sum(1 for r in report.results if r.status == FAIL)
+    n_warn = sum(1 for r in report.results if r.status == WARN)
+    n_pass = sum(1 for r in report.results if r.status == PASS)
+    lines.append("")
+    lines.append(f"smoke: {n_pass} passed, {n_warn} warnings, {n_fail} failed")
+    return "\n".join(line for line in lines if line is not None)

--- a/src/tutormoments/smoke.py
+++ b/src/tutormoments/smoke.py
@@ -21,7 +21,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 
-from tutormoments.models import ThinkingLevel, resolve_thinking
+from tutormoments.models import resolve_thinking
 from tutormoments.resources import resource_text
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class SyncCheck:
     label: str  # e.g. "arm:claude-opus-4-8" or "student"
     model: str
     provider: str
-    thinking: "ThinkingLevel | None"
+    thinking: dict | None  # provider-native thinking config from the spec
     json_mode: bool
 
 
@@ -46,7 +46,7 @@ class SyncCheck:
 class BatchCheck:
     provider: str
     model: str
-    thinking: "ThinkingLevel | None"
+    thinking: dict | None
 
 
 @dataclass
@@ -129,8 +129,8 @@ def build_smoke_plan(
         return providers is None or provider in providers
 
     if "tutor" in roles:
-        arm_names = arms if arms is not None else list(
-            cfg.get("benchmark_models") or cfg.get("models") or {}
+        arm_names = (
+            arms if arms is not None else list(cfg.get("benchmark_models") or {})
         )
         for name in arm_names:
             arm = resolve_arm(name, config_path)  # raises on unknown arm
@@ -211,10 +211,13 @@ def build_smoke_plan(
     )
 
 
-def _thinking_expectation(wire, level) -> str:
-    """What the wire fragment promises: required / optional / off / na."""
-    if level is None:
-        return "na"
+def _thinking_expectation(wire) -> str:
+    """What the wire fragment promises: required / optional / off / na.
+
+    Derived from the wire fragment alone. When nothing is sent, the model's
+    own default rules (omit means off on some Anthropic tiers, adaptive on
+    others), so the expectation is unknowable from config: "na".
+    """
     if wire.gemini_thinking_config is not None:
         cfgd = wire.gemini_thinking_config
         budget = cfgd.get("thinking_budget")
@@ -232,9 +235,7 @@ def _thinking_expectation(wire, level) -> str:
         return "optional"  # adaptive: the model decides
     if wire.openai_reasoning_effort is not None:
         return "off" if wire.openai_reasoning_effort == "none" else "required"
-    if level == ThinkingLevel.NONE:
-        return "off"  # omit-style off (anthropic 4.x tiers)
-    return "na"  # noop mechanism (together internal reasoners)
+    return "na"  # nothing sent: provider default / internal reasoners
 
 
 def _thinking_evidence(usage: dict) -> "int | None":
@@ -323,7 +324,7 @@ def run_smoke(
                 row.status = FAIL
                 row.detail = "no token usage recorded"
             else:
-                expectation = _thinking_expectation(wire, check.thinking)
+                expectation = _thinking_expectation(wire)
                 evidence = _thinking_evidence(usage)
                 row.thinking_evidence = "n/a" if evidence is None else str(evidence)
                 status, note = _judge_thinking(expectation, evidence, strict_thinking)

--- a/src/tutormoments/smoke.py
+++ b/src/tutormoments/smoke.py
@@ -240,10 +240,13 @@ def _thinking_evidence(usage: dict) -> "int | None":
     reasoning = usage.get("reasoning", 0) or 0
     if reasoning:
         return int(reasoning)
-    if "thinking_blocks" in usage:
-        return int(usage.get("thinking_blocks") or 0)
-    # OpenAI/Gemini report reasoning tokens in the `reasoning` bucket; zero
-    # there IS the observation. Together never reports one.
+    # Anthropic: thinking blocks; OpenAI: the informational reasoning_tokens
+    # subset of completion_tokens. Either key's presence means the provider
+    # reported the dimension, so zero IS the observation.
+    for key in ("thinking_blocks", "reasoning_tokens"):
+        if key in usage:
+            return int(usage.get(key) or 0)
+    # Together never reports a reasoning dimension at all.
     if usage.get("provider") == "together":
         return None
     return int(reasoning)

--- a/src/tutormoments/student.py
+++ b/src/tutormoments/student.py
@@ -108,7 +108,7 @@ def resolve_student(student_id: str | None = None) -> dict:
     from tutormoments.config import get_registered_student, student_spec
 
     spec = student_spec()
-    model = student_id or spec["model"]
+    model = student_id or spec.model
 
     # FIRST: check registry for either an explicit student_id or config student.model.
     if model is not None:
@@ -120,10 +120,8 @@ def resolve_student(student_id: str | None = None) -> dict:
     # Shared per model (see tutormoments.client.get_client): a fresh client per
     # moment would pay a TLS handshake inside the measured window.
     client = get_client(model)
-    kwargs = {k: v for k, v in spec.items() if k not in {"model", "mode"}}
-    kwargs.setdefault("thinking", False)
     return {
         "kind": "hosted",
         "client": client,
-        "kwargs": kwargs,
+        "kwargs": {"thinking": spec.thinking},
     }

--- a/src/tutormoments/taxonomy.py
+++ b/src/tutormoments/taxonomy.py
@@ -793,18 +793,16 @@ def pool_report(kept: list[Facet], excluded: list[tuple[Facet, str]]) -> str:
 # 5. LLM classifier (resume + checkpoint)
 # ============================================================================
 #
-# Classifies unique statements against the frozen A-M scheme using
-# claude-opus-4-8 with structured-output JSON (the category letter is a
-# schema enum, so the model can't hallucinate one). Statements are
-# deduplicated, batched, and assignments are appended to a sidecar JSONL
+# Classifies unique statements against the frozen A-M scheme using the
+# `taxonomy` config block's model with structured-output JSON (the category
+# letter is a schema enum, so the model can't hallucinate one). Statements
+# are deduplicated, batched, and assignments are appended to a sidecar JSONL
 # so a crash or ctrl-C loses at most the in-flight batch.
 #
 # Designed for two-step operation: a small first-run probe (default 25
 # batches, ~$1) for sanity-checking the distribution, then a resume call
 # (re-run without --max-batches) to finish.
 
-CLASSIFIER_MODEL = "claude-opus-4-8"
-CLASSIFIER_BATCH_SIZE = 50
 CLASSIFIER_MAX_RETRIES = 4
 CLASSIFIER_FIRST_RUN_PROBE = 25
 _CLASSIFIER_PROGRESS_EVERY = 30
@@ -841,9 +839,10 @@ def classify_pool(
             None we build a ModelClient from the `taxonomy` config block
             (requires the provider API key).
         model / thinking / batch_size: override the `taxonomy` config block;
-            each falls back to config (then a module default) when None.
-            `thinking` is a canonical ladder level (ThinkingLevel or its
-            string form), same contract as ModelClient.generate.
+            each falls back to config when None (a missing or broken config
+            raises -- there is no silent module default). `thinking` is a
+            provider-native thinking mapping, same contract as
+            ModelClient.generate.
 
     Returns:
         Mapping from statement -> category letter, covering every statement
@@ -858,21 +857,18 @@ def classify_pool(
     # Resolve model / thinking / batch_size from the taxonomy config block,
     # honoring explicit overrides. Config import is local so `import
     # tutormoments.taxonomy` stays lightweight (no client/provider-SDK import
-    # unless we actually classify).
-    spec = None
-    if client is None or model is None or thinking is None or batch_size is None:
-        try:
-            from tutormoments.config import taxonomy_spec
+    # unless we actually classify). A missing or broken config raises here:
+    # the classifier must never silently substitute its own LM settings.
+    if model is None or thinking is None or batch_size is None:
+        from tutormoments.config import taxonomy_spec
 
-            spec = taxonomy_spec()
-        except Exception:
-            spec = None
-    if model is None:
-        model = spec.model if spec is not None else CLASSIFIER_MODEL
-    if thinking is None and spec is not None:
-        thinking = spec.thinking
-    if batch_size is None:
-        batch_size = spec.batch_size if spec is not None else CLASSIFIER_BATCH_SIZE
+        spec = taxonomy_spec()
+        if model is None:
+            model = spec.model
+        if thinking is None:
+            thinking = spec.thinking
+        if batch_size is None:
+            batch_size = spec.batch_size
 
     statements = sorted(
         {f.statement.strip() for f in kept if f.statement and f.statement.strip()},

--- a/src/tutormoments/taxonomy.py
+++ b/src/tutormoments/taxonomy.py
@@ -818,7 +818,7 @@ def classify_pool(
     first_run_probe: int = CLASSIFIER_FIRST_RUN_PROBE,
     client: Any = None,
     model: Optional[str] = None,
-    thinking: Optional[bool] = None,
+    thinking=None,
     batch_size: Optional[int] = None,
 ) -> dict[str, str]:
     """Classify every unique statement in `kept` into A-M.
@@ -842,6 +842,8 @@ def classify_pool(
             (requires the provider API key).
         model / thinking / batch_size: override the `taxonomy` config block;
             each falls back to config (then a module default) when None.
+            `thinking` is a canonical ladder level (ThinkingLevel or its
+            string form), same contract as ModelClient.generate.
 
     Returns:
         Mapping from statement -> category letter, covering every statement
@@ -857,20 +859,20 @@ def classify_pool(
     # honoring explicit overrides. Config import is local so `import
     # tutormoments.taxonomy` stays lightweight (no client/provider-SDK import
     # unless we actually classify).
-    spec: dict = {}
+    spec = None
     if client is None or model is None or thinking is None or batch_size is None:
         try:
             from tutormoments.config import taxonomy_spec
 
             spec = taxonomy_spec()
         except Exception:
-            spec = {}
+            spec = None
     if model is None:
-        model = spec.get("model", CLASSIFIER_MODEL)
-    if thinking is None:
-        thinking = bool(spec.get("thinking", False))
+        model = spec.model if spec is not None else CLASSIFIER_MODEL
+    if thinking is None and spec is not None:
+        thinking = spec.thinking
     if batch_size is None:
-        batch_size = int(spec.get("batch_size", CLASSIFIER_BATCH_SIZE))
+        batch_size = spec.batch_size if spec is not None else CLASSIFIER_BATCH_SIZE
 
     statements = sorted(
         {f.statement.strip() for f in kept if f.statement and f.statement.strip()},
@@ -913,7 +915,7 @@ def classify_pool(
 
         client = ModelClient(model)
 
-    ask = _make_classifier(client, thinking=bool(thinking))
+    ask = _make_classifier(client, thinking=thinking)
 
     for bi in range(stop_after):
         start = bi * batch_size
@@ -948,7 +950,7 @@ def classify_pool(
     return assigned
 
 
-def _make_classifier(client: Any, *, thinking: bool = False):
+def _make_classifier(client: Any, *, thinking=None):
     """Build a `(statements, label) -> ({stmt: letter}, usage_dict)` callable.
 
     `client` exposes `.generate(...)` (a `tutormoments.client.ModelClient` or a

--- a/src/tutormoments/tutor.py
+++ b/src/tutormoments/tutor.py
@@ -75,26 +75,28 @@ def resolve_tutor(tutor_id: str) -> dict:
     Returns:
         Dictionary with:
         - kind == "registered": {"kind": "registered", "fn": <callable>}
-        - kind == "hosted": {"kind": "hosted", "client": ModelClient, "kwargs": dict}
+        - kind == "hosted": {"kind": "hosted", "client": ModelClient,
+          "kwargs": dict, "arm": ArmSpec}
 
     Raises:
-        ValueError: If tutor_id is not registered and not in model roster.
+        ValueError: If tutor_id is not registered and not in the arm roster.
     """
     from tutormoments.client import get_client
-    from tutormoments.config import get_registered_tutor, resolve_model
+    from tutormoments.config import get_registered_tutor, resolve_arm
 
     # FIRST: check registry
     registered_fn = get_registered_tutor(tutor_id)
     if registered_fn is not None:
         return {"kind": "registered", "fn": registered_fn}
 
-    # ELSE: resolve as hosted model (raises ValueError if unknown)
-    model_spec = resolve_model(tutor_id)
+    # ELSE: resolve as a roster arm (raises ValueError if unknown)
+    arm = resolve_arm(tutor_id)
     # Shared per model: a fresh client per moment would pay a TLS handshake on
     # the conversation's first turn, inflating the cold-cache latency figure.
-    client = get_client(tutor_id)
+    client = get_client(arm.model)
     return {
         "kind": "hosted",
         "client": client,
-        "kwargs": model_spec["kwargs"],
+        "kwargs": {"thinking": arm.thinking},
+        "arm": arm,
     }

--- a/tests/tutormoments/test_cli.py
+++ b/tests/tutormoments/test_cli.py
@@ -162,6 +162,7 @@ def _make_run_config(
     arm="claude-opus-4-8",
     model=None,
     thinking="dynamic",
+    condition=None,
 ):
     """Build a fake RunConfig-like object.
 
@@ -182,8 +183,15 @@ def _make_run_config(
     cfg.replay_concurrency = replay_concurrency
     cfg.student = StudentSpec(model="claude-haiku", mode="oracle", thinking="dynamic")
     cfg.scorer = ScorerSpec(model="claude-opus-4-6", thinking="dynamic")
+    condition = condition or str(getattr(thinking, "value", thinking))
     cfg.resolved_tutors = {
-        arm: ArmSpec(name=arm, model=model, provider="anthropic", thinking=thinking)
+        arm: ArmSpec(
+            name=arm,
+            model=model,
+            provider="anthropic",
+            thinking=thinking,
+            condition=condition,
+        )
     }
     cfg.config_source = "test"
     return cfg
@@ -238,6 +246,7 @@ def test_run_cell_writes_all_files(tmp_path):
     assert cfg_data["tutor"] == "claude-opus-4-8"
     assert cfg_data["arm"] == "claude-opus-4-8"
     assert cfg_data["model"] == "claude-opus-4-8"
+    assert cfg_data["condition"] == "dynamic"
     # Frozen specs are serialized as plain dicts with thinking as a string.
     assert cfg_data["student"] == {
         "model": "claude-haiku",
@@ -251,6 +260,7 @@ def test_run_cell_writes_all_files(tmp_path):
             "model": "claude-opus-4-8",
             "provider": "anthropic",
             "thinking": "dynamic",
+            "condition": "dynamic",
         }
     }
 
@@ -273,6 +283,7 @@ def test_run_cell_writes_all_files(tmp_path):
     # Identity block: tutor_model is the ARM name; model the resolved id.
     assert summary["tutor_model"] == "claude-opus-4-8"
     assert summary["model"] == "claude-opus-4-8"
+    assert summary["condition"] == "dynamic"
     assert summary["mode"] == "plain"
 
     # summary metrics == aggregate of the 2 annotations
@@ -981,7 +992,7 @@ def test_report_joins_probe_ttft_onto_the_matching_run(tmp_path):
     main(["report", "--results-root", str(results_root), "--out", out_stem])
 
     rows = {
-        line.split("|")[2].strip(): line
+        line.split("|")[3].strip(): line
         for line in (tmp_path / "leaderboard.md").read_text("utf-8").splitlines()
         if line.startswith("| model-alpha")
     }
@@ -1472,16 +1483,19 @@ def test_run_cell_keys_results_by_arm_name_not_model_id(tmp_path):
     assert cfg_data["arm"] == "sonnet-high"
     assert cfg_data["tutor"] == "sonnet-high"
     assert cfg_data["model"] == "claude-sonnet-4-6"
+    assert cfg_data["condition"] == "high"
     assert cfg_data["resolved_tutors"]["sonnet-high"] == {
         "name": "sonnet-high",
         "model": "claude-sonnet-4-6",
         "provider": "anthropic",
         "thinking": "high",
+        "condition": "high",
     }
 
     summary = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
     assert summary["tutor_model"] == "sonnet-high"
     assert summary["model"] == "claude-sonnet-4-6"
+    assert summary["condition"] == "high"
     assert summary["mode"] == "plain"
 
 

--- a/tests/tutormoments/test_cli.py
+++ b/tests/tutormoments/test_cli.py
@@ -161,8 +161,8 @@ def _make_run_config(
     replay_concurrency=1,
     arm="claude-opus-4-8",
     model=None,
-    thinking="dynamic",
-    condition=None,
+    thinking=None,
+    condition="dynamic",
 ):
     """Build a fake RunConfig-like object.
 
@@ -170,6 +170,8 @@ def _make_run_config(
     provider model id (defaults to the arm name, as in the config schema).
     """
     model = model or arm
+    if thinking is None:
+        thinking = {"thinking": {"type": "adaptive"}}
     cfg = MagicMock()
     cfg.dataset = dataset
     cfg.data_path = None
@@ -181,9 +183,12 @@ def _make_run_config(
     cfg.modes = ["plain"]
     cfg.trials = 1
     cfg.replay_concurrency = replay_concurrency
-    cfg.student = StudentSpec(model="claude-haiku", mode="oracle", thinking="dynamic")
-    cfg.scorer = ScorerSpec(model="claude-opus-4-6", thinking="dynamic")
-    condition = condition or str(getattr(thinking, "value", thinking))
+    cfg.student = StudentSpec(
+        model="claude-haiku", mode="oracle", thinking={"thinking": None}
+    )
+    cfg.scorer = ScorerSpec(
+        model="claude-opus-4-6", thinking={"thinking": {"type": "adaptive"}}
+    )
     cfg.resolved_tutors = {
         arm: ArmSpec(
             name=arm,
@@ -247,19 +252,23 @@ def test_run_cell_writes_all_files(tmp_path):
     assert cfg_data["arm"] == "claude-opus-4-8"
     assert cfg_data["model"] == "claude-opus-4-8"
     assert cfg_data["condition"] == "dynamic"
-    # Frozen specs are serialized as plain dicts with thinking as a string.
+    # Frozen specs are serialized as plain dicts; thinking is the exact
+    # provider-native mapping the run sent.
     assert cfg_data["student"] == {
         "model": "claude-haiku",
         "mode": "oracle",
-        "thinking": "dynamic",
+        "thinking": {"thinking": None},
     }
-    assert cfg_data["scorer"] == {"model": "claude-opus-4-6", "thinking": "dynamic"}
+    assert cfg_data["scorer"] == {
+        "model": "claude-opus-4-6",
+        "thinking": {"thinking": {"type": "adaptive"}},
+    }
     assert cfg_data["resolved_tutors"] == {
         "claude-opus-4-8": {
             "name": "claude-opus-4-8",
             "model": "claude-opus-4-8",
             "provider": "anthropic",
-            "thinking": "dynamic",
+            "thinking": {"thinking": {"type": "adaptive"}},
             "condition": "dynamic",
         }
     }
@@ -558,15 +567,15 @@ providers:
   openai:    { env: OPENAI_API_KEY }
   gemini:    { env: GEMINI_API_KEY }
 
-models:
-  claude-opus-4-8:   { thinking: dynamic }
-  claude-sonnet-4-6: { thinking: dynamic }
-  gemini-2.5-pro:    { thinking: dynamic }
-  gpt-5.5:           { thinking: high }
-  sonnet-high:       { model: claude-sonnet-4-6, thinking: high }
+benchmark_models:
+  claude-opus-4-8:   { thinking: { type: adaptive }, condition: dynamic }
+  claude-sonnet-4-6: { thinking: { type: adaptive }, condition: dynamic }
+  gemini-2.5-pro:    { thinking_budget: -1, condition: dynamic }
+  gpt-5.5:           { reasoning: high, condition: high }
+  sonnet-high:       { model: claude-sonnet-4-6, thinking: { type: adaptive }, effort: high, condition: high }
 
-student: { model: claude-haiku-4-5, mode: oracle, thinking: none }
-scorer:  { model: claude-opus-4-6, thinking: dynamic }
+student: { model: claude-haiku-4-5, mode: oracle, thinking: null }
+scorer:  { model: claude-opus-4-6, thinking: { type: adaptive } }
 
 defaults: { trials: 1, max_turns: 4 }
 retry: { max_retries: 1, base_delay: 1 }
@@ -1219,11 +1228,11 @@ def test_run_config_argument_becomes_active_config_for_late_resolution(
 providers:
   openai: { env: OPENAI_API_KEY }
 
-models:
-  gpt-5.5: { thinking: high }
+benchmark_models:
+  gpt-5.5: { reasoning: high, condition: high }
 
-student: { model: claude-haiku-4-5, mode: oracle, thinking: none }
-scorer: { model: gpt-5.5, thinking: high }
+student: { model: claude-haiku-4-5, mode: oracle, thinking: null }
+scorer: { model: gpt-5.5, reasoning: high }
 
 defaults: { trials: 1, max_turns: 1 }
 retry: { max_retries: 1, base_delay: 1 }
@@ -1452,7 +1461,11 @@ def test_run_cell_keys_results_by_arm_name_not_model_id(tmp_path):
     annotations = [_make_annotation(s.id) for s in scenarios]
 
     cfg_mock = _make_run_config(
-        sample=2, arm="sonnet-high", model="claude-sonnet-4-6", thinking="high"
+        sample=2,
+        arm="sonnet-high",
+        model="claude-sonnet-4-6",
+        thinking={"thinking": {"type": "adaptive"}, "effort": "high"},
+        condition="high",
     )
 
     with (
@@ -1488,7 +1501,7 @@ def test_run_cell_keys_results_by_arm_name_not_model_id(tmp_path):
         "name": "sonnet-high",
         "model": "claude-sonnet-4-6",
         "provider": "anthropic",
-        "thinking": "high",
+        "thinking": {"thinking": {"type": "adaptive"}, "effort": "high"},
         "condition": "high",
     }
 

--- a/tests/tutormoments/test_cli.py
+++ b/tests/tutormoments/test_cli.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tutormoments.config import ArmSpec, ScorerSpec, StudentSpec
 from tutormoments.moments import Moment
 from tutormoments.scoring import Annotation
 
@@ -153,8 +154,21 @@ _TAX_RESULT = {
 }
 
 
-def _make_run_config(sample=2, dataset="test_ds", max_turns=4, replay_concurrency=1):
-    """Build a fake RunConfig-like object."""
+def _make_run_config(
+    sample=2,
+    dataset="test_ds",
+    max_turns=4,
+    replay_concurrency=1,
+    arm="claude-opus-4-8",
+    model=None,
+    thinking="dynamic",
+):
+    """Build a fake RunConfig-like object.
+
+    `arm` is the roster key results are keyed by; `model` is the resolved
+    provider model id (defaults to the arm name, as in the config schema).
+    """
+    model = model or arm
     cfg = MagicMock()
     cfg.dataset = dataset
     cfg.data_path = None
@@ -162,13 +176,15 @@ def _make_run_config(sample=2, dataset="test_ds", max_turns=4, replay_concurrenc
     cfg.dataset_config = "moments"
     cfg.sample = sample
     cfg.max_turns = max_turns
-    cfg.tutors = ["claude-opus-4-8"]
+    cfg.tutors = [arm]
     cfg.modes = ["plain"]
     cfg.trials = 1
     cfg.replay_concurrency = replay_concurrency
-    cfg.student = {"model": "claude-haiku", "mode": "oracle", "thinking": "adaptive"}
-    cfg.scorer = {"model": "claude-opus-4-6", "thinking": "adaptive"}
-    cfg.resolved_tutors = {"claude-opus-4-8": {}}
+    cfg.student = StudentSpec(model="claude-haiku", mode="oracle", thinking="dynamic")
+    cfg.scorer = ScorerSpec(model="claude-opus-4-6", thinking="dynamic")
+    cfg.resolved_tutors = {
+        arm: ArmSpec(name=arm, model=model, provider="anthropic", thinking=thinking)
+    }
     cfg.config_source = "test"
     return cfg
 
@@ -217,6 +233,26 @@ def test_run_cell_writes_all_files(tmp_path):
     assert isinstance(cfg_data, dict)
     # --seed was removed (never seeded anything); must not be recorded
     assert "seed" not in cfg_data
+    # Arm-based identity: `tutor`/`arm` are the roster key, `model` the
+    # resolved provider model id.
+    assert cfg_data["tutor"] == "claude-opus-4-8"
+    assert cfg_data["arm"] == "claude-opus-4-8"
+    assert cfg_data["model"] == "claude-opus-4-8"
+    # Frozen specs are serialized as plain dicts with thinking as a string.
+    assert cfg_data["student"] == {
+        "model": "claude-haiku",
+        "mode": "oracle",
+        "thinking": "dynamic",
+    }
+    assert cfg_data["scorer"] == {"model": "claude-opus-4-6", "thinking": "dynamic"}
+    assert cfg_data["resolved_tutors"] == {
+        "claude-opus-4-8": {
+            "name": "claude-opus-4-8",
+            "model": "claude-opus-4-8",
+            "provider": "anthropic",
+            "thinking": "dynamic",
+        }
+    }
 
     # 2 transcripts
     for s in scenarios:
@@ -233,6 +269,11 @@ def test_run_cell_writes_all_files(tmp_path):
     # summary.json
     assert (run_dir / "summary.json").exists()
     summary = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+
+    # Identity block: tutor_model is the ARM name; model the resolved id.
+    assert summary["tutor_model"] == "claude-opus-4-8"
+    assert summary["model"] == "claude-opus-4-8"
+    assert summary["mode"] == "plain"
 
     # summary metrics == aggregate of the 2 annotations
     assert summary["n_scenarios"] == expected_summary["n_scenarios"]
@@ -498,12 +539,48 @@ def test_run_cell_raises_when_all_scenarios_fail(tmp_path):
 # Test 4: cell expansion -- tutors x modes = cells with correct lane assignment
 # ---------------------------------------------------------------------------
 
+# An arm-based roster covering all three providers, plus an arm whose key is
+# NOT a model id (lane must come from its resolved model's provider).
+_ARM_CONFIG_YAML = """
+providers:
+  anthropic: { env: ANTHROPIC_API_KEY }
+  openai:    { env: OPENAI_API_KEY }
+  gemini:    { env: GEMINI_API_KEY }
 
-def test_cell_expansion_and_lane_assignment():
+models:
+  claude-opus-4-8:   { thinking: dynamic }
+  claude-sonnet-4-6: { thinking: dynamic }
+  gemini-2.5-pro:    { thinking: dynamic }
+  gpt-5.5:           { thinking: high }
+  sonnet-high:       { model: claude-sonnet-4-6, thinking: high }
+
+student: { model: claude-haiku-4-5, mode: oracle, thinking: none }
+scorer:  { model: claude-opus-4-6, thinking: dynamic }
+
+defaults: { trials: 1, max_turns: 4 }
+retry: { max_retries: 1, base_delay: 1 }
+batch: { timeout: 60 }
+""".strip()
+
+
+@pytest.fixture
+def arm_config(tmp_path, monkeypatch):
+    """Point TUTORMOMENTS_CONFIG at a roster of arms for lane-resolution tests."""
+    from tutormoments.config import _reset_config_cache
+
+    config_path = tmp_path / "arm_config.yaml"
+    config_path.write_text(_ARM_CONFIG_YAML, encoding="utf-8")
+    monkeypatch.setenv("TUTORMOMENTS_CONFIG", str(config_path))
+    _reset_config_cache()
+    yield
+    _reset_config_cache()
+
+
+def test_cell_expansion_and_lane_assignment(arm_config):
     """3 tutors x 2 modes = 6 cells; each cell gets the correct provider lane."""
     from tutormoments.cli import expand_cells
 
-    tutors = ["claude-opus-4-8", "gemini-3.1-pro-preview", "gpt-5.4"]
+    tutors = ["claude-opus-4-8", "gemini-2.5-pro", "gpt-5.5"]
     modes = ["plain", "scaffolding_rigor"]
 
     cells = expand_cells(tutors, modes)
@@ -516,11 +593,21 @@ def test_cell_expansion_and_lane_assignment():
         for m in modes:
             assert (t, m) in pairs, f"Missing cell ({t}, {m})"
 
-    # Check lane assignment by provider
+    # Check lane assignment by the arm's resolved model's provider
     lane_map = {c["tutor"]: c["lane"] for c in cells}
     assert lane_map["claude-opus-4-8"] == "anthropic"
-    assert lane_map["gemini-3.1-pro-preview"] == "gemini"
-    assert lane_map["gpt-5.4"] == "openai"
+    assert lane_map["gemini-2.5-pro"] == "gemini"
+    assert lane_map["gpt-5.5"] == "openai"
+
+
+def test_cell_expansion_arm_key_that_is_not_a_model_id(arm_config):
+    """An arm named after its condition (not a model id) still lands on the
+    lane of its resolved model's provider."""
+    from tutormoments.cli import expand_cells
+
+    cells = expand_cells(["sonnet-high"], ["plain"])
+
+    assert cells == [{"tutor": "sonnet-high", "mode": "plain", "lane": "anthropic"}]
 
 
 # ---------------------------------------------------------------------------
@@ -528,12 +615,12 @@ def test_cell_expansion_and_lane_assignment():
 # ---------------------------------------------------------------------------
 
 
-def test_scheduler_within_lane_sequential(tmp_path):
+def test_scheduler_within_lane_sequential(tmp_path, arm_config):
     """Cells within a lane are called in order; all 6 run_cell calls complete."""
     from tutormoments.cli import expand_cells, run_sweep
 
     # 2 tutors in the same lane (anthropic), 1 mode each -> 2 cells in 1 lane
-    tutors = ["claude-opus-4-8", "claude-haiku-3-5"]
+    tutors = ["claude-opus-4-8", "claude-sonnet-4-6"]
     modes = ["plain"]
 
     cells = expand_cells(tutors, modes)
@@ -557,9 +644,9 @@ def test_scheduler_within_lane_sequential(tmp_path):
     # All 2 cells produced a run_id
     assert len(run_ids) == 2
 
-    # Within-lane sequential: claude-opus-4-8 before claude-haiku-3-5 (sweep order)
+    # Within-lane sequential: claude-opus-4-8 before claude-sonnet-4-6 (sweep order)
     tutors_in_order = [t for t, m in call_order]
-    assert tutors_in_order == ["claude-opus-4-8", "claude-haiku-3-5"]
+    assert tutors_in_order == ["claude-opus-4-8", "claude-sonnet-4-6"]
 
 
 def test_scheduler_multiple_lanes_all_cells_run(tmp_path):
@@ -604,9 +691,16 @@ def _make_run_config_trials(
     cfg.modes = ["plain"]
     cfg.trials = n_trials
     cfg.replay_concurrency = replay_concurrency
-    cfg.student = {"model": "claude-haiku", "mode": "oracle", "thinking": "adaptive"}
-    cfg.scorer = {"model": "claude-opus-4-6", "thinking": "adaptive"}
-    cfg.resolved_tutors = {"claude-opus-4-8": {}}
+    cfg.student = StudentSpec(model="claude-haiku", mode="oracle", thinking="dynamic")
+    cfg.scorer = ScorerSpec(model="claude-opus-4-6", thinking="dynamic")
+    cfg.resolved_tutors = {
+        "claude-opus-4-8": ArmSpec(
+            name="claude-opus-4-8",
+            model="claude-opus-4-8",
+            provider="anthropic",
+            thinking="dynamic",
+        )
+    }
     cfg.config_source = "test"
     return cfg
 
@@ -1115,10 +1209,10 @@ providers:
   openai: { env: OPENAI_API_KEY }
 
 models:
-  gpt-4o-mini: {}
+  gpt-5.5: { thinking: high }
 
-student: { model: mock-student, mode: oracle, thinking: false }
-scorer: { model: gpt-4o-mini, thinking: false }
+student: { model: claude-haiku-4-5, mode: oracle, thinking: none }
+scorer: { model: gpt-5.5, thinking: high }
 
 defaults: { trials: 1, max_turns: 1 }
 retry: { max_retries: 1, base_delay: 1 }
@@ -1130,11 +1224,11 @@ batch: { timeout: 60 }
     observed = {}
 
     def fake_run_sweep(cells, run_cfg, *, date, results_root):
-        from tutormoments.config import resolve_model, scorer_spec, student_spec
+        from tutormoments.config import resolve_arm, scorer_spec, student_spec
 
-        observed["provider"] = resolve_model("gpt-4o-mini")["provider"]
-        observed["student"] = student_spec()["model"]
-        observed["scorer"] = scorer_spec()["model"]
+        observed["provider"] = resolve_arm("gpt-5.5").provider
+        observed["student"] = student_spec().model
+        observed["scorer"] = scorer_spec().model
         observed["run_cfg_source"] = run_cfg.config_source
         return ["fake_run"]
 
@@ -1149,7 +1243,7 @@ batch: { timeout: 60 }
                 "--config",
                 str(config_path),
                 "--tutors",
-                "gpt-4o-mini",
+                "gpt-5.5",
                 "--dataset",
                 "readme_mock",
             ]
@@ -1157,8 +1251,8 @@ batch: { timeout: 60 }
 
         assert observed == {
             "provider": "openai",
-            "student": "mock-student",
-            "scorer": "gpt-4o-mini",
+            "student": "claude-haiku-4-5",
+            "scorer": "gpt-5.5",
             "run_cfg_source": str(config_path),
         }
         assert os.environ["TUTORMOMENTS_CONFIG"] == str(config_path)
@@ -1327,6 +1421,68 @@ def test_run_cell_folds_taxonomy_block_into_summary(tmp_path):
     # taxonomy usage folded into the token bookkeeping
     assert summary["tokens"]["taxonomy"] == tax_result["usage"]
     assert summary["tokens"]["total"]["total_tokens"] >= 1000
+
+
+# ---------------------------------------------------------------------------
+# Arm identity: an arm keyed by a condition name, not a model id
+# ---------------------------------------------------------------------------
+
+
+def test_run_cell_keys_results_by_arm_name_not_model_id(tmp_path):
+    """For an arm whose key is not a model id (sonnet-high -> claude-sonnet-4-6):
+    the run id is keyed by the ARM name, config.json records arm == tutor ==
+    the arm name with model == the resolved id, and the summary identity block
+    carries both."""
+    import tutormoments.results as results_mod
+    from tutormoments.cli import run_cell
+
+    scenarios = list(FIXTURE_SCENARIOS)
+    transcripts = [_make_transcript(s.id) for s in scenarios]
+    annotations = [_make_annotation(s.id) for s in scenarios]
+
+    cfg_mock = _make_run_config(
+        sample=2, arm="sonnet-high", model="claude-sonnet-4-6", thinking="high"
+    )
+
+    with (
+        patch(_CFG_PATCH, return_value=cfg_mock),
+        patch(_LOAD_PATCH, return_value=_load_result(scenarios)),
+        patch(_CONV_PATCH, side_effect=transcripts),
+        patch(_SCORE_PATCH, side_effect=_score_batch_from(annotations)),
+        patch(_TAX_PATCH, return_value=_TAX_RESULT),
+        patch(
+            "tutormoments.cli.results.make_run_id", wraps=results_mod.make_run_id
+        ) as mock_run_id,
+    ):
+        run_id = run_cell(
+            tutor="sonnet-high",
+            mode="plain",
+            run_cfg=None,
+            date="20260626",
+            results_root=str(tmp_path),
+        )
+
+    # make_run_id received the ARM name, not the resolved model id
+    mock_run_id.assert_called_once_with("sonnet-high", "plain", "test_ds", "20260626")
+    assert "sonnet-high" in run_id
+    assert "claude-sonnet-4-6" not in run_id
+
+    run_dir = tmp_path / run_id
+    cfg_data = json.loads((run_dir / "config.json").read_text(encoding="utf-8"))
+    assert cfg_data["arm"] == "sonnet-high"
+    assert cfg_data["tutor"] == "sonnet-high"
+    assert cfg_data["model"] == "claude-sonnet-4-6"
+    assert cfg_data["resolved_tutors"]["sonnet-high"] == {
+        "name": "sonnet-high",
+        "model": "claude-sonnet-4-6",
+        "provider": "anthropic",
+        "thinking": "high",
+    }
+
+    summary = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["tutor_model"] == "sonnet-high"
+    assert summary["model"] == "claude-sonnet-4-6"
+    assert summary["mode"] == "plain"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tutormoments/test_client.py
+++ b/tests/tutormoments/test_client.py
@@ -1442,3 +1442,49 @@ class TestCancelBatch:
             c = ModelClient("deepseek-ai/DeepSeek-V4-Pro")
         with pytest.raises(ValueError, match="Batch API not supported"):
             cancel_batch(c, "b1")
+
+
+def test_openai_usage_captures_reasoning_tokens():
+    """The informational reasoning_tokens key rides alongside the usage vector.
+
+    It is a subset of completion_tokens (not a separate cost bucket), so the
+    canonical `reasoning` bucket stays 0 -- moving it there would double-count
+    against `output`. The smoke layer reads it as thinking evidence.
+    """
+    from tutormoments.client import _openai_batch_usage, _openai_style_usage
+
+    usage_obj = SimpleNamespace(
+        prompt_tokens=53,
+        completion_tokens=109,
+        total_tokens=162,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0, cache_write_tokens=0),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=64),
+    )
+    usage = _openai_style_usage(
+        usage_obj, provider="openai", model="gpt-5.5", endpoint="sync"
+    )
+    assert usage["reasoning_tokens"] == 64
+    assert usage["reasoning"] == 0
+    assert usage["output"] == 109
+    assert usage["total"] == 53 + 109
+
+    batch = _openai_batch_usage(
+        {
+            "prompt_tokens": 53,
+            "completion_tokens": 109,
+            "total_tokens": 162,
+            "completion_tokens_details": {"reasoning_tokens": 64},
+        },
+        model="gpt-5.5",
+    )
+    assert batch["reasoning_tokens"] == 64
+    assert batch["reasoning"] == 0
+
+    # Absent details: key present, zero -- "reported dimension, zero observed".
+    bare = _openai_style_usage(
+        SimpleNamespace(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+        provider="together",
+        model="deepseek-ai/DeepSeek-V4-Pro",
+        endpoint="sync",
+    )
+    assert bare["reasoning_tokens"] == 0

--- a/tests/tutormoments/test_client.py
+++ b/tests/tutormoments/test_client.py
@@ -1,4 +1,6 @@
+import copy
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -6,15 +8,23 @@ import pytest
 from tutormoments.client import (
     ModelClient,
     ModelResponse,
-    _anthropic_thinking_param,
+    _base64_bytes,
+    _build_image_blocks_anthropic,
+    _build_image_blocks_gemini,
+    _build_image_blocks_openai,
     _mime_from_path,
+    _presigned_url,
+    _should_use_presigned_url,
     _strip_json_fences,
     build_batch_entry,
+    cancel_batch,
     infer_provider,
+    normalize_usage,
     run_batch,
     run_sync_entries,
     write_jsonl,
 )
+from tutormoments.models import ThinkingConfigError
 
 
 @pytest.mark.parametrize(
@@ -44,49 +54,161 @@ def test_infer_provider_unknown_raises():
         infer_provider("totally-unknown-model")
 
 
-class TestAnthropicThinkingParam:
-    def test_adaptive_models_get_adaptive_shape(self):
-        for m in (
-            "claude-opus-4-8",
-            "claude-opus-4-7",
-            "claude-opus-4-6",
-            "claude-sonnet-4-6",
-            "claude-sonnet-5",
-            "claude-fable-5",
+class TestGenerateThinkingWire:
+    """The thinking ladder resolves to the exact wire bytes the raw knobs sent.
+
+    The full (family, rung) -> wire matrix is pinned in test_models.py; these
+    tests prove the client actually places each resolved fragment on the
+    request. Each expected payload is byte-identical to what the pre-ladder
+    client produced for the equivalent raw-knob inputs (thinking=True,
+    thinking_budget, effort, reasoning_effort) -- the wire-level
+    reproducibility proof for the refactor.
+    """
+
+    def _anthropic(self, monkeypatch, model, **gen_kwargs):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        with patch("anthropic.Anthropic") as MockAnthropic:
+            client_obj = MagicMock()
+            client_obj.messages.create.return_value = _fake_anthropic_message("ok")
+            MockAnthropic.return_value = client_obj
+            ModelClient(model).generate("Q", json_mode=False, **gen_kwargs)
+        return client_obj.messages.create.call_args.kwargs
+
+    def test_anthropic_dynamic_sends_adaptive(self, monkeypatch):
+        # Old thinking=True on adaptive-tier models.
+        kwargs = self._anthropic(monkeypatch, "claude-opus-4-6", thinking="dynamic")
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert "extra_body" not in kwargs  # no effort alongside plain adaptive
+
+    def test_anthropic_xhigh_sends_adaptive_plus_effort(self, monkeypatch):
+        # Old thinking=True + effort="xhigh".
+        kwargs = self._anthropic(monkeypatch, "claude-opus-4-8", thinking="xhigh")
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert kwargs["extra_body"]["output_config"] == {"effort": "xhigh"}
+
+    def test_anthropic_legacy_high_sends_enabled_budget_and_bumps_max_tokens(
+        self, monkeypatch
+    ):
+        # Old haiku-4-5 thinking=True (legacy enabled + default budget 16384).
+        # Enabled mode requires max_tokens >= budget + headroom.
+        kwargs = self._anthropic(
+            monkeypatch, "claude-haiku-4-5", thinking="high", max_tokens=100
+        )
+        assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 16384}
+        assert kwargs["max_tokens"] == 16384 + 64
+
+    def test_anthropic_haiku_output_cap_comes_from_registry(self, monkeypatch):
+        # max_tokens=0 resolves to the provider maximum (128000), which the
+        # registry's per-model cap clamps to haiku's 64000. The dated id
+        # resolves to the claude-haiku-4-5 entry by longest prefix.
+        kwargs = self._anthropic(monkeypatch, "claude-haiku-4-5-20251001")
+        assert kwargs["max_tokens"] == 64000
+
+    def test_anthropic_none_level_sends_no_thinking_param(self, monkeypatch):
+        kwargs = self._anthropic(monkeypatch, "claude-opus-4-6", thinking="none")
+        assert "thinking" not in kwargs
+        assert "extra_body" not in kwargs
+
+    def test_no_stated_condition_sends_nothing_even_unregistered(self, monkeypatch):
+        # thinking=None is unvalidated and unsent -- works for model ids the
+        # registry has never heard of (dev/direct client use).
+        kwargs = self._anthropic(
+            monkeypatch, "claude-experimental-dev-model", thinking=None
+        )
+        assert "thinking" not in kwargs
+
+    def _gemini(self, monkeypatch, model, **gen_kwargs):
+        monkeypatch.setenv("GEMINI_API_KEY", "k")
+        with patch("google.genai.Client") as MockGenai:
+            client_obj = MagicMock()
+            client_obj.models.generate_content.return_value = SimpleNamespace(
+                text="ok", usage_metadata=None
+            )
+            MockGenai.return_value = client_obj
+            ModelClient(model).generate("Q", json_mode=False, **gen_kwargs)
+        return client_obj.models.generate_content.call_args.kwargs
+
+    def test_gemini_dynamic_sends_budget_minus_one(self, monkeypatch):
+        # Old thinking=True + thinking_budget=-1.
+        kwargs = self._gemini(monkeypatch, "gemini-2.5-pro", thinking="dynamic")
+        assert kwargs["config"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_budget": -1,
+        }
+
+    def test_gemini_flash_none_sends_zero_budget(self, monkeypatch):
+        # Old thinking=False; only valid where the API accepts budget 0.
+        kwargs = self._gemini(monkeypatch, "gemini-2.5-flash", thinking="none")
+        assert kwargs["config"]["thinking_config"] == {
+            "include_thoughts": False,
+            "thinking_budget": 0,
+        }
+
+    def test_gemini_no_condition_omits_thinking_config(self, monkeypatch):
+        kwargs = self._gemini(monkeypatch, "gemini-2.5-pro")
+        assert "thinking_config" not in kwargs["config"]
+
+    def _openai(self, monkeypatch, model, **gen_kwargs):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        with patch("openai.OpenAI") as MockOpenAI:
+            client_obj = MagicMock()
+            client_obj.chat.completions.create.return_value = SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+                usage=None,
+            )
+            MockOpenAI.return_value = client_obj
+            ModelClient(model).generate("Q", json_mode=False, **gen_kwargs)
+        return client_obj.chat.completions.create.call_args.kwargs
+
+    def test_openai_high_sends_reasoning_effort(self, monkeypatch):
+        # Old reasoning_effort="high".
+        kwargs = self._openai(monkeypatch, "gpt-5.5", thinking="high")
+        assert kwargs["reasoning_effort"] == "high"
+
+    def test_openai_no_condition_omits_reasoning_effort(self, monkeypatch):
+        kwargs = self._openai(monkeypatch, "gpt-5.5")
+        assert "reasoning_effort" not in kwargs
+
+    def test_unsatisfiable_level_fails_before_sdk_call_without_retries(
+        self, monkeypatch
+    ):
+        # gemini-2.5-pro is always-thinking: `none` must die at resolve time,
+        # before any request is made and without burning the retry budget.
+        monkeypatch.setenv("GEMINI_API_KEY", "k")
+        with (
+            patch("google.genai.Client") as MockGenai,
+            patch("tutormoments.client.time.sleep") as mock_sleep,
         ):
-            assert _anthropic_thinking_param(m, 0) == {"type": "adaptive"}
+            client_obj = MagicMock()
+            MockGenai.return_value = client_obj
+            c = ModelClient("gemini-2.5-pro")
+            with pytest.raises(ThinkingConfigError):
+                c.generate("Q", json_mode=False, thinking="none")
+        client_obj.models.generate_content.assert_not_called()
+        mock_sleep.assert_not_called()
 
-    def test_haiku_4_5_gets_legacy_enabled_shape(self):
-        # Haiku 4.5 is the one current model without adaptive-thinking support
-        # (extended thinking only, per the Anthropic models overview) --
-        # sending {"type": "adaptive"} there would 400.
-        assert _anthropic_thinking_param("claude-haiku-4-5", 4096) == {
-            "type": "enabled",
-            "budget_tokens": 4096,
-        }
-        assert _anthropic_thinking_param("claude-haiku-4-5-20251001", 0) == {
-            "type": "enabled",
-            "budget_tokens": 16384,
-        }
+    def test_unregistered_model_with_explicit_level_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        with patch("anthropic.Anthropic") as MockAnthropic:
+            client_obj = MagicMock()
+            MockAnthropic.return_value = client_obj
+            c = ModelClient("claude-experimental-dev-model")
+            with pytest.raises(ThinkingConfigError):
+                c.generate("Q", json_mode=False, thinking="high")
+        client_obj.messages.create.assert_not_called()
 
-    def test_unknown_or_future_model_defaults_to_adaptive(self):
-        # A brand-new Anthropic model must work with no code change (README
-        # "Running new tutor models"). Anything not in the frozen legacy set
-        # gets adaptive.
-        for m in ("claude-opus-5", "claude-sonnet-6", "totally-new-claude"):
-            assert _anthropic_thinking_param(m, 0) == {"type": "adaptive"}
-
-    def test_legacy_model_gets_enabled_with_budget(self):
-        assert _anthropic_thinking_param("claude-sonnet-4-5", 8192) == {
-            "type": "enabled",
-            "budget_tokens": 8192,
-        }
-
-    def test_legacy_model_zero_budget_defaults_16384(self):
-        assert _anthropic_thinking_param("claude-sonnet-4-5", 0) == {
-            "type": "enabled",
-            "budget_tokens": 16384,
-        }
+    def test_retired_raw_knob_kwargs_are_gone(self, monkeypatch):
+        # The raw knobs were deleted, not deprecated: passing one is a
+        # TypeError, so no caller can silently keep steering the old way.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        with patch("anthropic.Anthropic"):
+            c = ModelClient("claude-opus-4-6")
+        with pytest.raises(TypeError):
+            c.generate("Q", thinking_budget=16384)
+        with pytest.raises(TypeError):
+            c.generate("Q", effort="xhigh")
+        with pytest.raises(TypeError):
+            c.generate("Q", reasoning_effort="high")
 
 
 def test_strip_json_fences_removes_markdown_fence():
@@ -291,42 +413,8 @@ def test_get_retry_config_values():
 
 
 # ===================================================================
-# Task 7: vision image-block builders + cacheable-prefix
+# Task 7: image-block builders + cacheable-prefix
 # ===================================================================
-
-from tutormoments.client import (
-    VISION_CAPABLE_PREFIXES,
-    _base64_bytes,
-    _build_image_blocks_anthropic,
-    _build_image_blocks_gemini,
-    _build_image_blocks_openai,
-    _presigned_url,
-    _should_use_presigned_url,
-    validate_vision_support,
-)
-
-
-class TestVisionSupport:
-    def test_vision_capable_prefixes_covers_current_anthropic_tutors(self):
-        # Every Anthropic model in the tutor roster must pass the vision gate.
-        validate_vision_support("claude-sonnet-5")
-        validate_vision_support("claude-fable-5")
-
-    def test_vision_capable_prefixes_contains_known_models(self):
-        # Spot-check a few entries from the source list.
-        assert "claude-opus-4" in VISION_CAPABLE_PREFIXES
-        assert "gpt-4o" in VISION_CAPABLE_PREFIXES
-        assert "gemini-2" in VISION_CAPABLE_PREFIXES
-
-    def test_validate_vision_support_passes_for_capable_model(self):
-        # Should not raise.
-        validate_vision_support("claude-opus-4-6")
-        validate_vision_support("gpt-4o-mini")
-        validate_vision_support("gemini-2.0-flash")
-
-    def test_validate_vision_support_raises_for_unknown_model(self):
-        with pytest.raises(ValueError, match="not in the vision-capable list"):
-            validate_vision_support("claude-2")
 
 
 class TestShouldUsePresignedUrl:
@@ -585,8 +673,11 @@ def test_run_batch_anthropic_remaps_custom_ids(monkeypatch):
 
 
 def test_run_batch_anthropic_sends_thinking_and_effort(monkeypatch):
-    """Batch requests must carry the same thinking/effort params as sync calls
-    (benchmark fidelity: batch mode may not silently diverge from run_conversation)."""
+    """Batch requests must carry the same wire thinking/effort fragment as sync
+    calls (benchmark fidelity: batch mode may not silently diverge from
+    run_conversation). thinking="xhigh" resolves to adaptive thinking plus
+    output_config.effort -- the exact bytes the retired thinking=True +
+    effort="xhigh" knobs produced."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     with (
         patch("anthropic.Anthropic") as MockAnthropic,
@@ -605,12 +696,44 @@ def test_run_batch_anthropic_sends_thinking_and_effort(monkeypatch):
             c,
             [build_batch_entry("kA", "pA")],
             poll_interval=0,
-            thinking=True,
-            effort="xhigh",
+            thinking="xhigh",
         )
         (submitted,) = client_obj.messages.batches.create.call_args.kwargs["requests"]
     assert submitted["params"]["thinking"] == {"type": "adaptive"}
     assert submitted["params"]["output_config"] == {"effort": "xhigh"}
+
+
+def test_run_batch_anthropic_legacy_budget_and_registry_cap(monkeypatch):
+    """Legacy (enabled+budget) models get budget_tokens on batch requests, no
+    output_config, and the registry's per-model output cap clamps the entry's
+    max_tokens (build_batch_entry's 65536 default > haiku's 64000 cap)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    with (
+        patch("anthropic.Anthropic") as MockAnthropic,
+        patch("tutormoments.client.time.sleep"),
+    ):
+        client_obj = MagicMock()
+        batch = MagicMock()
+        batch.id = "b1"
+        batch.processing_status = "ended"
+        client_obj.messages.batches.create.return_value = batch
+        client_obj.messages.batches.retrieve.return_value = batch
+        client_obj.messages.batches.results.return_value = []
+        MockAnthropic.return_value = client_obj
+        c = ModelClient("claude-haiku-4-5")
+        run_batch(
+            c,
+            [build_batch_entry("kA", "pA")],
+            poll_interval=0,
+            thinking="high",
+        )
+        (submitted,) = client_obj.messages.batches.create.call_args.kwargs["requests"]
+    assert submitted["params"]["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": 16384,
+    }
+    assert submitted["params"]["max_tokens"] == 64000
+    assert "output_config" not in submitted["params"]
 
 
 def test_run_batch_anthropic_resume_rebuilds_id_map(monkeypatch):
@@ -650,17 +773,47 @@ def test_run_batch_anthropic_resume_rebuilds_id_map(monkeypatch):
         ]
         MockAnthropic.return_value = client_obj
         c = ModelClient("claude-opus-4-6")
+        created_ids = []
         out = run_batch(
             c,
             [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")],
             poll_interval=0,
             existing_batch_id="b1",
+            on_batch_created=created_ids.append,
         )
-    # No fresh submission on resume.
+    # No fresh submission on resume, so the created-callback never fires.
     client_obj.messages.batches.create.assert_not_called()
     client_obj.messages.batches.retrieve.assert_called_with("b1")
+    assert created_ids == []
     assert out["kA"]["text"] == "A"
     assert out["kB"]["text"] == "B"
+
+
+def test_run_batch_calls_on_batch_created_after_fresh_submit(monkeypatch):
+    """A fresh submission reports its batch id via on_batch_created (ctrl-C
+    recovery hook) before the poll loop starts."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    with (
+        patch("anthropic.Anthropic") as MockAnthropic,
+        patch("tutormoments.client.time.sleep"),
+    ):
+        client_obj = MagicMock()
+        batch = MagicMock()
+        batch.id = "b-fresh"
+        batch.processing_status = "ended"
+        client_obj.messages.batches.create.return_value = batch
+        client_obj.messages.batches.retrieve.return_value = batch
+        client_obj.messages.batches.results.return_value = []
+        MockAnthropic.return_value = client_obj
+        c = ModelClient("claude-opus-4-6")
+        created_ids = []
+        run_batch(
+            c,
+            [build_batch_entry("kA", "pA")],
+            poll_interval=0,
+            on_batch_created=created_ids.append,
+        )
+    assert created_ids == ["b-fresh"]
 
 
 def test_run_batch_openai_parses_results(monkeypatch):
@@ -770,10 +923,6 @@ def test_run_batch_unsupported_provider_raises(monkeypatch):
 # ===================================================================
 # Canonical usage vector (cost tracking, Phase 1)
 # ===================================================================
-
-from types import SimpleNamespace
-
-from tutormoments.client import normalize_usage
 
 
 def test_normalize_usage_total_is_derived_and_provenance_rides_along():
@@ -1122,3 +1271,174 @@ def test_run_batch_gemini_captures_cache_read_and_reasoning(monkeypatch):
         c = ModelClient("gemini-3.1-pro-preview")
         out = run_batch(c, [build_batch_entry("kA", "pA")], poll_interval=0)
     _assert_gemini_vector(out["kA"]["usage"], "batch")
+
+
+# ===================================================================
+# Thinking ladder on the batch paths + cancel_batch + sync forwarding
+# ===================================================================
+
+
+def _mock_gemini_batch_client(result_text: str):
+    """Gemini batch double that captures the uploaded JSONL before the submit
+    path unlinks the temp file."""
+    client_obj = MagicMock()
+    captured = {}
+
+    def _upload(file, config=None):
+        with open(file, encoding="utf-8") as fh:
+            captured["jsonl"] = fh.read()
+        uploaded = MagicMock()
+        uploaded.name = "files/up1"
+        return uploaded
+
+    client_obj.files.upload.side_effect = _upload
+    batch = MagicMock()
+    batch.name = "batches/gb1"
+    batch.state.name = "JOB_STATE_SUCCEEDED"
+    batch.dest.file_name = "files/out1"
+    client_obj.batches.create.return_value = batch
+    client_obj.batches.get.return_value = batch
+    client_obj.files.download.return_value = result_text.encode("utf-8")
+    return client_obj, captured
+
+
+def test_run_batch_gemini_injects_thinking_config_without_mutating_entries(
+    monkeypatch,
+):
+    """thinking="dynamic" lands in every uploaded JSONL line's
+    generation_config as the include_thoughts/budget -1 wire shape, and the
+    caller's entry dicts stay untouched (resume flows re-submit them)."""
+    monkeypatch.setenv("GEMINI_API_KEY", "key-test")
+    result_text = "\n".join(
+        json.dumps(
+            {
+                "key": key,
+                "response": {
+                    "candidates": [{"content": {"parts": [{"text": "A"}]}}],
+                    "usageMetadata": {},
+                },
+            }
+        )
+        for key in ("kA", "kB")
+    )
+    entries = [build_batch_entry("kA", "pA"), build_batch_entry("kB", "pB")]
+    entries_before = copy.deepcopy(entries)
+    with (
+        patch("google.genai.Client") as MockGenai,
+        patch("tutormoments.client.time.sleep"),
+    ):
+        client_obj, captured = _mock_gemini_batch_client(result_text)
+        MockGenai.return_value = client_obj
+        c = ModelClient("gemini-2.5-pro")
+        out = run_batch(c, entries, poll_interval=0, thinking="dynamic")
+    lines = [json.loads(ln) for ln in captured["jsonl"].strip().splitlines()]
+    assert len(lines) == 2
+    for line in lines:
+        assert line["request"]["generation_config"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_budget": -1,
+        }
+        # The rest of the generation_config is carried over unchanged.
+        assert line["request"]["generation_config"]["max_output_tokens"] == 65536
+    assert entries == entries_before
+    assert set(out) == {"kA", "kB"}
+
+
+def test_run_batch_gemini_skips_thought_parts_and_joins_text(monkeypatch):
+    """Result parsing drops parts flagged thought: true (reasoning summaries,
+    not the answer) and joins the remaining text parts, keeping batch text
+    identical to sync response.text."""
+    monkeypatch.setenv("GEMINI_API_KEY", "key-test")
+    result_text = json.dumps(
+        {
+            "key": "kA",
+            "response": {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"text": "reasoning...", "thought": True},
+                                {"text": '{"a":'},
+                                {"text": " 1}"},
+                            ]
+                        }
+                    }
+                ],
+                "usageMetadata": {},
+            },
+        }
+    )
+    with (
+        patch("google.genai.Client") as MockGenai,
+        patch("tutormoments.client.time.sleep"),
+    ):
+        client_obj, _ = _mock_gemini_batch_client(result_text)
+        MockGenai.return_value = client_obj
+        c = ModelClient("gemini-2.5-pro")
+        out = run_batch(
+            c, [build_batch_entry("kA", "pA")], poll_interval=0, thinking="dynamic"
+        )
+    assert out["kA"]["text"] == '{"a": 1}'
+
+
+def test_run_batch_unsatisfiable_level_fails_before_upload(monkeypatch):
+    """A level the model cannot honor dies at resolve time -- nothing is
+    uploaded and no batch job is created."""
+    monkeypatch.setenv("GEMINI_API_KEY", "key-test")
+    with patch("google.genai.Client") as MockGenai:
+        client_obj = MagicMock()
+        MockGenai.return_value = client_obj
+        c = ModelClient("gemini-2.5-pro")
+        with pytest.raises(ThinkingConfigError):
+            run_batch(
+                c, [build_batch_entry("k", "p")], poll_interval=0, thinking="none"
+            )
+    client_obj.files.upload.assert_not_called()
+    client_obj.batches.create.assert_not_called()
+
+
+def test_run_sync_entries_forwards_thinking_to_generate(monkeypatch):
+    """run_sync_entries takes the same ladder level run_batch does and passes
+    it straight through to generate(), so switching between the sync and batch
+    paths keeps the same benchmark condition."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    with patch("anthropic.Anthropic"):
+        c = ModelClient("claude-opus-4-6")
+    with patch.object(c, "generate", return_value=ModelResponse("R")) as mock_gen:
+        out = run_sync_entries(c, [build_batch_entry("k1", "p1")], thinking="dynamic")
+    assert mock_gen.call_args.kwargs["thinking"] == "dynamic"
+    assert out["k1"]["text"] == "R"
+
+
+class TestCancelBatch:
+    def test_gemini_routes_to_batches_cancel_by_name(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "k")
+        with patch("google.genai.Client") as MockGenai:
+            client_obj = MagicMock()
+            MockGenai.return_value = client_obj
+            cancel_batch(ModelClient("gemini-2.5-pro"), "batches/gb1")
+        client_obj.batches.cancel.assert_called_once_with(name="batches/gb1")
+
+    def test_openai_routes_to_batches_cancel(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        with patch("openai.OpenAI") as MockOpenAI:
+            client_obj = MagicMock()
+            MockOpenAI.return_value = client_obj
+            cancel_batch(ModelClient("gpt-5.5"), "ob1")
+        client_obj.batches.cancel.assert_called_once_with("ob1")
+
+    def test_anthropic_routes_to_messages_batches_cancel(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        with patch("anthropic.Anthropic") as MockAnthropic:
+            client_obj = MagicMock()
+            MockAnthropic.return_value = client_obj
+            cancel_batch(ModelClient("claude-opus-4-6"), "mb1")
+        client_obj.messages.batches.cancel.assert_called_once_with("mb1")
+
+    def test_unsupported_provider_raises(self, monkeypatch):
+        monkeypatch.setenv("TOGETHER_API_KEY", "key-test")
+        with patch("openai.OpenAI") as MockOpenAI:
+            MockOpenAI.return_value = MagicMock()
+            c = ModelClient("deepseek-ai/DeepSeek-V4-Pro")
+        with pytest.raises(ValueError, match="Batch API not supported"):
+            cancel_batch(c, "b1")

--- a/tests/tutormoments/test_client.py
+++ b/tests/tutormoments/test_client.py
@@ -55,13 +55,12 @@ def test_infer_provider_unknown_raises():
 
 
 class TestGenerateThinkingWire:
-    """The thinking ladder resolves to the exact wire bytes the raw knobs sent.
+    """Provider-native thinking configs resolve to the exact wire bytes.
 
-    The full (family, rung) -> wire matrix is pinned in test_models.py; these
+    The full native-config -> wire matrix is pinned in test_models.py; these
     tests prove the client actually places each resolved fragment on the
-    request. Each expected payload is byte-identical to what the pre-ladder
-    client produced for the equivalent raw-knob inputs (thinking=True,
-    thinking_budget, effort, reasoning_effort) -- the wire-level
+    request. Each expected payload is byte-identical to what earlier client
+    revisions produced for the equivalent inputs -- the wire-level
     reproducibility proof for the refactor.
     """
 
@@ -74,25 +73,29 @@ class TestGenerateThinkingWire:
             ModelClient(model).generate("Q", json_mode=False, **gen_kwargs)
         return client_obj.messages.create.call_args.kwargs
 
-    def test_anthropic_dynamic_sends_adaptive(self, monkeypatch):
-        # Old thinking=True on adaptive-tier models.
-        kwargs = self._anthropic(monkeypatch, "claude-opus-4-6", thinking="dynamic")
+    def test_anthropic_adaptive_sends_adaptive(self, monkeypatch):
+        kwargs = self._anthropic(
+            monkeypatch, "claude-opus-4-6", thinking={"thinking": {"type": "adaptive"}}
+        )
         assert kwargs["thinking"] == {"type": "adaptive"}
         assert "extra_body" not in kwargs  # no effort alongside plain adaptive
 
-    def test_anthropic_xhigh_sends_adaptive_plus_effort(self, monkeypatch):
-        # Old thinking=True + effort="xhigh".
-        kwargs = self._anthropic(monkeypatch, "claude-opus-4-8", thinking="xhigh")
+    def test_anthropic_adaptive_plus_effort(self, monkeypatch):
+        kwargs = self._anthropic(
+            monkeypatch,
+            "claude-opus-4-8",
+            thinking={"thinking": {"type": "adaptive"}, "effort": "xhigh"},
+        )
         assert kwargs["thinking"] == {"type": "adaptive"}
         assert kwargs["extra_body"]["output_config"] == {"effort": "xhigh"}
 
-    def test_anthropic_legacy_high_sends_enabled_budget_and_bumps_max_tokens(
-        self, monkeypatch
-    ):
-        # Old haiku-4-5 thinking=True (legacy enabled + default budget 16384).
+    def test_anthropic_enabled_budget_bumps_max_tokens(self, monkeypatch):
         # Enabled mode requires max_tokens >= budget + headroom.
         kwargs = self._anthropic(
-            monkeypatch, "claude-haiku-4-5", thinking="high", max_tokens=100
+            monkeypatch,
+            "claude-haiku-4-5",
+            thinking={"thinking": {"type": "enabled", "budget_tokens": 16384}},
+            max_tokens=100,
         )
         assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 16384}
         assert kwargs["max_tokens"] == 16384 + 64
@@ -104,8 +107,10 @@ class TestGenerateThinkingWire:
         kwargs = self._anthropic(monkeypatch, "claude-haiku-4-5-20251001")
         assert kwargs["max_tokens"] == 64000
 
-    def test_anthropic_none_level_sends_no_thinking_param(self, monkeypatch):
-        kwargs = self._anthropic(monkeypatch, "claude-opus-4-6", thinking="none")
+    def test_anthropic_null_thinking_sends_no_thinking_param(self, monkeypatch):
+        kwargs = self._anthropic(
+            monkeypatch, "claude-opus-4-6", thinking={"thinking": None}
+        )
         assert "thinking" not in kwargs
         assert "extra_body" not in kwargs
 
@@ -129,16 +134,19 @@ class TestGenerateThinkingWire:
         return client_obj.models.generate_content.call_args.kwargs
 
     def test_gemini_dynamic_sends_budget_minus_one(self, monkeypatch):
-        # Old thinking=True + thinking_budget=-1.
-        kwargs = self._gemini(monkeypatch, "gemini-2.5-pro", thinking="dynamic")
+        kwargs = self._gemini(
+            monkeypatch, "gemini-2.5-pro", thinking={"thinking_budget": -1}
+        )
         assert kwargs["config"]["thinking_config"] == {
             "include_thoughts": True,
             "thinking_budget": -1,
         }
 
-    def test_gemini_flash_none_sends_zero_budget(self, monkeypatch):
-        # Old thinking=False; only valid where the API accepts budget 0.
-        kwargs = self._gemini(monkeypatch, "gemini-2.5-flash", thinking="none")
+    def test_gemini_flash_zero_budget_disables_thoughts(self, monkeypatch):
+        # Only valid where the API accepts budget 0.
+        kwargs = self._gemini(
+            monkeypatch, "gemini-2.5-flash", thinking={"thinking_budget": 0}
+        )
         assert kwargs["config"]["thinking_config"] == {
             "include_thoughts": False,
             "thinking_budget": 0,
@@ -161,18 +169,15 @@ class TestGenerateThinkingWire:
         return client_obj.chat.completions.create.call_args.kwargs
 
     def test_openai_high_sends_reasoning_effort(self, monkeypatch):
-        # Old reasoning_effort="high".
-        kwargs = self._openai(monkeypatch, "gpt-5.5", thinking="high")
+        kwargs = self._openai(monkeypatch, "gpt-5.5", thinking={"reasoning": "high"})
         assert kwargs["reasoning_effort"] == "high"
 
     def test_openai_no_condition_omits_reasoning_effort(self, monkeypatch):
         kwargs = self._openai(monkeypatch, "gpt-5.5")
         assert "reasoning_effort" not in kwargs
 
-    def test_unsatisfiable_level_fails_before_sdk_call_without_retries(
-        self, monkeypatch
-    ):
-        # gemini-2.5-pro is always-thinking: `none` must die at resolve time,
+    def test_malformed_config_fails_before_sdk_call_without_retries(self, monkeypatch):
+        # A provider-mismatched thinking config must die at resolve time,
         # before any request is made and without burning the retry budget.
         monkeypatch.setenv("GEMINI_API_KEY", "k")
         with (
@@ -183,16 +188,17 @@ class TestGenerateThinkingWire:
             MockGenai.return_value = client_obj
             c = ModelClient("gemini-2.5-pro")
             with pytest.raises(ThinkingConfigError):
-                c.generate("Q", json_mode=False, thinking="none")
+                c.generate("Q", json_mode=False, thinking={"reasoning": "high"})
         client_obj.models.generate_content.assert_not_called()
         mock_sleep.assert_not_called()
 
-    def test_unregistered_model_with_explicit_level_fails_closed(self, monkeypatch):
+    def test_retired_ladder_level_fails_closed(self, monkeypatch):
+        # A stray ladder-level string must not silently configure anything.
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         with patch("anthropic.Anthropic") as MockAnthropic:
             client_obj = MagicMock()
             MockAnthropic.return_value = client_obj
-            c = ModelClient("claude-experimental-dev-model")
+            c = ModelClient("claude-opus-4-8")
             with pytest.raises(ThinkingConfigError):
                 c.generate("Q", json_mode=False, thinking="high")
         client_obj.messages.create.assert_not_called()
@@ -675,9 +681,7 @@ def test_run_batch_anthropic_remaps_custom_ids(monkeypatch):
 def test_run_batch_anthropic_sends_thinking_and_effort(monkeypatch):
     """Batch requests must carry the same wire thinking/effort fragment as sync
     calls (benchmark fidelity: batch mode may not silently diverge from
-    run_conversation). thinking="xhigh" resolves to adaptive thinking plus
-    output_config.effort -- the exact bytes the retired thinking=True +
-    effort="xhigh" knobs produced."""
+    run_conversation): adaptive thinking plus output_config.effort."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     with (
         patch("anthropic.Anthropic") as MockAnthropic,
@@ -696,15 +700,15 @@ def test_run_batch_anthropic_sends_thinking_and_effort(monkeypatch):
             c,
             [build_batch_entry("kA", "pA")],
             poll_interval=0,
-            thinking="xhigh",
+            thinking={"thinking": {"type": "adaptive"}, "effort": "xhigh"},
         )
         (submitted,) = client_obj.messages.batches.create.call_args.kwargs["requests"]
     assert submitted["params"]["thinking"] == {"type": "adaptive"}
     assert submitted["params"]["output_config"] == {"effort": "xhigh"}
 
 
-def test_run_batch_anthropic_legacy_budget_and_registry_cap(monkeypatch):
-    """Legacy (enabled+budget) models get budget_tokens on batch requests, no
+def test_run_batch_anthropic_enabled_budget_and_registry_cap(monkeypatch):
+    """Enabled+budget thinking gets budget_tokens on batch requests, no
     output_config, and the registry's per-model output cap clamps the entry's
     max_tokens (build_batch_entry's 65536 default > haiku's 64000 cap)."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
@@ -725,7 +729,7 @@ def test_run_batch_anthropic_legacy_budget_and_registry_cap(monkeypatch):
             c,
             [build_batch_entry("kA", "pA")],
             poll_interval=0,
-            thinking="high",
+            thinking={"thinking": {"type": "enabled", "budget_tokens": 16384}},
         )
         (submitted,) = client_obj.messages.batches.create.call_args.kwargs["requests"]
     assert submitted["params"]["thinking"] == {
@@ -1305,7 +1309,7 @@ def _mock_gemini_batch_client(result_text: str):
 def test_run_batch_gemini_injects_thinking_config_without_mutating_entries(
     monkeypatch,
 ):
-    """thinking="dynamic" lands in every uploaded JSONL line's
+    """A model-paced thinking config lands in every uploaded JSONL line's
     generation_config as the include_thoughts/budget -1 wire shape, and the
     caller's entry dicts stay untouched (resume flows re-submit them)."""
     monkeypatch.setenv("GEMINI_API_KEY", "key-test")
@@ -1330,7 +1334,7 @@ def test_run_batch_gemini_injects_thinking_config_without_mutating_entries(
         client_obj, captured = _mock_gemini_batch_client(result_text)
         MockGenai.return_value = client_obj
         c = ModelClient("gemini-2.5-pro")
-        out = run_batch(c, entries, poll_interval=0, thinking="dynamic")
+        out = run_batch(c, entries, poll_interval=0, thinking={"thinking_budget": -1})
     lines = [json.loads(ln) for ln in captured["jsonl"].strip().splitlines()]
     assert len(lines) == 2
     for line in lines:
@@ -1376,13 +1380,16 @@ def test_run_batch_gemini_skips_thought_parts_and_joins_text(monkeypatch):
         MockGenai.return_value = client_obj
         c = ModelClient("gemini-2.5-pro")
         out = run_batch(
-            c, [build_batch_entry("kA", "pA")], poll_interval=0, thinking="dynamic"
+            c,
+            [build_batch_entry("kA", "pA")],
+            poll_interval=0,
+            thinking={"thinking_budget": -1},
         )
     assert out["kA"]["text"] == '{"a": 1}'
 
 
-def test_run_batch_unsatisfiable_level_fails_before_upload(monkeypatch):
-    """A level the model cannot honor dies at resolve time -- nothing is
+def test_run_batch_malformed_config_fails_before_upload(monkeypatch):
+    """A malformed thinking config dies at resolve time -- nothing is
     uploaded and no batch job is created."""
     monkeypatch.setenv("GEMINI_API_KEY", "key-test")
     with patch("google.genai.Client") as MockGenai:
@@ -1391,22 +1398,43 @@ def test_run_batch_unsatisfiable_level_fails_before_upload(monkeypatch):
         c = ModelClient("gemini-2.5-pro")
         with pytest.raises(ThinkingConfigError):
             run_batch(
-                c, [build_batch_entry("k", "p")], poll_interval=0, thinking="none"
+                c,
+                [build_batch_entry("k", "p")],
+                poll_interval=0,
+                thinking={"reasoning": "high"},
             )
     client_obj.files.upload.assert_not_called()
     client_obj.batches.create.assert_not_called()
 
 
+def test_run_sync_entries_malformed_config_fails_before_loop(monkeypatch):
+    """Fail-fast parity with run_batch: a malformed thinking mapping raises
+    up front instead of being demoted to N identical per-entry errors."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    with patch("anthropic.Anthropic"):
+        c = ModelClient("claude-opus-4-6")
+    with patch.object(c, "generate") as mock_gen:
+        with pytest.raises(ThinkingConfigError):
+            run_sync_entries(
+                c, [build_batch_entry("k1", "p1")], thinking={"reasoning": "high"}
+            )
+    mock_gen.assert_not_called()
+
+
 def test_run_sync_entries_forwards_thinking_to_generate(monkeypatch):
-    """run_sync_entries takes the same ladder level run_batch does and passes
-    it straight through to generate(), so switching between the sync and batch
-    paths keeps the same benchmark condition."""
+    """run_sync_entries takes the same thinking mapping run_batch does and
+    passes it straight through to generate(), so switching between the sync
+    and batch paths keeps the same benchmark condition."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     with patch("anthropic.Anthropic"):
         c = ModelClient("claude-opus-4-6")
     with patch.object(c, "generate", return_value=ModelResponse("R")) as mock_gen:
-        out = run_sync_entries(c, [build_batch_entry("k1", "p1")], thinking="dynamic")
-    assert mock_gen.call_args.kwargs["thinking"] == "dynamic"
+        out = run_sync_entries(
+            c,
+            [build_batch_entry("k1", "p1")],
+            thinking={"thinking": {"type": "adaptive"}},
+        )
+    assert mock_gen.call_args.kwargs["thinking"] == {"thinking": {"type": "adaptive"}}
     assert out["k1"]["text"] == "R"
 
 

--- a/tests/tutormoments/test_client.py
+++ b/tests/tutormoments/test_client.py
@@ -519,11 +519,23 @@ def test_run_sync_entries_records_error_per_key(monkeypatch):
             out = run_sync_entries(c, [build_batch_entry("k1", "p1")])
     assert out["k1"]["text"] == ""
     assert "boom" in out["k1"]["error"]
-    assert out["k1"]["usage"] == {
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "total_tokens": 0,
-    }
+    # Error rows keep zeros but carry the canonical keys + provenance.
+    usage = out["k1"]["usage"]
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "input_uncached",
+        "cache_read",
+        "cache_write",
+        "output",
+        "reasoning",
+        "total",
+    ):
+        assert usage[key] == 0
+    assert usage["provider"] == "anthropic"
+    assert usage["model"] == "claude-opus-4-6"
+    assert usage["endpoint"] == "sync"
 
 
 def test_run_batch_anthropic_remaps_custom_ids(monkeypatch):
@@ -548,7 +560,12 @@ def test_run_batch_anthropic_remaps_custom_ids(monkeypatch):
             b.type = "text"
             b.text = text
             msg.content = [b]
-            msg.usage = MagicMock(input_tokens=1, output_tokens=1)
+            msg.usage = MagicMock(
+                input_tokens=1,
+                output_tokens=1,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
             r.result.message = msg
             return r
 
@@ -618,7 +635,12 @@ def test_run_batch_anthropic_resume_rebuilds_id_map(monkeypatch):
             b.type = "text"
             b.text = text
             msg.content = [b]
-            msg.usage = MagicMock(input_tokens=1, output_tokens=1)
+            msg.usage = MagicMock(
+                input_tokens=1,
+                output_tokens=1,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
             r.result.message = msg
             return r
 
@@ -743,3 +765,360 @@ def test_run_batch_unsupported_provider_raises(monkeypatch):
         c = ModelClient("deepseek-ai/DeepSeek-V3")
         with pytest.raises(ValueError, match="Batch API not supported"):
             run_batch(c, [build_batch_entry("k", "p")], poll_interval=0)
+
+
+# ===================================================================
+# Canonical usage vector (cost tracking, Phase 1)
+# ===================================================================
+
+from types import SimpleNamespace
+
+from tutormoments.client import normalize_usage
+
+
+def test_normalize_usage_total_is_derived_and_provenance_rides_along():
+    u = normalize_usage(
+        "gemini",
+        "gemini-3.1-pro-preview",
+        "sync",
+        input_uncached=200,
+        cache_read=100,
+        cache_write=25,
+        output=30,
+        reasoning=50,
+    )
+    assert u["total"] == 405  # one definition: sum of the five buckets
+    assert u["provider"] == "gemini"
+    assert u["model"] == "gemini-3.1-pro-preview"
+    assert u["endpoint"] == "sync"
+
+
+def test_model_response_default_usage_has_canonical_zero_vector():
+    usage = ModelResponse("x").usage
+    for key in ("input_uncached", "cache_read", "cache_write", "output", "reasoning"):
+        assert usage[key] == 0
+    assert usage["total"] == 0
+
+
+def _gemini_usage_meta(prompt=300, candidates=25, cached=100, thoughts=50):
+    return SimpleNamespace(
+        prompt_token_count=prompt,
+        candidates_token_count=candidates,
+        total_token_count=prompt + candidates + thoughts,
+        cached_content_token_count=cached,
+        thoughts_token_count=thoughts,
+    )
+
+
+def _assert_gemini_vector(usage, endpoint):
+    assert usage["input_uncached"] == 200  # prompt 300 minus 100 cached
+    assert usage["cache_read"] == 100
+    assert usage["cache_write"] == 0
+    assert usage["output"] == 25
+    assert usage["reasoning"] == 50
+    # Canonical total agrees with the provider's thinking-inclusive total,
+    # unlike legacy input+output recomputation.
+    assert usage["total"] == 375
+    assert usage["total_tokens"] == 375
+    assert usage["provider"] == "gemini"
+    assert usage["endpoint"] == endpoint
+
+
+def test_gemini_sync_captures_cache_read_and_reasoning(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "k")
+    with patch("google.genai.Client") as MockGenai:
+        client_obj = MagicMock()
+        client_obj.models.generate_content.return_value = SimpleNamespace(
+            text="hi", usage_metadata=_gemini_usage_meta()
+        )
+        MockGenai.return_value = client_obj
+        resp = ModelClient("gemini-3.1-pro-preview").generate("Q", json_mode=False)
+    _assert_gemini_vector(resp.usage, "sync")
+
+
+def test_gemini_stream_captures_cache_read_and_reasoning(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "k")
+    chunk = SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[SimpleNamespace(text="hi", thought=False)]
+                )
+            )
+        ],
+        usage_metadata=_gemini_usage_meta(),
+    )
+    with patch("google.genai.Client") as MockGenai:
+        client_obj = MagicMock()
+        client_obj.models.generate_content_stream.return_value = iter([chunk])
+        MockGenai.return_value = client_obj
+        resp = ModelClient("gemini-3.1-pro-preview").generate(
+            "Q", json_mode=False, stream=True
+        )
+    _assert_gemini_vector(resp.usage, "stream")
+
+
+def test_openai_sync_splits_cached_tokens_out_of_prompt(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))],
+        usage=SimpleNamespace(
+            prompt_tokens=500,
+            completion_tokens=20,
+            total_tokens=520,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=400),
+        ),
+    )
+    with patch("openai.OpenAI") as MockOpenAI:
+        client_obj = MagicMock()
+        client_obj.chat.completions.create.return_value = response
+        MockOpenAI.return_value = client_obj
+        resp = ModelClient("gpt-5.5-2026-04-23").generate("Q", json_mode=False)
+    usage = resp.usage
+    assert usage["input_uncached"] == 100
+    assert usage["cache_read"] == 400
+    assert usage["reasoning"] == 0
+    assert usage["output"] == 20
+    assert usage["total"] == 520
+    assert usage["input_tokens"] == 500  # legacy keys preserved
+    assert usage["provider"] == "openai"
+    assert usage["endpoint"] == "sync"
+
+
+def test_openai_sync_captures_cache_write_tokens(monkeypatch):
+    """GPT-5.6-generation models meter cache writes (billed at 1.25x input)
+    under prompt_tokens_details.cache_write_tokens, a subset of prompt_tokens
+    disjoint from cached_tokens. Mirrors live gpt-5.6-luna evidence
+    (2026-08-24): prompt 1120 = 1117 written + 3 uncached, plus a mixed case.
+    Older models' usage objects lack the attribute entirely -> 0 (covered by
+    test_openai_sync_splits_cached_tokens_out_of_prompt's fixture)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))],
+        usage=SimpleNamespace(
+            prompt_tokens=1120,
+            completion_tokens=5,
+            total_tokens=1125,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=100, cache_write_tokens=1017
+            ),
+        ),
+    )
+    with patch("openai.OpenAI") as MockOpenAI:
+        client_obj = MagicMock()
+        client_obj.chat.completions.create.return_value = response
+        MockOpenAI.return_value = client_obj
+        resp = ModelClient("gpt-5.5-2026-04-23").generate("Q", json_mode=False)
+    usage = resp.usage
+    assert usage["cache_write"] == 1017
+    assert usage["cache_read"] == 100
+    assert usage["input_uncached"] == 3  # prompt - cached - written
+    assert usage["output"] == 5
+    assert usage["total"] == 1125
+    assert usage["input_tokens"] == 1120  # legacy key untouched
+
+
+def test_together_sync_and_stream_report_identical_vectors(monkeypatch):
+    """Regression for the sync/stream asymmetry: the sync Together path used
+    to drop cached_tokens that the streamed path captured."""
+    monkeypatch.setenv("TOGETHER_API_KEY", "sk-test")
+    usage_obj = SimpleNamespace(
+        prompt_tokens=50,
+        completion_tokens=10,
+        total_tokens=60,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=7),
+    )
+
+    with patch("openai.OpenAI") as MockOpenAI:
+        client_obj = MagicMock()
+        client_obj.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))],
+            usage=usage_obj,
+        )
+        MockOpenAI.return_value = client_obj
+        sync_usage = (
+            ModelClient("deepseek-ai/DeepSeek-V4-Pro")
+            .generate("Q", json_mode=False)
+            .usage
+        )
+
+    chunks = [
+        SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="hi"))], usage=None
+        ),
+        SimpleNamespace(choices=[], usage=usage_obj),
+    ]
+    with patch("openai.OpenAI") as MockOpenAI:
+        client_obj = MagicMock()
+        client_obj.chat.completions.create.return_value = iter(chunks)
+        MockOpenAI.return_value = client_obj
+        stream_usage = (
+            ModelClient("deepseek-ai/DeepSeek-V4-Pro")
+            .generate("Q", json_mode=False, stream=True)
+            .usage
+        )
+
+    assert sync_usage["cached_tokens"] == 7
+    assert sync_usage["cache_read"] == 7
+    assert sync_usage["input_uncached"] == 43
+    assert sync_usage["provider"] == "together"
+    assert sync_usage["endpoint"] == "sync"
+    assert stream_usage["endpoint"] == "stream"
+    for key, value in sync_usage.items():
+        if key != "endpoint":
+            assert stream_usage[key] == value, key
+
+
+def test_anthropic_sync_cache_buckets_stay_disjoint_from_input(monkeypatch):
+    """input_tokens already excludes the cache buckets, so input_uncached maps
+    to it directly -- re-adding cache tokens at the base rate is the
+    double-count trap the costing layer guards against."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    msg = _fake_anthropic_message("hi", in_tok=10, out_tok=5)
+    msg.usage = MagicMock(
+        input_tokens=10,
+        output_tokens=5,
+        cache_creation_input_tokens=100,
+        cache_read_input_tokens=800,
+    )
+    with patch("anthropic.Anthropic") as MockAnthropic:
+        client_obj = MagicMock()
+        client_obj.messages.create.return_value = msg
+        MockAnthropic.return_value = client_obj
+        resp = ModelClient("claude-opus-4-6").generate("Q", json_mode=False)
+    usage = resp.usage
+    assert usage["input_uncached"] == 10
+    assert usage["cache_read"] == 800
+    assert usage["cache_write"] == 100
+    assert usage["output"] == 5
+    assert usage["total"] == 915
+    assert usage["total_tokens"] == 15  # legacy definition unchanged
+    assert usage["endpoint"] == "sync"
+
+
+def test_run_batch_anthropic_cache_fields_survive(monkeypatch):
+    """Regression for the open-coded batch usage dict that silently dropped
+    the cache buckets: the batch path must route through _anthropic_usage."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    with (
+        patch("anthropic.Anthropic") as MockAnthropic,
+        patch("tutormoments.client.time.sleep"),
+    ):
+        client_obj = MagicMock()
+        batch = MagicMock()
+        batch.id = "b1"
+        batch.processing_status = "ended"
+        client_obj.messages.batches.create.return_value = batch
+        client_obj.messages.batches.retrieve.return_value = batch
+
+        r = MagicMock()
+        r.custom_id = "r0"
+        r.result.type = "succeeded"
+        msg = MagicMock()
+        block = MagicMock()
+        block.type = "text"
+        block.text = "A"
+        msg.content = [block]
+        msg.usage = MagicMock(
+            input_tokens=10,
+            output_tokens=5,
+            cache_creation_input_tokens=55,
+            cache_read_input_tokens=1234,
+        )
+        r.result.message = msg
+        client_obj.messages.batches.results.return_value = [r]
+        MockAnthropic.return_value = client_obj
+        c = ModelClient("claude-opus-4-6")
+        out = run_batch(c, [build_batch_entry("kA", "pA")], poll_interval=0)
+    usage = out["kA"]["usage"]
+    assert usage["cache_read"] == 1234
+    assert usage["cache_write"] == 55
+    assert usage["cache_read_input_tokens"] == 1234  # legacy key too
+    assert usage["input_uncached"] == 10
+    assert usage["total"] == 1304
+    assert usage["endpoint"] == "batch"
+    assert usage["provider"] == "anthropic"
+
+
+def test_run_batch_openai_forces_cache_read_zero(monkeypatch):
+    """Prompt caching does not apply on the OpenAI Batch API, so cache_read is
+    0 by construction even if the response body carries a cached_tokens field."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    with patch("openai.OpenAI") as MockOpenAI, patch("tutormoments.client.time.sleep"):
+        client_obj = MagicMock()
+        uploaded = MagicMock()
+        uploaded.id = "file-1"
+        client_obj.files.create.return_value = uploaded
+        batch = MagicMock()
+        batch.id = "ob1"
+        batch.status = "completed"
+        batch.output_file_id = "out-1"
+        client_obj.batches.create.return_value = batch
+        client_obj.batches.retrieve.return_value = batch
+        line = json.dumps(
+            {
+                "custom_id": "kA",
+                "response": {
+                    "body": {
+                        "choices": [{"message": {"content": "A"}}],
+                        "usage": {
+                            "prompt_tokens": 12,
+                            "completion_tokens": 3,
+                            "total_tokens": 15,
+                            "prompt_tokens_details": {"cached_tokens": 9},
+                        },
+                    }
+                },
+            }
+        )
+        content_obj = MagicMock()
+        content_obj.content = line.encode("utf-8")
+        client_obj.files.content.return_value = content_obj
+        MockOpenAI.return_value = client_obj
+        c = ModelClient("gpt-5.4")
+        out = run_batch(c, [build_batch_entry("kA", "pA")], poll_interval=0)
+    usage = out["kA"]["usage"]
+    assert usage["cache_read"] == 0
+    assert usage["input_uncached"] == 12
+    assert usage["output"] == 3
+    assert usage["total"] == 15
+    assert usage["endpoint"] == "batch"
+    assert usage["provider"] == "openai"
+
+
+def test_run_batch_gemini_captures_cache_read_and_reasoning(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "key-test")
+    with (
+        patch("google.genai.Client") as MockGenai,
+        patch("tutormoments.client.time.sleep"),
+    ):
+        client_obj = MagicMock()
+        uploaded = MagicMock()
+        uploaded.name = "files/up1"
+        client_obj.files.upload.return_value = uploaded
+        batch = MagicMock()
+        batch.name = "batches/gb1"
+        batch.state.name = "JOB_STATE_SUCCEEDED"
+        batch.dest.file_name = "files/out1"
+        client_obj.batches.create.return_value = batch
+        client_obj.batches.get.return_value = batch
+        line = json.dumps(
+            {
+                "key": "kA",
+                "response": {
+                    "candidates": [{"content": {"parts": [{"text": "A"}]}}],
+                    "usageMetadata": {
+                        "promptTokenCount": 300,
+                        "candidatesTokenCount": 25,
+                        "totalTokenCount": 375,
+                        "cachedContentTokenCount": 100,
+                        "thoughtsTokenCount": 50,
+                    },
+                },
+            }
+        )
+        client_obj.files.download.return_value = line.encode("utf-8")
+        MockGenai.return_value = client_obj
+        c = ModelClient("gemini-3.1-pro-preview")
+        out = run_batch(c, [build_batch_entry("kA", "pA")], poll_interval=0)
+    _assert_gemini_vector(out["kA"]["usage"], "batch")

--- a/tests/tutormoments/test_config.py
+++ b/tests/tutormoments/test_config.py
@@ -4,23 +4,27 @@ import pytest
 
 from tutormoments import config as cfgmod
 from tutormoments.config import ArmSpec
-from tutormoments.models import ThinkingConfigError, ThinkingLevel
+from tutormoments.models import ThinkingConfigError
 
 # A complete, valid config skeleton for override tests. Individual tests
 # append or replace blocks on top of it.
-_BASE_YAML = """
+_BASE_ARM = (
+    "benchmark_models:\n"
+    "  claude-opus-4-8: { model: claude-opus-4-8, thinking: { type: adaptive }, "
+    "effort: xhigh, condition: xhigh }"
+)
+_BASE_YAML = f"""
 providers:
-  anthropic: { env: ANTHROPIC_API_KEY }
-  openai:    { env: OPENAI_API_KEY }
-  gemini:    { env: GEMINI_API_KEY }
-  together:  { env: TOGETHER_API_KEY }
-models:
-  claude-opus-4-8: { thinking: xhigh }
-student: { model: claude-opus-4-6, mode: oracle, thinking: none }
-scorer:  { model: claude-opus-4-6, thinking: dynamic }
-defaults: { trials: 1, max_turns: 2 }
-retry:    { max_retries: 1, base_delay: 1 }
-batch:    { timeout: 123 }
+  anthropic: {{ env: ANTHROPIC_API_KEY }}
+  openai:    {{ env: OPENAI_API_KEY }}
+  gemini:    {{ env: GEMINI_API_KEY }}
+  together:  {{ env: TOGETHER_API_KEY }}
+{_BASE_ARM}
+student: {{ model: claude-opus-4-6, mode: oracle, thinking: null }}
+scorer:  {{ model: claude-opus-4-6, thinking: {{ type: adaptive }} }}
+defaults: {{ trials: 1, max_turns: 2 }}
+retry:    {{ max_retries: 1, base_delay: 1 }}
+batch:    {{ timeout: 123 }}
 """
 
 
@@ -29,6 +33,10 @@ def _write_config(tmp_path, text):
     config_path.write_text(text, encoding="utf-8")
     cfgmod._reset_config_cache()
     return config_path
+
+
+def _with_roster(tmp_path, roster_yaml: str):
+    return _write_config(tmp_path, _BASE_YAML.replace(_BASE_ARM, roster_yaml))
 
 
 def test_packaged_default_config_parses_and_has_expected_roster():
@@ -63,12 +71,15 @@ def test_packaged_default_config_parses_and_has_expected_roster():
     assert cfg["student"] == {
         "model": "claude-opus-4-6",
         "mode": "oracle",
-        "thinking": "none",
+        "thinking": {"type": "disabled"},
     }
-    assert cfg["scorer"] == {"model": "claude-opus-4-6", "thinking": "dynamic"}
+    assert cfg["scorer"] == {
+        "model": "claude-opus-4-6",
+        "thinking": {"type": "adaptive"},
+    }
     assert cfg["taxonomy"] == {
         "model": "claude-opus-4-8",
-        "thinking": "none",
+        "thinking": {"type": "disabled"},
         "batch_size": 50,
     }
     assert cfg["defaults"] == {"trials": 1, "max_turns": 5}
@@ -140,7 +151,8 @@ def test_resolve_arm_unknown_raises():
 def test_scorer_and_student_specs():
     cfgmod._reset_config_cache()
     assert cfgmod.scorer_spec().model == "claude-opus-4-6"
-    assert cfgmod.student_spec().thinking == ThinkingLevel.NONE
+    assert cfgmod.scorer_spec().thinking == {"thinking": {"type": "adaptive"}}
+    assert cfgmod.student_spec().thinking == {"thinking": {"type": "disabled"}}
 
 
 def test_build_run_config_defaults():
@@ -213,7 +225,7 @@ def test_groundtruth_phase_config_shape():
     cfgmod._reset_config_cache()
     gt = cfgmod.get_groundtruth_phase_config()
     assert gt.model == "claude-opus-4-8"
-    assert gt.thinking == ThinkingLevel.DYNAMIC
+    assert gt.thinking == {"thinking": {"type": "adaptive"}}
     assert gt.poll_interval == 60
     assert gt.labeller is not None
 
@@ -234,14 +246,13 @@ def test_get_labeller_config_routes_by_type():
 
 def test_arm_model_key_distinct_and_shared_model(tmp_path):
     """An arm's `model:` may differ from its key; two arms may share a model."""
-    config_path = _write_config(
+    config_path = _with_roster(
         tmp_path,
-        _BASE_YAML.replace(
-            "models:\n  claude-opus-4-8: { thinking: xhigh }",
-            "models:\n"
-            "  opus-deep:    { model: claude-opus-4-8, thinking: xhigh }\n"
-            "  opus-shallow: { model: claude-opus-4-8, thinking: low }",
-        ),
+        "benchmark_models:\n"
+        "  opus-deep:    { model: claude-opus-4-8, thinking: { type: adaptive }, "
+        "effort: xhigh, condition: xhigh }\n"
+        "  opus-shallow: { model: claude-opus-4-8, thinking: { type: adaptive }, "
+        "effort: low, condition: low }",
     )
     deep = cfgmod.resolve_arm("opus-deep", config_path=config_path)
     shallow = cfgmod.resolve_arm("opus-shallow", config_path=config_path)
@@ -249,43 +260,33 @@ def test_arm_model_key_distinct_and_shared_model(tmp_path):
     assert deep.model == "claude-opus-4-8"
     # Provider is inferred from the model id, not the (arbitrary) arm key.
     assert deep.provider == "anthropic"
-    assert deep.thinking == "xhigh"
+    assert deep.thinking == {"thinking": {"type": "adaptive"}, "effort": "xhigh"}
     # The two arms coexist as distinct conditions on the same model.
     assert shallow.model == deep.model
-    assert shallow.thinking == "low"
+    assert shallow.thinking == {"thinking": {"type": "adaptive"}, "effort": "low"}
 
 
 def test_arm_model_defaults_to_key(tmp_path):
-    config_path = _write_config(tmp_path, _BASE_YAML)
+    config_path = _with_roster(
+        tmp_path,
+        "benchmark_models:\n"
+        "  claude-opus-4-8: { thinking: { type: adaptive }, effort: xhigh, "
+        "condition: xhigh }",
+    )
     arm = cfgmod.resolve_arm("claude-opus-4-8", config_path=config_path)
     assert arm.model == "claude-opus-4-8"
     assert arm.provider == "anthropic"
 
 
-def test_arm_missing_thinking_fails_at_load(tmp_path):
-    config_path = _write_config(
-        tmp_path,
-        _BASE_YAML.replace(
-            "claude-opus-4-8: { thinking: xhigh }", "claude-opus-4-8: {}"
-        ),
-    )
-    with pytest.raises(ThinkingConfigError, match="`thinking` is required"):
-        cfgmod.load_config(config_path)
-    # ThinkingConfigError is a ValueError, so broad callers still catch it.
-    assert issubclass(ThinkingConfigError, ValueError)
-
-
 def test_benchmark_models_accept_provider_native_params(tmp_path):
     """benchmark_models states the exact provider-native knobs in config."""
-    config_path = _write_config(
+    config_path = _with_roster(
         tmp_path,
-        _BASE_YAML.replace(
-            "models:\n  claude-opus-4-8: { thinking: xhigh }",
-            "benchmark_models:\n"
-            "  gemini-low: { model: gemini-2.5-pro, thinking_budget: 4096, condition: low }\n"
-            "  gpt-low:    { model: gpt-5.5-2026-04-23, reasoning: low, condition: low }\n"
-            "  sonnet-hi:  { model: claude-sonnet-4-6, thinking: { type: adaptive }, effort: high, condition: high }\n",
-        ),
+        "benchmark_models:\n"
+        "  gemini-low: { model: gemini-2.5-pro, thinking_budget: 4096, condition: low }\n"
+        "  gpt-low:    { model: gpt-5.5-2026-04-23, reasoning: low, condition: low }\n"
+        "  sonnet-hi:  { model: claude-sonnet-4-6, thinking: { type: adaptive }, "
+        "effort: high, condition: high }",
     )
     gemini = cfgmod.resolve_arm("gemini-low", config_path=config_path)
     gpt = cfgmod.resolve_arm("gpt-low", config_path=config_path)
@@ -299,95 +300,111 @@ def test_benchmark_models_accept_provider_native_params(tmp_path):
 
 
 def test_benchmark_models_reject_provider_mismatched_keys(tmp_path):
-    config_path = _write_config(
+    config_path = _with_roster(
         tmp_path,
-        _BASE_YAML.replace(
-            "models:\n  claude-opus-4-8: { thinking: xhigh }",
-            "benchmark_models:\n"
-            "  gpt-bad: { model: gpt-5.5-2026-04-23, thinking_budget: 4096, condition: low }\n",
-        ),
+        "benchmark_models:\n"
+        "  gpt-bad: { model: gpt-5.5-2026-04-23, thinking_budget: 4096, condition: low }",
     )
     with pytest.raises(ThinkingConfigError, match="unknown key"):
         cfgmod.load_config(config_path)
+    # ThinkingConfigError is a ValueError, so broad callers still catch it.
+    assert issubclass(ThinkingConfigError, ValueError)
 
 
 def test_benchmark_models_require_condition(tmp_path):
-    config_path = _write_config(
+    config_path = _with_roster(
         tmp_path,
-        _BASE_YAML.replace(
-            "models:\n  claude-opus-4-8: { thinking: xhigh }",
-            "benchmark_models:\n"
-            "  gpt-low: { model: gpt-5.5-2026-04-23, reasoning: low }\n",
-        ),
+        "benchmark_models:\n  gpt-low: { model: gpt-5.5-2026-04-23, reasoning: low }",
     )
     with pytest.raises(ThinkingConfigError, match="`condition`"):
         cfgmod.load_config(config_path)
 
 
-@pytest.mark.parametrize(
-    "entry",
-    [
-        "{ thinking: xhigh, thinking_budget: 8192 }",
-        "{ reasoning_effort: high }",
-        "{ thinking: high, effort: high }",
-    ],
-)
-def test_raw_knob_keys_rejected_with_migration_hint(tmp_path, entry):
-    config_path = _write_config(
+def test_benchmark_models_require_explicit_thinking(tmp_path):
+    # An anthropic arm must state its thinking block (null = send nothing);
+    # leaving it out entirely is not a benchmarkable condition.
+    config_path = _with_roster(
         tmp_path,
-        _BASE_YAML.replace(
-            "claude-opus-4-8: { thinking: xhigh }", f"claude-opus-4-8: {entry}"
-        ),
+        "benchmark_models:\n"
+        "  opus-implicit: { model: claude-opus-4-8, condition: default }",
     )
-    with pytest.raises(ThinkingConfigError, match="thinking ladder"):
+    with pytest.raises(ThinkingConfigError, match="must set thinking"):
         cfgmod.load_config(config_path)
 
 
-@pytest.mark.parametrize("value", ["true", "false"])
-def test_boolean_thinking_rejected_with_hint(tmp_path, value):
-    config_path = _write_config(
+def test_retired_models_roster_rejected_with_hint(tmp_path):
+    # The pre-release `models:` ladder roster must not load silently.
+    config_path = _with_roster(
         tmp_path,
-        _BASE_YAML.replace(
-            "claude-opus-4-8: { thinking: xhigh }",
-            f"claude-opus-4-8: {{ thinking: {value} }}",
-        ),
+        "models:\n  claude-opus-4-8: { thinking: xhigh }",
     )
-    with pytest.raises(ThinkingConfigError, match="replaced by the ladder"):
+    with pytest.raises(ThinkingConfigError, match="benchmark_models"):
         cfgmod.load_config(config_path)
 
 
-def test_unsatisfiable_scorer_level_fails_at_load(tmp_path):
-    # gemini-2.5-pro is always-thinking: `none` has no wire form.
+def test_retired_ladder_level_in_role_block_rejected(tmp_path):
     config_path = _write_config(
         tmp_path,
         _BASE_YAML.replace(
+            "scorer:  { model: claude-opus-4-6, thinking: { type: adaptive } }",
             "scorer:  { model: claude-opus-4-6, thinking: dynamic }",
-            "scorer:  { model: gemini-2.5-pro, thinking: none }",
         ),
     )
     with pytest.raises(ThinkingConfigError, match="config scorer"):
         cfgmod.load_config(config_path)
 
 
-def test_unsatisfiable_taxonomy_level_fails_at_load(tmp_path):
-    # The o-series has no off switch: `none` is unsatisfiable.
+def test_malformed_scorer_thinking_fails_at_load(tmp_path):
     config_path = _write_config(
         tmp_path,
-        _BASE_YAML + "taxonomy: { model: o3, thinking: none, batch_size: 10 }\n",
+        _BASE_YAML.replace(
+            "scorer:  { model: claude-opus-4-6, thinking: { type: adaptive } }",
+            "scorer:  { model: gemini-2.5-pro, thinking_budget: many }",
+        ),
+    )
+    with pytest.raises(ThinkingConfigError, match="config scorer"):
+        cfgmod.load_config(config_path)
+
+
+def test_provider_mismatched_taxonomy_keys_fail_at_load(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML + "taxonomy: { model: o3, thinking_budget: 4096, batch_size: 10 }\n",
     )
     with pytest.raises(ThinkingConfigError, match="config taxonomy"):
         cfgmod.load_config(config_path)
 
 
-def test_unsatisfiable_groundtruth_level_fails_at_load(tmp_path):
-    # DeepSeek reasons internally with no knob: only `dynamic` is expressible.
+def test_groundtruth_requires_provider_native_keys(tmp_path):
     config_path = _write_config(
         tmp_path,
         _BASE_YAML
-        + "groundtruth: { model: deepseek-ai/DeepSeek-V4-Pro, thinking: high }\n",
+        + "groundtruth: { model: deepseek-ai/DeepSeek-V4-Pro, reasoning: high }\n",
     )
     with pytest.raises(ThinkingConfigError, match="config groundtruth"):
         cfgmod.load_config(config_path)
+
+
+def test_registered_student_takes_no_thinking_keys(tmp_path):
+    from tutormoments import register_student
+
+    @register_student("scripted-student")
+    def scripted(conversation):
+        return "student turn"
+
+    try:
+        config_path = _write_config(
+            tmp_path,
+            _BASE_YAML.replace(
+                "student: { model: claude-opus-4-6, mode: oracle, thinking: null }",
+                "student: { model: scripted-student, mode: oracle }",
+            ),
+        )
+        spec = cfgmod.student_spec(config_path)
+        assert spec.model == "scripted-student"
+        assert spec.thinking is None
+    finally:
+        cfgmod._STUDENT_REGISTRY.pop("scripted-student", None)
 
 
 def test_specs_are_frozen():
@@ -395,11 +412,11 @@ def test_specs_are_frozen():
     cfgmod._reset_config_cache()
     arm = cfgmod.resolve_arm("claude-opus-4-8")
     with pytest.raises(dataclasses.FrozenInstanceError):
-        arm.thinking = ThinkingLevel.NONE
+        arm.thinking = {}
     with pytest.raises(dataclasses.FrozenInstanceError):
         cfgmod.student_spec().model = "other-model"
     with pytest.raises(dataclasses.FrozenInstanceError):
-        cfgmod.scorer_spec().thinking = ThinkingLevel.NONE
+        cfgmod.scorer_spec().thinking = {}
     # The cached spec is unchanged.
     assert cfgmod.resolve_arm("claude-opus-4-8").thinking == {
         "thinking": {"type": "adaptive"},
@@ -424,6 +441,6 @@ def test_build_run_config_mixes_registered_and_roster_tutors(tmp_path):
         assert rc.resolved_tutors["scripted-tutor"] is None
         arm = rc.resolved_tutors["claude-opus-4-8"]
         assert isinstance(arm, ArmSpec)
-        assert arm.thinking == "xhigh"
+        assert arm.thinking == {"thinking": {"type": "adaptive"}, "effort": "xhigh"}
     finally:
         cfgmod._TUTOR_REGISTRY.pop("scripted-tutor", None)

--- a/tests/tutormoments/test_config.py
+++ b/tests/tutormoments/test_config.py
@@ -1,4 +1,34 @@
+import dataclasses
+
+import pytest
+
 from tutormoments import config as cfgmod
+from tutormoments.config import ArmSpec
+from tutormoments.models import ThinkingConfigError, ThinkingLevel
+
+# A complete, valid config skeleton for override tests. Individual tests
+# append or replace blocks on top of it.
+_BASE_YAML = """
+providers:
+  anthropic: { env: ANTHROPIC_API_KEY }
+  openai:    { env: OPENAI_API_KEY }
+  gemini:    { env: GEMINI_API_KEY }
+  together:  { env: TOGETHER_API_KEY }
+models:
+  claude-opus-4-8: { thinking: xhigh }
+student: { model: claude-opus-4-6, mode: oracle, thinking: none }
+scorer:  { model: claude-opus-4-6, thinking: dynamic }
+defaults: { trials: 1, max_turns: 2 }
+retry:    { max_retries: 1, base_delay: 1 }
+batch:    { timeout: 123 }
+"""
+
+
+def _write_config(tmp_path, text):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(text, encoding="utf-8")
+    cfgmod._reset_config_cache()
+    return config_path
 
 
 def test_packaged_default_config_parses_and_has_expected_roster():
@@ -15,21 +45,18 @@ def test_packaged_default_config_parses_and_has_expected_roster():
         "gpt-5.5-2026-04-23",
         "deepseek-ai/DeepSeek-V4-Pro",
     }
-    assert cfg["models"]["claude-opus-4-8"] == {"thinking": True, "effort": "xhigh"}
-    assert cfg["models"]["claude-sonnet-5"] == {
-        "thinking": "adaptive",
-        "effort": "xhigh",
-    }
-    assert cfg["models"]["deepseek-ai/DeepSeek-V4-Pro"] == {}
+    assert cfg["models"]["claude-opus-4-8"] == {"thinking": "xhigh"}
+    assert cfg["models"]["claude-sonnet-5"] == {"thinking": "xhigh"}
+    assert cfg["models"]["deepseek-ai/DeepSeek-V4-Pro"] == {"thinking": "dynamic"}
     assert cfg["student"] == {
         "model": "claude-opus-4-6",
         "mode": "oracle",
-        "thinking": False,
+        "thinking": "none",
     }
-    assert cfg["scorer"] == {"model": "claude-opus-4-6", "thinking": "adaptive"}
+    assert cfg["scorer"] == {"model": "claude-opus-4-6", "thinking": "dynamic"}
     assert cfg["taxonomy"] == {
         "model": "claude-opus-4-8",
-        "thinking": False,
+        "thinking": "none",
         "batch_size": 50,
     }
     assert cfg["defaults"] == {"trials": 1, "max_turns": 5}
@@ -56,26 +83,7 @@ def test_load_config_returns_parsed_dict():
 
 
 def test_load_config_accepts_explicit_override(tmp_path):
-    config_path = tmp_path / "custom.yaml"
-    config_path.write_text(
-        """
-providers:
-  anthropic: { env: ANTHROPIC_API_KEY }
-  openai:    { env: OPENAI_API_KEY }
-  gemini:    { env: GEMINI_API_KEY }
-  together:  { env: TOGETHER_API_KEY }
-models:
-  claude-opus-4-8: { thinking: false }
-student: { model: claude-opus-4-6, mode: oracle, thinking: false }
-scorer:  { model: claude-opus-4-6, thinking: adaptive }
-defaults: { trials: 1, max_turns: 2 }
-retry:    { max_retries: 1, base_delay: 1 }
-batch:    { timeout: 123 }
-""",
-        encoding="utf-8",
-    )
-
-    cfgmod._reset_config_cache()
+    config_path = _write_config(tmp_path, _BASE_YAML)
     cfg = cfgmod.load_config(config_path)
     assert cfg["defaults"]["max_turns"] == 2
     rc = cfgmod.build_run_config(
@@ -86,39 +94,42 @@ batch:    { timeout: 123 }
     assert rc.config_source == str(config_path)
 
 
-def test_resolve_model_known():
-    r = cfgmod.resolve_model("claude-opus-4-8")
-    assert r["provider"] == "anthropic"
-    assert r["env"] == "ANTHROPIC_API_KEY"
-    assert r["kwargs"] == {"thinking": True, "effort": "xhigh"}
+def test_resolve_arm_known():
+    cfgmod._reset_config_cache()
+    arm = cfgmod.resolve_arm("claude-opus-4-8")
+    assert isinstance(arm, ArmSpec)
+    assert arm.name == "claude-opus-4-8"
+    assert arm.model == "claude-opus-4-8"
+    assert arm.provider == "anthropic"
+    assert arm.thinking == ThinkingLevel.XHIGH
+    assert arm.thinking == "xhigh"  # str-Enum: string comparison works
 
 
-def test_resolve_model_together_empty_kwargs():
-    r = cfgmod.resolve_model("deepseek-ai/DeepSeek-V4-Pro")
-    assert r["provider"] == "together"
-    assert r["kwargs"] == {}
+def test_resolve_arm_together():
+    arm = cfgmod.resolve_arm("deepseek-ai/DeepSeek-V4-Pro")
+    assert arm.provider == "together"
+    assert arm.thinking == "dynamic"
 
 
-def test_resolve_model_gemini():
-    r = cfgmod.resolve_model("gemini-2.5-pro")
-    assert r["provider"] == "gemini"
-    assert r["env"] == "GEMINI_API_KEY"
-    assert r["kwargs"] == {"thinking": True, "thinking_budget": -1}
+def test_resolve_arm_gemini():
+    arm = cfgmod.resolve_arm("gemini-2.5-pro")
+    assert arm.provider == "gemini"
+    assert arm.thinking == "dynamic"
 
 
-def test_resolve_model_unknown_raises():
-    import pytest
-
-    with pytest.raises(ValueError):
-        cfgmod.resolve_model("gpt-9-imaginary")
+def test_resolve_arm_unknown_raises():
+    with pytest.raises(ValueError, match="not in roster"):
+        cfgmod.resolve_arm("gpt-9-imaginary")
 
 
 def test_scorer_and_student_specs():
-    assert cfgmod.scorer_spec()["model"] == "claude-opus-4-6"
-    assert cfgmod.student_spec()["thinking"] is False
+    cfgmod._reset_config_cache()
+    assert cfgmod.scorer_spec().model == "claude-opus-4-6"
+    assert cfgmod.student_spec().thinking == ThinkingLevel.NONE
 
 
 def test_build_run_config_defaults():
+    cfgmod._reset_config_cache()
     rc = cfgmod.build_run_config(tutors=["claude-opus-4-8"])
     assert rc.modes == ["plain", "scaffolding_rigor"]
     # The default config pins the released HF dataset; the runnable set defaults
@@ -131,10 +142,10 @@ def test_build_run_config_defaults():
     # row-sampling implementation) and only misled about reproducibility.
     assert not hasattr(rc, "seed")
     assert rc.sample is None
-    assert rc.resolved_tutors["claude-opus-4-8"] == {
-        "thinking": True,
-        "effort": "xhigh",
-    }
+    arm = rc.resolved_tutors["claude-opus-4-8"]
+    assert isinstance(arm, ArmSpec)
+    assert arm.model == "claude-opus-4-8"
+    assert arm.thinking == "xhigh"
 
 
 def test_build_run_config_overrides():
@@ -142,10 +153,11 @@ def test_build_run_config_overrides():
         tutors=["gpt-5.5-2026-04-23"], modes=["plain"], sample=10, trials=3
     )
     assert rc.modes == ["plain"] and rc.sample == 10 and rc.trials == 3
-    assert rc.resolved_tutors["gpt-5.5-2026-04-23"] == {
-        "thinking": True,
-        "reasoning_effort": "high",
-    }
+    arm = rc.resolved_tutors["gpt-5.5-2026-04-23"]
+    assert isinstance(arm, ArmSpec)
+    assert arm.model == "gpt-5.5-2026-04-23"
+    assert arm.provider == "openai"
+    assert arm.thinking == "high"
 
 
 def test_register_and_lookup_tutor():
@@ -158,7 +170,8 @@ def test_register_and_lookup_tutor():
     assert cfgmod.get_registered_tutor("my-model") is my_tutor
     rc = cfgmod.build_run_config(tutors=["my-model"])
     assert "my-model" in rc.tutors
-    assert rc.resolved_tutors["my-model"] == {}
+    # A registered tutor has no model spec: it maps to None in resolved_tutors.
+    assert rc.resolved_tutors["my-model"] is None
 
 
 def test_register_and_lookup_student():
@@ -182,10 +195,10 @@ def test_registered_student_lookup_returns_none_for_unknown():
 def test_groundtruth_phase_config_shape():
     cfgmod._reset_config_cache()
     gt = cfgmod.get_groundtruth_phase_config()
-    assert gt["model"] == "claude-opus-4-8"
-    assert gt["thinking"] == "adaptive"
-    assert gt["poll_interval"] == 60
-    assert "labeller" in gt
+    assert gt.model == "claude-opus-4-8"
+    assert gt.thinking == ThinkingLevel.DYNAMIC
+    assert gt.poll_interval == 60
+    assert gt.labeller is not None
 
 
 def test_get_labeller_config_routes_by_type():
@@ -195,3 +208,153 @@ def test_get_labeller_config_routes_by_type():
         "scaffolding": "classify_scaffolding",
         "rapport": "classify_rapport",
     }
+
+
+# ---------------------------------------------------------------------------
+# New-contract tests: the arm roster (thinking ladder registry).
+# ---------------------------------------------------------------------------
+
+
+def test_arm_model_key_distinct_and_shared_model(tmp_path):
+    """An arm's `model:` may differ from its key; two arms may share a model."""
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML.replace(
+            "models:\n  claude-opus-4-8: { thinking: xhigh }",
+            "models:\n"
+            "  opus-deep:    { model: claude-opus-4-8, thinking: xhigh }\n"
+            "  opus-shallow: { model: claude-opus-4-8, thinking: low }",
+        ),
+    )
+    deep = cfgmod.resolve_arm("opus-deep", config_path=config_path)
+    shallow = cfgmod.resolve_arm("opus-shallow", config_path=config_path)
+    assert deep.name == "opus-deep"
+    assert deep.model == "claude-opus-4-8"
+    # Provider is inferred from the model id, not the (arbitrary) arm key.
+    assert deep.provider == "anthropic"
+    assert deep.thinking == "xhigh"
+    # The two arms coexist as distinct conditions on the same model.
+    assert shallow.model == deep.model
+    assert shallow.thinking == "low"
+
+
+def test_arm_model_defaults_to_key(tmp_path):
+    config_path = _write_config(tmp_path, _BASE_YAML)
+    arm = cfgmod.resolve_arm("claude-opus-4-8", config_path=config_path)
+    assert arm.model == "claude-opus-4-8"
+    assert arm.provider == "anthropic"
+
+
+def test_arm_missing_thinking_fails_at_load(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML.replace(
+            "claude-opus-4-8: { thinking: xhigh }", "claude-opus-4-8: {}"
+        ),
+    )
+    with pytest.raises(ThinkingConfigError, match="`thinking` is required"):
+        cfgmod.load_config(config_path)
+    # ThinkingConfigError is a ValueError, so broad callers still catch it.
+    assert issubclass(ThinkingConfigError, ValueError)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "{ thinking: xhigh, thinking_budget: 8192 }",
+        "{ reasoning_effort: high }",
+        "{ thinking: high, effort: high }",
+    ],
+)
+def test_raw_knob_keys_rejected_with_migration_hint(tmp_path, entry):
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML.replace(
+            "claude-opus-4-8: { thinking: xhigh }", f"claude-opus-4-8: {entry}"
+        ),
+    )
+    with pytest.raises(ThinkingConfigError, match="thinking ladder"):
+        cfgmod.load_config(config_path)
+
+
+@pytest.mark.parametrize("value", ["true", "false"])
+def test_boolean_thinking_rejected_with_hint(tmp_path, value):
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML.replace(
+            "claude-opus-4-8: { thinking: xhigh }",
+            f"claude-opus-4-8: {{ thinking: {value} }}",
+        ),
+    )
+    with pytest.raises(ThinkingConfigError, match="replaced by the ladder"):
+        cfgmod.load_config(config_path)
+
+
+def test_unsatisfiable_scorer_level_fails_at_load(tmp_path):
+    # gemini-2.5-pro is always-thinking: `none` has no wire form.
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML.replace(
+            "scorer:  { model: claude-opus-4-6, thinking: dynamic }",
+            "scorer:  { model: gemini-2.5-pro, thinking: none }",
+        ),
+    )
+    with pytest.raises(ThinkingConfigError, match="config scorer"):
+        cfgmod.load_config(config_path)
+
+
+def test_unsatisfiable_taxonomy_level_fails_at_load(tmp_path):
+    # The o-series has no off switch: `none` is unsatisfiable.
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML + "taxonomy: { model: o3, thinking: none, batch_size: 10 }\n",
+    )
+    with pytest.raises(ThinkingConfigError, match="config taxonomy"):
+        cfgmod.load_config(config_path)
+
+
+def test_unsatisfiable_groundtruth_level_fails_at_load(tmp_path):
+    # DeepSeek reasons internally with no knob: only `dynamic` is expressible.
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML
+        + "groundtruth: { model: deepseek-ai/DeepSeek-V4-Pro, thinking: high }\n",
+    )
+    with pytest.raises(ThinkingConfigError, match="config groundtruth"):
+        cfgmod.load_config(config_path)
+
+
+def test_specs_are_frozen():
+    """Mutating a shared spec must raise, not silently poison the cache."""
+    cfgmod._reset_config_cache()
+    arm = cfgmod.resolve_arm("claude-opus-4-8")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        arm.thinking = ThinkingLevel.NONE
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cfgmod.student_spec().model = "other-model"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cfgmod.scorer_spec().thinking = ThinkingLevel.NONE
+    # The cached spec is unchanged.
+    assert cfgmod.resolve_arm("claude-opus-4-8").thinking == "xhigh"
+
+
+def test_build_run_config_mixes_registered_and_roster_tutors(tmp_path):
+    from tutormoments import register_tutor
+
+    config_path = _write_config(tmp_path, _BASE_YAML)
+
+    @register_tutor("scripted-tutor")
+    def scripted(conversation):
+        return "next turn"
+
+    try:
+        rc = cfgmod.build_run_config(
+            tutors=["scripted-tutor", "claude-opus-4-8"],
+            config_path=config_path,
+        )
+        assert rc.resolved_tutors["scripted-tutor"] is None
+        arm = rc.resolved_tutors["claude-opus-4-8"]
+        assert isinstance(arm, ArmSpec)
+        assert arm.thinking == "xhigh"
+    finally:
+        cfgmod._TUTOR_REGISTRY.pop("scripted-tutor", None)

--- a/tests/tutormoments/test_config.py
+++ b/tests/tutormoments/test_config.py
@@ -35,7 +35,7 @@ def test_packaged_default_config_parses_and_has_expected_roster():
     cfgmod._reset_config_cache()
     cfg = cfgmod.load_config()
     assert set(cfg["providers"]) == {"anthropic", "openai", "gemini", "together"}
-    assert set(cfg["models"]) == {
+    assert set(cfg["benchmark_models"]) == {
         "claude-opus-4-8",
         "claude-sonnet-4-6",
         "claude-sonnet-5",
@@ -43,11 +43,23 @@ def test_packaged_default_config_parses_and_has_expected_roster():
         "gemini-3.5-flash",
         "gpt-5.4-mini-2026-03-17",
         "gpt-5.5-2026-04-23",
-        "deepseek-ai/DeepSeek-V4-Pro",
+        "deepseek-v4-pro",
     }
-    assert cfg["models"]["claude-opus-4-8"] == {"thinking": "xhigh"}
-    assert cfg["models"]["claude-sonnet-5"] == {"thinking": "xhigh"}
-    assert cfg["models"]["deepseek-ai/DeepSeek-V4-Pro"] == {"thinking": "dynamic"}
+    assert cfg["benchmark_models"]["claude-opus-4-8"] == {
+        "model": "claude-opus-4-8",
+        "thinking": {"type": "adaptive"},
+        "effort": "xhigh",
+        "condition": "xhigh",
+    }
+    assert cfg["benchmark_models"]["gpt-5.5-2026-04-23"] == {
+        "model": "gpt-5.5-2026-04-23",
+        "reasoning": "high",
+        "condition": "high",
+    }
+    assert cfg["benchmark_models"]["deepseek-v4-pro"] == {
+        "model": "deepseek-ai/DeepSeek-V4-Pro",
+        "condition": "dynamic",
+    }
     assert cfg["student"] == {
         "model": "claude-opus-4-6",
         "mode": "oracle",
@@ -78,7 +90,7 @@ def test_load_config_returns_parsed_dict():
     cfgmod._reset_config_cache()
     c = cfgmod.load_config()
     assert c["scorer"]["model"] == "claude-opus-4-6"
-    assert "models" in c and "providers" in c
+    assert "benchmark_models" in c and "providers" in c
     assert cfgmod.describe_config_source() == "tutormoments:default_config.yaml"
 
 
@@ -101,20 +113,23 @@ def test_resolve_arm_known():
     assert arm.name == "claude-opus-4-8"
     assert arm.model == "claude-opus-4-8"
     assert arm.provider == "anthropic"
-    assert arm.thinking == ThinkingLevel.XHIGH
-    assert arm.thinking == "xhigh"  # str-Enum: string comparison works
+    assert arm.thinking == {"thinking": {"type": "adaptive"}, "effort": "xhigh"}
+    assert arm.condition == "xhigh"
 
 
 def test_resolve_arm_together():
-    arm = cfgmod.resolve_arm("deepseek-ai/DeepSeek-V4-Pro")
+    arm = cfgmod.resolve_arm("deepseek-v4-pro")
     assert arm.provider == "together"
-    assert arm.thinking == "dynamic"
+    assert arm.model == "deepseek-ai/DeepSeek-V4-Pro"
+    assert arm.thinking == {}
+    assert arm.condition == "dynamic"
 
 
 def test_resolve_arm_gemini():
     arm = cfgmod.resolve_arm("gemini-2.5-pro")
     assert arm.provider == "gemini"
-    assert arm.thinking == "dynamic"
+    assert arm.thinking == {"include_thoughts": True, "thinking_budget": -1}
+    assert arm.condition == "dynamic"
 
 
 def test_resolve_arm_unknown_raises():
@@ -145,7 +160,8 @@ def test_build_run_config_defaults():
     arm = rc.resolved_tutors["claude-opus-4-8"]
     assert isinstance(arm, ArmSpec)
     assert arm.model == "claude-opus-4-8"
-    assert arm.thinking == "xhigh"
+    assert arm.thinking == {"thinking": {"type": "adaptive"}, "effort": "xhigh"}
+    assert arm.condition == "xhigh"
 
 
 def test_build_run_config_overrides():
@@ -157,7 +173,8 @@ def test_build_run_config_overrides():
     assert isinstance(arm, ArmSpec)
     assert arm.model == "gpt-5.5-2026-04-23"
     assert arm.provider == "openai"
-    assert arm.thinking == "high"
+    assert arm.thinking == {"reasoning": "high"}
+    assert arm.condition == "high"
 
 
 def test_register_and_lookup_tutor():
@@ -211,7 +228,7 @@ def test_get_labeller_config_routes_by_type():
 
 
 # ---------------------------------------------------------------------------
-# New-contract tests: the arm roster (thinking ladder registry).
+# Arm roster contract tests.
 # ---------------------------------------------------------------------------
 
 
@@ -256,6 +273,55 @@ def test_arm_missing_thinking_fails_at_load(tmp_path):
         cfgmod.load_config(config_path)
     # ThinkingConfigError is a ValueError, so broad callers still catch it.
     assert issubclass(ThinkingConfigError, ValueError)
+
+
+def test_benchmark_models_accept_provider_native_params(tmp_path):
+    """benchmark_models states the exact provider-native knobs in config."""
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML.replace(
+            "models:\n  claude-opus-4-8: { thinking: xhigh }",
+            "benchmark_models:\n"
+            "  gemini-low: { model: gemini-2.5-pro, thinking_budget: 4096, condition: low }\n"
+            "  gpt-low:    { model: gpt-5.5-2026-04-23, reasoning: low, condition: low }\n"
+            "  sonnet-hi:  { model: claude-sonnet-4-6, thinking: { type: adaptive }, effort: high, condition: high }\n",
+        ),
+    )
+    gemini = cfgmod.resolve_arm("gemini-low", config_path=config_path)
+    gpt = cfgmod.resolve_arm("gpt-low", config_path=config_path)
+    sonnet = cfgmod.resolve_arm("sonnet-hi", config_path=config_path)
+    assert gemini.thinking == {"thinking_budget": 4096}
+    assert gemini.condition == "low"
+    assert gpt.thinking == {"reasoning": "low"}
+    assert gpt.condition == "low"
+    assert sonnet.thinking == {"thinking": {"type": "adaptive"}, "effort": "high"}
+    assert sonnet.condition == "high"
+
+
+def test_benchmark_models_reject_provider_mismatched_keys(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML.replace(
+            "models:\n  claude-opus-4-8: { thinking: xhigh }",
+            "benchmark_models:\n"
+            "  gpt-bad: { model: gpt-5.5-2026-04-23, thinking_budget: 4096, condition: low }\n",
+        ),
+    )
+    with pytest.raises(ThinkingConfigError, match="unknown key"):
+        cfgmod.load_config(config_path)
+
+
+def test_benchmark_models_require_condition(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        _BASE_YAML.replace(
+            "models:\n  claude-opus-4-8: { thinking: xhigh }",
+            "benchmark_models:\n"
+            "  gpt-low: { model: gpt-5.5-2026-04-23, reasoning: low }\n",
+        ),
+    )
+    with pytest.raises(ThinkingConfigError, match="`condition`"):
+        cfgmod.load_config(config_path)
 
 
 @pytest.mark.parametrize(
@@ -335,7 +401,10 @@ def test_specs_are_frozen():
     with pytest.raises(dataclasses.FrozenInstanceError):
         cfgmod.scorer_spec().thinking = ThinkingLevel.NONE
     # The cached spec is unchanged.
-    assert cfgmod.resolve_arm("claude-opus-4-8").thinking == "xhigh"
+    assert cfgmod.resolve_arm("claude-opus-4-8").thinking == {
+        "thinking": {"type": "adaptive"},
+        "effort": "xhigh",
+    }
 
 
 def test_build_run_config_mixes_registered_and_roster_tutors(tmp_path):

--- a/tests/tutormoments/test_default_config_wire.py
+++ b/tests/tutormoments/test_default_config_wire.py
@@ -43,7 +43,7 @@ EXPECTED_ARM_WIRE = {
     ),
     "gpt-5.4-mini-2026-03-17": ("gpt-5.4-mini-2026-03-17", None, None, None, "high"),
     "gpt-5.5-2026-04-23": ("gpt-5.5-2026-04-23", None, None, None, "high"),
-    "deepseek-ai/DeepSeek-V4-Pro": (
+    "deepseek-v4-pro": (
         "deepseek-ai/DeepSeek-V4-Pro",
         None,
         None,
@@ -65,7 +65,7 @@ def _assert_wire(model, level, expected):
 
 def test_default_roster_covers_expected_arms():
     load_config()
-    arms = load_config()["models"]
+    arms = load_config()["benchmark_models"]
     assert set(arms) == set(EXPECTED_ARM_WIRE)
 
 

--- a/tests/tutormoments/test_default_config_wire.py
+++ b/tests/tutormoments/test_default_config_wire.py
@@ -1,10 +1,17 @@
 """Pin the shipped config's effective wire behavior.
 
-This is the machine-checkable statement that the arm/ladder migration changed
-zero wire bytes for the packaged default_config.yaml: every arm and role spec
-must translate to exactly the fragment the pre-migration code sent. If a
-registry or config edit changes any row here, that is a benchmark-condition
-change and must be deliberate (and called out in the PR).
+This is the machine-checkable statement of exactly what the packaged
+default_config.yaml sends. If a config edit changes any row here, that is a
+benchmark-condition change and must be deliberate (and called out in the PR).
+
+The provider-native config migration changed zero wire bytes for the tutor
+arms and the scorer/groundtruth roles. One deliberate change was made for the
+thinking-off roles (student, taxonomy): they now send an explicit
+`thinking: {"type": "disabled"}` instead of omitting the param. On the
+Anthropic 4.x models these roles use, omission already meant thinking off, so
+the *condition* is unchanged -- but omission means adaptive on Sonnet 5+, so
+the explicit block keeps the condition stable under model swaps and lets
+`tutormoments smoke` assert it (an omitted param judges as "na").
 """
 
 import pytest
@@ -20,6 +27,7 @@ from tutormoments.config import (
 from tutormoments.models import resolve_thinking
 
 ADAPTIVE = {"type": "adaptive"}
+DISABLED = {"type": "disabled"}
 
 # arm/role -> (model, anthropic_thinking, anthropic_effort,
 #              gemini_thinking_config, openai_reasoning_effort)
@@ -76,10 +84,12 @@ def test_default_arm_wire(arm_name):
 
 
 def test_default_student_wire():
-    # Pre-migration: student thinking=false on claude-opus-4-6 omitted the
-    # thinking param entirely.
+    # Deliberate change from the pre-migration config (see module docstring):
+    # explicit disabled instead of omitting the param. Same condition on 4.x.
     spec = student_spec()
-    _assert_wire(spec.model, spec.thinking, ("claude-opus-4-6", None, None, None, None))
+    _assert_wire(
+        spec.model, spec.thinking, ("claude-opus-4-6", DISABLED, None, None, None)
+    )
 
 
 def test_default_scorer_wire():
@@ -91,9 +101,12 @@ def test_default_scorer_wire():
 
 
 def test_default_taxonomy_wire():
-    # Pre-migration: taxonomy thinking=false omitted the thinking param.
+    # Deliberate change from the pre-migration config (see module docstring):
+    # explicit disabled instead of omitting the param. Same condition on 4.x.
     spec = taxonomy_spec()
-    _assert_wire(spec.model, spec.thinking, ("claude-opus-4-8", None, None, None, None))
+    _assert_wire(
+        spec.model, spec.thinking, ("claude-opus-4-8", DISABLED, None, None, None)
+    )
 
 
 def test_default_groundtruth_wire():

--- a/tests/tutormoments/test_default_config_wire.py
+++ b/tests/tutormoments/test_default_config_wire.py
@@ -1,0 +1,105 @@
+"""Pin the shipped config's effective wire behavior.
+
+This is the machine-checkable statement that the arm/ladder migration changed
+zero wire bytes for the packaged default_config.yaml: every arm and role spec
+must translate to exactly the fragment the pre-migration code sent. If a
+registry or config edit changes any row here, that is a benchmark-condition
+change and must be deliberate (and called out in the PR).
+"""
+
+import pytest
+
+from tutormoments.config import (
+    get_groundtruth_phase_config,
+    load_config,
+    resolve_arm,
+    scorer_spec,
+    student_spec,
+    taxonomy_spec,
+)
+from tutormoments.models import resolve_thinking
+
+ADAPTIVE = {"type": "adaptive"}
+
+# arm/role -> (model, anthropic_thinking, anthropic_effort,
+#              gemini_thinking_config, openai_reasoning_effort)
+EXPECTED_ARM_WIRE = {
+    "claude-opus-4-8": ("claude-opus-4-8", ADAPTIVE, "xhigh", None, None),
+    "claude-sonnet-4-6": ("claude-sonnet-4-6", ADAPTIVE, "high", None, None),
+    "claude-sonnet-5": ("claude-sonnet-5", ADAPTIVE, "xhigh", None, None),
+    "gemini-2.5-pro": (
+        "gemini-2.5-pro",
+        None,
+        None,
+        {"include_thoughts": True, "thinking_budget": -1},
+        None,
+    ),
+    "gemini-3.5-flash": (
+        "gemini-3.5-flash",
+        None,
+        None,
+        {"include_thoughts": True, "thinking_budget": -1},
+        None,
+    ),
+    "gpt-5.4-mini-2026-03-17": ("gpt-5.4-mini-2026-03-17", None, None, None, "high"),
+    "gpt-5.5-2026-04-23": ("gpt-5.5-2026-04-23", None, None, None, "high"),
+    "deepseek-ai/DeepSeek-V4-Pro": (
+        "deepseek-ai/DeepSeek-V4-Pro",
+        None,
+        None,
+        None,
+        None,
+    ),
+}
+
+
+def _assert_wire(model, level, expected):
+    exp_model, anth, effort, gem, oai = expected
+    assert model == exp_model
+    wire = resolve_thinking(model, level)
+    assert wire.anthropic_thinking == anth
+    assert wire.anthropic_effort == effort
+    assert wire.gemini_thinking_config == gem
+    assert wire.openai_reasoning_effort == oai
+
+
+def test_default_roster_covers_expected_arms():
+    load_config()
+    arms = load_config()["models"]
+    assert set(arms) == set(EXPECTED_ARM_WIRE)
+
+
+@pytest.mark.parametrize("arm_name", sorted(EXPECTED_ARM_WIRE))
+def test_default_arm_wire(arm_name):
+    arm = resolve_arm(arm_name)
+    _assert_wire(arm.model, arm.thinking, EXPECTED_ARM_WIRE[arm_name])
+
+
+def test_default_student_wire():
+    # Pre-migration: student thinking=false on claude-opus-4-6 omitted the
+    # thinking param entirely.
+    spec = student_spec()
+    _assert_wire(spec.model, spec.thinking, ("claude-opus-4-6", None, None, None, None))
+
+
+def test_default_scorer_wire():
+    # Pre-migration: scorer thinking="adaptive" sent {"type": "adaptive"}.
+    spec = scorer_spec()
+    _assert_wire(
+        spec.model, spec.thinking, ("claude-opus-4-6", ADAPTIVE, None, None, None)
+    )
+
+
+def test_default_taxonomy_wire():
+    # Pre-migration: taxonomy thinking=false omitted the thinking param.
+    spec = taxonomy_spec()
+    _assert_wire(spec.model, spec.thinking, ("claude-opus-4-8", None, None, None, None))
+
+
+def test_default_groundtruth_wire():
+    # Pre-migration: groundtruth thinking="adaptive" sent {"type": "adaptive"}
+    # (thinking_budget: 0 and reasoning_effort: "" were no-ops).
+    spec = get_groundtruth_phase_config()
+    _assert_wire(
+        spec.model, spec.thinking, ("claude-opus-4-8", ADAPTIVE, None, None, None)
+    )

--- a/tests/tutormoments/test_latency.py
+++ b/tests/tutormoments/test_latency.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from tutormoments.config import ArmSpec, StudentSpec
 from tutormoments.latency import (
     MIN_CACHE_HIT_SAMPLES,
     MIN_SESSION_CACHE_READ_TOKENS,
@@ -337,7 +338,15 @@ class _Cfg:
     dataset_revision = None
     dataset_config = "moments"
     max_turns = 4
-    student = {"model": "claude-haiku-4-5", "mode": "oracle"}
+    student = StudentSpec(model="claude-haiku-4-5", mode="oracle", thinking="none")
+    resolved_tutors = {
+        "claude-opus-4-8": ArmSpec(
+            name="claude-opus-4-8",
+            model="claude-opus-4-8",
+            provider="anthropic",
+            thinking="xhigh",
+        )
+    }
 
     def __init__(self, data_path):
         self.data_path = data_path
@@ -377,6 +386,9 @@ def test_run_probe_writes_latency_json(tmp_path, monkeypatch):
         (tmp_path / "results" / run_id / "latency.json").read_text(encoding="utf-8")
     )
     assert written["source"] == "probe"
+    # tutor_model is the ARM name; model the resolved provider model id
+    assert written["tutor_model"] == "claude-opus-4-8"
+    assert written["model"] == "claude-opus-4-8"
     assert written["tutor"]["n_samples"] == 2
     assert block["subsample"]["subsample_source"] == "frozen_release"
 

--- a/tests/tutormoments/test_models.py
+++ b/tests/tutormoments/test_models.py
@@ -1,8 +1,8 @@
-"""Contract tests for the model registry and thinking-ladder translation.
+"""Contract tests for the model registry and thinking-parameter translation.
 
-The matrix below pins the exact wire fragment every (family, rung) pair
-produces. These are benchmark-defining mappings: a change here changes what
-gets sent to providers, so the expected values are written out literally
+The matrix below pins the exact wire fragment every provider-native thinking
+config produces. These are benchmark-defining mappings: a change here changes
+what gets sent to providers, so the expected values are written out literally
 rather than derived.
 """
 
@@ -10,19 +10,17 @@ import pytest
 
 from tutormoments.models import (
     ThinkingConfigError,
-    ThinkingLevel,
     _validate_registry,
     get_pricing,
     infer_provider,
     max_output_cap,
-    resolve_native_thinking,
     resolve_thinking,
 )
 
 # ---------------------------------------------------------------------------
-# The ladder -> wire matrix, one row per (model, level) that must SUCCEED.
-# Expected is (anthropic_thinking, anthropic_effort, gemini_thinking_config,
-# openai_reasoning_effort).
+# The native-config -> wire matrix, one row per (model, thinking) that must
+# SUCCEED. Expected is (anthropic_thinking, anthropic_effort,
+# gemini_thinking_config, openai_reasoning_effort).
 # ---------------------------------------------------------------------------
 
 ADAPTIVE = {"type": "adaptive"}
@@ -43,212 +41,149 @@ def _oai(effort):
 NOTHING = (None, None, None, None)
 
 WIRE_MATRIX = [
-    # --- anthropic 4.6 adaptive tier ---
-    ("claude-opus-4-6", "none", NOTHING),
-    ("claude-opus-4-6", "low", _anth(ADAPTIVE, "low")),
-    ("claude-opus-4-6", "high", _anth(ADAPTIVE, "high")),
-    ("claude-opus-4-6", "dynamic", _anth(ADAPTIVE)),
-    ("claude-sonnet-4-6", "high", _anth(ADAPTIVE, "high")),
-    # --- anthropic 4.7+ adaptive tier ---
-    ("claude-opus-4-8", "none", NOTHING),
-    ("claude-opus-4-8", "xhigh", _anth(ADAPTIVE, "xhigh")),
-    ("claude-opus-4-8", "dynamic", _anth(ADAPTIVE)),
-    # --- sonnet 5: off must be explicit ---
-    ("claude-sonnet-5", "none", _anth({"type": "disabled"})),
-    ("claude-sonnet-5", "xhigh", _anth(ADAPTIVE, "xhigh")),
-    ("claude-sonnet-5", "dynamic", _anth(ADAPTIVE)),
-    # --- anthropic legacy (enabled + budget) ---
-    ("claude-haiku-4-5", "none", NOTHING),
-    ("claude-haiku-4-5", "low", _anth({"type": "enabled", "budget_tokens": 4096})),
-    ("claude-haiku-4-5", "high", _anth({"type": "enabled", "budget_tokens": 16384})),
-    ("claude-3-7-sonnet", "high", _anth({"type": "enabled", "budget_tokens": 16384})),
-    # --- gemini 2.5 pro (always-thinking) ---
+    # --- anthropic: thinking null means "send no thinking param" ---
+    ("claude-opus-4-6", {"thinking": None}, NOTHING),
+    (
+        "claude-opus-4-6",
+        {"thinking": ADAPTIVE, "effort": "high"},
+        _anth(ADAPTIVE, "high"),
+    ),
+    (
+        "claude-opus-4-8",
+        {"thinking": ADAPTIVE, "effort": "xhigh"},
+        _anth(ADAPTIVE, "xhigh"),
+    ),
+    ("claude-opus-4-8", {"thinking": ADAPTIVE}, _anth(ADAPTIVE)),
+    (
+        "claude-sonnet-5",
+        {"thinking": {"type": "disabled"}},
+        _anth({"type": "disabled"}),
+    ),
+    (
+        "claude-haiku-4-5",
+        {"thinking": {"type": "enabled", "budget_tokens": 16384}},
+        _anth({"type": "enabled", "budget_tokens": 16384}),
+    ),
+    # --- gemini: budget or level; include_thoughts defaults on unless off ---
     (
         "gemini-2.5-pro",
-        "high",
+        {"thinking_budget": 16384},
         _gem({"include_thoughts": True, "thinking_budget": 16384}),
     ),
     (
         "gemini-2.5-pro",
-        "xhigh",
-        _gem({"include_thoughts": True, "thinking_budget": 32768}),
-    ),
-    (
-        "gemini-2.5-pro",
-        "dynamic",
+        {"include_thoughts": True, "thinking_budget": -1},
         _gem({"include_thoughts": True, "thinking_budget": -1}),
     ),
-    # --- gemini 2.5 flash (off is real) ---
     (
         "gemini-2.5-flash",
-        "none",
+        {"thinking_budget": 0},
         _gem({"include_thoughts": False, "thinking_budget": 0}),
     ),
     (
-        "gemini-2.5-flash",
-        "low",
-        _gem({"include_thoughts": True, "thinking_budget": 4096}),
-    ),
-    (
-        "gemini-2.5-flash",
-        "dynamic",
-        _gem({"include_thoughts": True, "thinking_budget": -1}),
-    ),
-    # --- gemini 3.x: dynamic keeps the proven budget -1 shape ---
-    (
         "gemini-3.5-flash",
-        "dynamic",
-        _gem({"include_thoughts": True, "thinking_budget": -1}),
+        {"thinking_level": "high"},
+        _gem({"include_thoughts": True, "thinking_level": "high"}),
     ),
-    # --- openai gpt-5 line ---
-    ("gpt-5.5", "low", _oai("low")),
-    ("gpt-5.5", "high", _oai("high")),
-    ("gpt-5.4-mini", "high", _oai("high")),
-    # --- openai o-series ---
-    ("o3", "low", _oai("low")),
-    ("o4", "high", _oai("high")),
-    # --- together internal reasoners ---
-    ("deepseek-ai/DeepSeek-V4-Pro", "dynamic", NOTHING),
+    # --- openai ---
+    ("gpt-5.5", {"reasoning": "low"}, _oai("low")),
+    ("gpt-5.5-2026-04-23", {"reasoning": "high"}, _oai("high")),
+    ("o3", {"reasoning": "low"}, _oai("low")),
+    # --- together internal reasoners: no knobs, nothing sent ---
+    ("deepseek-ai/DeepSeek-V4-Pro", {}, NOTHING),
 ]
 
 
-@pytest.mark.parametrize("model,level,expected", WIRE_MATRIX)
-def test_wire_matrix(model, level, expected):
-    wire = resolve_thinking(model, level)
+@pytest.mark.parametrize("model,thinking,expected", WIRE_MATRIX)
+def test_wire_matrix(model, thinking, expected):
+    wire = resolve_thinking(model, thinking)
     anth_thinking, anth_effort, gem_config, oai_effort = expected
     assert wire.anthropic_thinking == anth_thinking
     assert wire.anthropic_effort == anth_effort
     assert wire.gemini_thinking_config == gem_config
     assert wire.openai_reasoning_effort == oai_effort
-    assert wire.level == ThinkingLevel(level)
 
 
 # ---------------------------------------------------------------------------
-# Unsatisfiable rungs must raise with a reason.
-# ---------------------------------------------------------------------------
-
-UNSATISFIABLE = [
-    ("gemini-2.5-pro", "none"),  # API rejects budget 0
-    ("gemini-3.5-flash", "none"),  # thinking_level floor doesn't guarantee off
-    ("o3", "none"),  # no off switch
-    ("o3", "xhigh"),
-    ("deepseek-ai/DeepSeek-V4-Pro", "none"),  # always-thinking
-    ("deepseek-ai/DeepSeek-V4-Pro", "high"),  # no depth knob at all
-    ("claude-opus-4-6", "xhigh"),  # 4.6 tier has no xhigh
-    ("claude-haiku-4-5", "dynamic"),  # legacy models have no adaptive mode
-]
-
-
-@pytest.mark.parametrize("model,level", UNSATISFIABLE)
-def test_unsatisfiable_rungs_raise(model, level):
-    with pytest.raises(ThinkingConfigError) as exc_info:
-        resolve_thinking(model, level)
-    assert "does not support" in str(exc_info.value)
-
-
-def test_unsatisfiable_error_carries_family_reason():
-    with pytest.raises(ThinkingConfigError, match="rejects thinking_budget"):
-        resolve_thinking("gemini-2.5-pro", "none")
-    with pytest.raises(ThinkingConfigError, match="off switch"):
-        resolve_thinking("o3-mini", "none")
-
-
-# ---------------------------------------------------------------------------
-# Unverified rungs are fail-closed until proven live.
-# ---------------------------------------------------------------------------
-
-UNVERIFIED = [
-    ("gemini-3.5-flash", "low"),
-    ("gemini-3.5-flash", "high"),
-    ("gpt-5.5", "none"),
-    ("gpt-5.5", "xhigh"),
-]
-
-
-@pytest.mark.parametrize("model,level", UNVERIFIED)
-def test_unverified_rungs_raise(model, level):
-    with pytest.raises(ThinkingConfigError, match="not been verified"):
-        resolve_thinking(model, level)
-
-
-# ---------------------------------------------------------------------------
-# Registration and matching rules.
+# Malformed or provider-mismatched configs must raise before any tokens.
 # ---------------------------------------------------------------------------
 
 
-def test_unregistered_model_with_explicit_level_raises():
-    with pytest.raises(ThinkingConfigError, match="not in the model registry"):
-        resolve_thinking("brand-new-model-9000", "high")
+def test_rejects_mismatched_provider_keys():
+    with pytest.raises(ThinkingConfigError, match="unknown key"):
+        resolve_thinking("gpt-5.5-2026-04-23", {"thinking_budget": 4096})
+    with pytest.raises(ThinkingConfigError, match="unknown key"):
+        resolve_thinking("gemini-2.5-pro", {"reasoning": "low"})
+    with pytest.raises(ThinkingConfigError, match="unknown key"):
+        resolve_thinking("deepseek-ai/DeepSeek-V4-Pro", {"thinking_budget": -1})
 
 
-def test_unregistered_model_with_none_level_is_a_noop():
+def test_gemini_requires_exactly_one_depth_knob():
+    with pytest.raises(ThinkingConfigError, match="cannot set both"):
+        resolve_thinking(
+            "gemini-2.5-pro", {"thinking_budget": 4096, "thinking_level": "low"}
+        )
+    with pytest.raises(ThinkingConfigError, match="must set"):
+        resolve_thinking("gemini-2.5-pro", {})
+    with pytest.raises(ThinkingConfigError, match="integer"):
+        resolve_thinking("gemini-2.5-pro", {"thinking_budget": "lots"})
+    with pytest.raises(ThinkingConfigError, match="include_thoughts"):
+        resolve_thinking(
+            "gemini-2.5-pro", {"thinking_budget": -1, "include_thoughts": "yes"}
+        )
+
+
+def test_openai_requires_reasoning():
+    with pytest.raises(ThinkingConfigError, match="must set reasoning"):
+        resolve_thinking("gpt-5.5", {})
+    with pytest.raises(ThinkingConfigError, match="non-empty string"):
+        resolve_thinking("gpt-5.5", {"reasoning": 3})
+
+
+def test_anthropic_requires_explicit_thinking():
+    # The key must be present -- null is the explicit "send nothing".
+    with pytest.raises(ThinkingConfigError, match="must set thinking"):
+        resolve_thinking("claude-opus-4-8", {})
+    with pytest.raises(ThinkingConfigError, match="mapping or null"):
+        resolve_thinking("claude-opus-4-8", {"thinking": "adaptive"})
+
+
+def test_rejects_bad_anthropic_shapes():
+    with pytest.raises(ThinkingConfigError, match="thinking.type"):
+        resolve_thinking("claude-opus-4-8", {"thinking": {"type": "vibes"}})
+    with pytest.raises(ThinkingConfigError, match="positive integer"):
+        resolve_thinking("claude-opus-4-8", {"thinking": {"type": "enabled"}})
+    with pytest.raises(ThinkingConfigError, match="only valid with"):
+        resolve_thinking(
+            "claude-opus-4-8",
+            {"thinking": {"type": "adaptive", "budget_tokens": 4096}},
+        )
+    with pytest.raises(ThinkingConfigError, match="effort requires"):
+        resolve_thinking(
+            "claude-opus-4-8", {"thinking": {"type": "disabled"}, "effort": "high"}
+        )
+    with pytest.raises(ThinkingConfigError, match="effort requires"):
+        resolve_thinking("claude-opus-4-8", {"thinking": None, "effort": "high"})
+
+
+def test_rejects_retired_ladder_levels():
+    # The canonical ladder was removed; a stray level string must not pass
+    # silently as if it configured anything.
+    with pytest.raises(ThinkingConfigError, match="must be a mapping"):
+        resolve_thinking("claude-opus-4-8", "xhigh")
+    with pytest.raises(ThinkingConfigError, match="must be a mapping"):
+        resolve_thinking("gemini-2.5-pro", "dynamic")
+    with pytest.raises(ThinkingConfigError, match="must be a mapping"):
+        resolve_thinking("gpt-5.5", True)
+
+
+def test_none_means_no_stated_condition():
+    # Direct (non-benchmark) calls: nothing sent, nothing checked.
     wire = resolve_thinking("claude-experimental-dev-model", None)
-    assert wire.level is None
     assert wire.anthropic_thinking is None
     assert wire.anthropic_effort is None
-
-
-def test_point_release_resolves_via_prefix():
-    wire = resolve_thinking("claude-haiku-4-5-20251001", "high")
-    assert wire.anthropic_thinking == {"type": "enabled", "budget_tokens": 16384}
-    wire = resolve_thinking("gpt-5.4-mini-2026-03-17", "high")
-    assert wire.openai_reasoning_effort == "high"
-    wire = resolve_thinking("gpt-5.5-2026-04-23", "high")
-    assert wire.openai_reasoning_effort == "high"
-
-
-def test_longest_prefix_wins():
-    # claude-opus-4-20250514 (legacy) must not be swallowed by any shorter
-    # entry; and its dated id resolves to itself, not claude-opus-4-...
-    wire = resolve_thinking("claude-opus-4-20250514", "high")
-    assert wire.anthropic_thinking == {"type": "enabled", "budget_tokens": 16384}
-
-
-def test_matching_is_case_insensitive():
-    wire = resolve_thinking("Claude-Opus-4-8", "xhigh")
-    assert wire.anthropic_effort == "xhigh"
-    wire = resolve_thinking("GPT-5.5-2026-04-23", "high")
-    assert wire.openai_reasoning_effort == "high"
-    wire = resolve_thinking("deepseek-ai/deepseek-v4-pro", "dynamic")
-    assert wire.provider == "together"
-
-
-# ---------------------------------------------------------------------------
-# ThinkingLevel.coerce: the config-boundary gate.
-# ---------------------------------------------------------------------------
-
-
-def test_coerce_accepts_ladder_strings_case_insensitively():
-    assert ThinkingLevel.coerce("HIGH") is ThinkingLevel.HIGH
-    assert ThinkingLevel.coerce("none") is ThinkingLevel.NONE
-    assert ThinkingLevel.coerce(None) is None
-    assert ThinkingLevel.coerce(ThinkingLevel.DYNAMIC) is ThinkingLevel.DYNAMIC
-
-
-@pytest.mark.parametrize("bad", [True, False])
-def test_coerce_rejects_booleans_with_migration_hint(bad):
-    with pytest.raises(ThinkingConfigError, match="ladder"):
-        ThinkingLevel.coerce(bad)
-
-
-def test_coerce_rejects_unknown_strings():
-    with pytest.raises(ThinkingConfigError, match="not a valid thinking level"):
-        ThinkingLevel.coerce("adaptive")  # retired spelling; dynamic replaced it
-    with pytest.raises(ThinkingConfigError, match="not a valid thinking level"):
-        ThinkingLevel.coerce("enabled")
-
-
-@pytest.mark.parametrize("dropped", ["minimal", "medium", "max"])
-def test_coerce_rejects_dropped_rungs(dropped):
-    # The ladder is deliberately small: these rungs were removed as unused.
-    # Re-adding one is a reviewed registry line + a smoke verification.
-    with pytest.raises(ThinkingConfigError, match="not a valid thinking level"):
-        ThinkingLevel.coerce(dropped)
-
-
-def test_coerce_rejects_numbers():
-    with pytest.raises(ThinkingConfigError, match="registry"):
-        ThinkingLevel.coerce(16384)
+    assert wire.gemini_thinking_config is None
+    assert wire.openai_reasoning_effort is None
 
 
 # ---------------------------------------------------------------------------
@@ -279,9 +214,18 @@ def test_infer_provider_unknown_raises():
         infer_provider("mystery-model")
 
 
+def test_point_release_resolves_via_prefix():
+    assert max_output_cap("claude-haiku-4-5-20251001") == 64000
+    assert infer_provider("gpt-5.4-mini-2026-03-17") == "openai"
+
+
+def test_matching_is_case_insensitive():
+    assert max_output_cap("Claude-Haiku-4-5") == 64000
+    assert infer_provider("deepseek-ai/deepseek-v4-pro") == "together"
+
+
 def test_max_output_cap():
     assert max_output_cap("claude-haiku-4-5") == 64000
-    assert max_output_cap("claude-haiku-4-5-20251001") == 64000
     assert max_output_cap("claude-opus-4-8") is None
     assert max_output_cap("not-registered") is None
 
@@ -294,52 +238,18 @@ def test_get_pricing_shape():
 
 
 def test_describe_renders_wire_form():
-    assert "adaptive" in resolve_thinking("claude-opus-4-8", "xhigh").describe()
-    assert "effort=xhigh" in resolve_thinking("claude-opus-4-8", "xhigh").describe()
-    assert "thinking_budget" in resolve_thinking("gemini-2.5-pro", "dynamic").describe()
+    adaptive_xhigh = {"thinking": {"type": "adaptive"}, "effort": "xhigh"}
+    assert "adaptive" in resolve_thinking("claude-opus-4-8", adaptive_xhigh).describe()
     assert (
-        resolve_thinking("deepseek-ai/DeepSeek-V4-Pro", "dynamic").describe()
-        == "(none sent)"
+        "effort=xhigh" in resolve_thinking("claude-opus-4-8", adaptive_xhigh).describe()
     )
-
-
-def test_resolve_native_thinking_accepts_provider_native_configs():
-    gemini = resolve_native_thinking("gemini-2.5-pro", {"thinking_budget": 4096})
-    assert gemini.gemini_thinking_config == {
-        "include_thoughts": True,
-        "thinking_budget": 4096,
-    }
-    openai = resolve_native_thinking("gpt-5.5-2026-04-23", {"reasoning": "low"})
-    assert openai.openai_reasoning_effort == "low"
-    anthropic = resolve_native_thinking(
-        "claude-opus-4-8", {"thinking": {"type": "adaptive"}, "effort": "xhigh"}
+    assert (
+        "thinking_budget"
+        in resolve_thinking("gemini-2.5-pro", {"thinking_budget": -1}).describe()
     )
-    assert anthropic.anthropic_thinking == {"type": "adaptive"}
-    assert anthropic.anthropic_effort == "xhigh"
-    together = resolve_native_thinking("deepseek-ai/DeepSeek-V4-Pro", {})
-    assert together.describe() == "(none sent)"
-
-
-def test_resolve_native_thinking_rejects_mismatched_provider_keys():
-    with pytest.raises(ThinkingConfigError, match="unknown key"):
-        resolve_native_thinking("gpt-5.5-2026-04-23", {"thinking_budget": 4096})
-    with pytest.raises(ThinkingConfigError, match="cannot set both"):
-        resolve_native_thinking(
-            "gemini-2.5-pro", {"thinking_budget": 4096, "thinking_level": "low"}
-        )
-
-
-def test_resolve_native_thinking_rejects_bad_anthropic_shapes():
-    with pytest.raises(ThinkingConfigError, match="thinking.type"):
-        resolve_native_thinking("claude-opus-4-8", {"thinking": {"type": "vibes"}})
-    with pytest.raises(ThinkingConfigError, match="positive integer"):
-        resolve_native_thinking(
-            "claude-opus-4-8", {"thinking": {"type": "enabled"}}
-        )
-    with pytest.raises(ThinkingConfigError, match="effort requires"):
-        resolve_native_thinking(
-            "claude-opus-4-8", {"thinking": {"type": "disabled"}, "effort": "high"}
-        )
+    assert (
+        resolve_thinking("deepseek-ai/DeepSeek-V4-Pro", {}).describe() == "(none sent)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -349,16 +259,9 @@ def test_resolve_native_thinking_rejects_bad_anthropic_shapes():
 
 def _minimal_registry():
     return {
-        "families": {
-            "fam": {
-                "provider": "anthropic",
-                "thinking": {
-                    "mechanism": "anthropic-adaptive",
-                    "rungs": {"none": "omit", "high": "high"},
-                },
-            }
+        "models": {
+            "claude-x": {"provider": "anthropic", "pricing": {}},
         },
-        "models": {"claude-x": {"family": "fam", "pricing": {}}},
     }
 
 
@@ -368,44 +271,35 @@ def test_validate_registry_accepts_minimal():
 
 def test_validate_registry_rejects_unknown_provider():
     bad = _minimal_registry()
-    bad["families"]["fam"]["provider"] = "closedai"
+    bad["models"]["claude-x"]["provider"] = "closedai"
     with pytest.raises(ValueError, match="unknown provider"):
         _validate_registry(bad)
 
 
-def test_validate_registry_rejects_unknown_mechanism():
+def test_validate_registry_rejects_missing_provider():
     bad = _minimal_registry()
-    bad["families"]["fam"]["thinking"]["mechanism"] = "vibes"
-    with pytest.raises(ValueError, match="unknown mechanism"):
+    del bad["models"]["claude-x"]["provider"]
+    with pytest.raises(ValueError, match="unknown provider"):
         _validate_registry(bad)
 
 
-def test_validate_registry_rejects_non_ladder_rung():
+def test_validate_registry_rejects_bad_output_cap():
     bad = _minimal_registry()
-    bad["families"]["fam"]["thinking"]["rungs"]["turbo"] = "high"
-    with pytest.raises(ValueError, match="not a ladder level"):
+    bad["models"]["claude-x"]["max_output_cap"] = -1
+    with pytest.raises(ValueError, match="max_output_cap"):
         _validate_registry(bad)
 
 
-def test_validate_registry_rejects_bad_rung_value_types():
+def test_validate_registry_rejects_bad_pricing():
     bad = _minimal_registry()
-    bad["families"]["fam"]["thinking"]["rungs"]["high"] = 16384
-    with pytest.raises(ValueError, match="anthropic-adaptive values"):
+    bad["models"]["claude-x"]["pricing"] = "cheap"
+    with pytest.raises(ValueError, match="pricing"):
         _validate_registry(bad)
 
 
-def test_validate_registry_rejects_unknown_family_reference():
-    bad = _minimal_registry()
-    bad["models"]["claude-x"]["family"] = "ghost"
-    with pytest.raises(ValueError, match="unknown family"):
-        _validate_registry(bad)
-
-
-def test_validate_registry_rejects_unverified_not_in_rungs():
-    bad = _minimal_registry()
-    bad["families"]["fam"]["thinking"]["unverified"] = ["max"]
-    with pytest.raises(ValueError, match="unverified rung"):
-        _validate_registry(bad)
+def test_validate_registry_rejects_empty():
+    with pytest.raises(ValueError, match="non-empty"):
+        _validate_registry({"models": {}})
 
 
 def test_packaged_registry_is_valid():
@@ -413,4 +307,5 @@ def test_packaged_registry_is_valid():
     from tutormoments.models import _load_registry
 
     registry = _load_registry()
-    assert "families" in registry and "models" in registry
+    assert "models" in registry
+    assert "families" not in registry  # the thinking ladder is gone

--- a/tests/tutormoments/test_models.py
+++ b/tests/tutormoments/test_models.py
@@ -15,6 +15,7 @@ from tutormoments.models import (
     get_pricing,
     infer_provider,
     max_output_cap,
+    resolve_native_thinking,
     resolve_thinking,
 )
 
@@ -300,6 +301,45 @@ def test_describe_renders_wire_form():
         resolve_thinking("deepseek-ai/DeepSeek-V4-Pro", "dynamic").describe()
         == "(none sent)"
     )
+
+
+def test_resolve_native_thinking_accepts_provider_native_configs():
+    gemini = resolve_native_thinking("gemini-2.5-pro", {"thinking_budget": 4096})
+    assert gemini.gemini_thinking_config == {
+        "include_thoughts": True,
+        "thinking_budget": 4096,
+    }
+    openai = resolve_native_thinking("gpt-5.5-2026-04-23", {"reasoning": "low"})
+    assert openai.openai_reasoning_effort == "low"
+    anthropic = resolve_native_thinking(
+        "claude-opus-4-8", {"thinking": {"type": "adaptive"}, "effort": "xhigh"}
+    )
+    assert anthropic.anthropic_thinking == {"type": "adaptive"}
+    assert anthropic.anthropic_effort == "xhigh"
+    together = resolve_native_thinking("deepseek-ai/DeepSeek-V4-Pro", {})
+    assert together.describe() == "(none sent)"
+
+
+def test_resolve_native_thinking_rejects_mismatched_provider_keys():
+    with pytest.raises(ThinkingConfigError, match="unknown key"):
+        resolve_native_thinking("gpt-5.5-2026-04-23", {"thinking_budget": 4096})
+    with pytest.raises(ThinkingConfigError, match="cannot set both"):
+        resolve_native_thinking(
+            "gemini-2.5-pro", {"thinking_budget": 4096, "thinking_level": "low"}
+        )
+
+
+def test_resolve_native_thinking_rejects_bad_anthropic_shapes():
+    with pytest.raises(ThinkingConfigError, match="thinking.type"):
+        resolve_native_thinking("claude-opus-4-8", {"thinking": {"type": "vibes"}})
+    with pytest.raises(ThinkingConfigError, match="positive integer"):
+        resolve_native_thinking(
+            "claude-opus-4-8", {"thinking": {"type": "enabled"}}
+        )
+    with pytest.raises(ThinkingConfigError, match="effort requires"):
+        resolve_native_thinking(
+            "claude-opus-4-8", {"thinking": {"type": "disabled"}, "effort": "high"}
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tutormoments/test_models.py
+++ b/tests/tutormoments/test_models.py
@@ -69,6 +69,11 @@ WIRE_MATRIX = [
     ),
     (
         "gemini-2.5-pro",
+        "xhigh",
+        _gem({"include_thoughts": True, "thinking_budget": 32768}),
+    ),
+    (
+        "gemini-2.5-pro",
         "dynamic",
         _gem({"include_thoughts": True, "thinking_budget": -1}),
     ),

--- a/tests/tutormoments/test_models.py
+++ b/tests/tutormoments/test_models.py
@@ -1,0 +1,386 @@
+"""Contract tests for the model registry and thinking-ladder translation.
+
+The matrix below pins the exact wire fragment every (family, rung) pair
+produces. These are benchmark-defining mappings: a change here changes what
+gets sent to providers, so the expected values are written out literally
+rather than derived.
+"""
+
+import pytest
+
+from tutormoments.models import (
+    ThinkingConfigError,
+    ThinkingLevel,
+    _validate_registry,
+    get_pricing,
+    infer_provider,
+    max_output_cap,
+    resolve_thinking,
+)
+
+# ---------------------------------------------------------------------------
+# The ladder -> wire matrix, one row per (model, level) that must SUCCEED.
+# Expected is (anthropic_thinking, anthropic_effort, gemini_thinking_config,
+# openai_reasoning_effort).
+# ---------------------------------------------------------------------------
+
+ADAPTIVE = {"type": "adaptive"}
+
+
+def _anth(thinking, effort=None):
+    return (thinking, effort, None, None)
+
+
+def _gem(config):
+    return (None, None, config, None)
+
+
+def _oai(effort):
+    return (None, None, None, effort)
+
+
+NOTHING = (None, None, None, None)
+
+WIRE_MATRIX = [
+    # --- anthropic 4.6 adaptive tier ---
+    ("claude-opus-4-6", "none", NOTHING),
+    ("claude-opus-4-6", "low", _anth(ADAPTIVE, "low")),
+    ("claude-opus-4-6", "medium", _anth(ADAPTIVE, "medium")),
+    ("claude-opus-4-6", "high", _anth(ADAPTIVE, "high")),
+    ("claude-opus-4-6", "max", _anth(ADAPTIVE, "max")),
+    ("claude-opus-4-6", "dynamic", _anth(ADAPTIVE)),
+    ("claude-sonnet-4-6", "high", _anth(ADAPTIVE, "high")),
+    # --- anthropic 4.7+ adaptive tier ---
+    ("claude-opus-4-8", "none", NOTHING),
+    ("claude-opus-4-8", "xhigh", _anth(ADAPTIVE, "xhigh")),
+    ("claude-opus-4-8", "dynamic", _anth(ADAPTIVE)),
+    # --- sonnet 5: off must be explicit ---
+    ("claude-sonnet-5", "none", _anth({"type": "disabled"})),
+    ("claude-sonnet-5", "xhigh", _anth(ADAPTIVE, "xhigh")),
+    ("claude-sonnet-5", "dynamic", _anth(ADAPTIVE)),
+    # --- anthropic legacy (enabled + budget) ---
+    ("claude-haiku-4-5", "none", NOTHING),
+    ("claude-haiku-4-5", "minimal", _anth({"type": "enabled", "budget_tokens": 1024})),
+    ("claude-haiku-4-5", "low", _anth({"type": "enabled", "budget_tokens": 4096})),
+    ("claude-haiku-4-5", "medium", _anth({"type": "enabled", "budget_tokens": 8192})),
+    ("claude-haiku-4-5", "high", _anth({"type": "enabled", "budget_tokens": 16384})),
+    ("claude-haiku-4-5", "max", _anth({"type": "enabled", "budget_tokens": 32768})),
+    ("claude-3-7-sonnet", "high", _anth({"type": "enabled", "budget_tokens": 16384})),
+    # --- gemini 2.5 pro (always-thinking) ---
+    (
+        "gemini-2.5-pro",
+        "minimal",
+        _gem({"include_thoughts": True, "thinking_budget": 1024}),
+    ),
+    (
+        "gemini-2.5-pro",
+        "high",
+        _gem({"include_thoughts": True, "thinking_budget": 16384}),
+    ),
+    (
+        "gemini-2.5-pro",
+        "max",
+        _gem({"include_thoughts": True, "thinking_budget": 32768}),
+    ),
+    (
+        "gemini-2.5-pro",
+        "dynamic",
+        _gem({"include_thoughts": True, "thinking_budget": -1}),
+    ),
+    # --- gemini 2.5 flash (off is real) ---
+    (
+        "gemini-2.5-flash",
+        "none",
+        _gem({"include_thoughts": False, "thinking_budget": 0}),
+    ),
+    (
+        "gemini-2.5-flash",
+        "low",
+        _gem({"include_thoughts": True, "thinking_budget": 4096}),
+    ),
+    (
+        "gemini-2.5-flash",
+        "max",
+        _gem({"include_thoughts": True, "thinking_budget": 24576}),
+    ),
+    (
+        "gemini-2.5-flash",
+        "dynamic",
+        _gem({"include_thoughts": True, "thinking_budget": -1}),
+    ),
+    # --- gemini 3.x: dynamic keeps the proven budget -1 shape ---
+    (
+        "gemini-3.5-flash",
+        "dynamic",
+        _gem({"include_thoughts": True, "thinking_budget": -1}),
+    ),
+    # --- openai gpt-5 line ---
+    ("gpt-5.5", "low", _oai("low")),
+    ("gpt-5.5", "medium", _oai("medium")),
+    ("gpt-5.5", "high", _oai("high")),
+    ("gpt-5.4-mini", "high", _oai("high")),
+    # --- openai o-series ---
+    ("o3", "low", _oai("low")),
+    ("o4", "high", _oai("high")),
+    # --- together internal reasoners ---
+    ("deepseek-ai/DeepSeek-V4-Pro", "dynamic", NOTHING),
+]
+
+
+@pytest.mark.parametrize("model,level,expected", WIRE_MATRIX)
+def test_wire_matrix(model, level, expected):
+    wire = resolve_thinking(model, level)
+    anth_thinking, anth_effort, gem_config, oai_effort = expected
+    assert wire.anthropic_thinking == anth_thinking
+    assert wire.anthropic_effort == anth_effort
+    assert wire.gemini_thinking_config == gem_config
+    assert wire.openai_reasoning_effort == oai_effort
+    assert wire.level == ThinkingLevel(level)
+
+
+# ---------------------------------------------------------------------------
+# Unsatisfiable rungs must raise with a reason.
+# ---------------------------------------------------------------------------
+
+UNSATISFIABLE = [
+    ("gemini-2.5-pro", "none"),  # API rejects budget 0
+    ("gemini-3.5-flash", "none"),  # thinking_level floor doesn't guarantee off
+    ("o3", "none"),  # no off switch
+    ("o3", "xhigh"),
+    ("deepseek-ai/DeepSeek-V4-Pro", "none"),  # always-thinking
+    ("deepseek-ai/DeepSeek-V4-Pro", "high"),  # no depth knob at all
+    ("claude-opus-4-6", "xhigh"),  # 4.6 tier has no xhigh
+    ("claude-haiku-4-5", "dynamic"),  # legacy models have no adaptive mode
+]
+
+
+@pytest.mark.parametrize("model,level", UNSATISFIABLE)
+def test_unsatisfiable_rungs_raise(model, level):
+    with pytest.raises(ThinkingConfigError) as exc_info:
+        resolve_thinking(model, level)
+    assert "does not support" in str(exc_info.value)
+
+
+def test_unsatisfiable_error_carries_family_reason():
+    with pytest.raises(ThinkingConfigError, match="rejects thinking_budget"):
+        resolve_thinking("gemini-2.5-pro", "none")
+    with pytest.raises(ThinkingConfigError, match="off switch"):
+        resolve_thinking("o3-mini", "none")
+
+
+# ---------------------------------------------------------------------------
+# Unverified rungs are fail-closed until proven live.
+# ---------------------------------------------------------------------------
+
+UNVERIFIED = [
+    ("gemini-3.5-flash", "minimal"),
+    ("gemini-3.5-flash", "low"),
+    ("gemini-3.5-flash", "high"),
+    ("gpt-5.5", "none"),
+    ("gpt-5.5", "minimal"),
+    ("gpt-5.5", "xhigh"),
+]
+
+
+@pytest.mark.parametrize("model,level", UNVERIFIED)
+def test_unverified_rungs_raise(model, level):
+    with pytest.raises(ThinkingConfigError, match="not been verified"):
+        resolve_thinking(model, level)
+
+
+# ---------------------------------------------------------------------------
+# Registration and matching rules.
+# ---------------------------------------------------------------------------
+
+
+def test_unregistered_model_with_explicit_level_raises():
+    with pytest.raises(ThinkingConfigError, match="not in the model registry"):
+        resolve_thinking("brand-new-model-9000", "high")
+
+
+def test_unregistered_model_with_none_level_is_a_noop():
+    wire = resolve_thinking("claude-experimental-dev-model", None)
+    assert wire.level is None
+    assert wire.anthropic_thinking is None
+    assert wire.anthropic_effort is None
+
+
+def test_point_release_resolves_via_prefix():
+    wire = resolve_thinking("claude-haiku-4-5-20251001", "high")
+    assert wire.anthropic_thinking == {"type": "enabled", "budget_tokens": 16384}
+    wire = resolve_thinking("gpt-5.4-mini-2026-03-17", "high")
+    assert wire.openai_reasoning_effort == "high"
+    wire = resolve_thinking("gpt-5.5-2026-04-23", "high")
+    assert wire.openai_reasoning_effort == "high"
+
+
+def test_longest_prefix_wins():
+    # claude-opus-4-20250514 (legacy) must not be swallowed by any shorter
+    # entry; and its dated id resolves to itself, not claude-opus-4-...
+    wire = resolve_thinking("claude-opus-4-20250514", "high")
+    assert wire.anthropic_thinking == {"type": "enabled", "budget_tokens": 16384}
+
+
+def test_matching_is_case_insensitive():
+    wire = resolve_thinking("Claude-Opus-4-8", "xhigh")
+    assert wire.anthropic_effort == "xhigh"
+    wire = resolve_thinking("GPT-5.5-2026-04-23", "high")
+    assert wire.openai_reasoning_effort == "high"
+    wire = resolve_thinking("deepseek-ai/deepseek-v4-pro", "dynamic")
+    assert wire.provider == "together"
+
+
+# ---------------------------------------------------------------------------
+# ThinkingLevel.coerce: the config-boundary gate.
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_accepts_ladder_strings_case_insensitively():
+    assert ThinkingLevel.coerce("HIGH") is ThinkingLevel.HIGH
+    assert ThinkingLevel.coerce("none") is ThinkingLevel.NONE
+    assert ThinkingLevel.coerce(None) is None
+    assert ThinkingLevel.coerce(ThinkingLevel.DYNAMIC) is ThinkingLevel.DYNAMIC
+
+
+@pytest.mark.parametrize("bad", [True, False])
+def test_coerce_rejects_booleans_with_migration_hint(bad):
+    with pytest.raises(ThinkingConfigError, match="ladder"):
+        ThinkingLevel.coerce(bad)
+
+
+def test_coerce_rejects_unknown_strings():
+    with pytest.raises(ThinkingConfigError, match="not a valid thinking level"):
+        ThinkingLevel.coerce("adaptive")  # retired spelling; dynamic replaced it
+    with pytest.raises(ThinkingConfigError, match="not a valid thinking level"):
+        ThinkingLevel.coerce("enabled")
+
+
+def test_coerce_rejects_numbers():
+    with pytest.raises(ThinkingConfigError, match="registry"):
+        ThinkingLevel.coerce(16384)
+
+
+# ---------------------------------------------------------------------------
+# Provider inference and per-model facts.
+# ---------------------------------------------------------------------------
+
+
+def test_infer_provider_registered_models():
+    assert infer_provider("claude-sonnet-5") == "anthropic"
+    assert infer_provider("gemini-3.5-flash") == "gemini"
+    assert infer_provider("gpt-5.5-2026-04-23") == "openai"
+    assert infer_provider("deepseek-ai/DeepSeek-V4-Pro") == "together"
+
+
+def test_infer_provider_unregistered_falls_back_to_prefixes():
+    assert infer_provider("claude-hypothetical-6") == "anthropic"
+    assert infer_provider("gpt-4o") == "openai"
+    assert infer_provider("o3-mini") == "openai"
+    assert infer_provider("qwen/Qwen3-235B") == "together"
+
+
+def test_infer_provider_is_case_insensitive():
+    assert infer_provider("GEMINI-2.5-PRO") == "gemini"
+
+
+def test_infer_provider_unknown_raises():
+    with pytest.raises(ValueError, match="Cannot infer provider"):
+        infer_provider("mystery-model")
+
+
+def test_max_output_cap():
+    assert max_output_cap("claude-haiku-4-5") == 64000
+    assert max_output_cap("claude-haiku-4-5-20251001") == 64000
+    assert max_output_cap("claude-opus-4-8") is None
+    assert max_output_cap("not-registered") is None
+
+
+def test_get_pricing_shape():
+    # Pricing is schema-room for the cost-tracking workstream: present, dict,
+    # empty until populated. Empty means "not priced yet", never "free".
+    assert get_pricing("claude-opus-4-8") == {}
+    assert get_pricing("unregistered-model") == {}
+
+
+def test_describe_renders_wire_form():
+    assert "adaptive" in resolve_thinking("claude-opus-4-8", "xhigh").describe()
+    assert "effort=xhigh" in resolve_thinking("claude-opus-4-8", "xhigh").describe()
+    assert "thinking_budget" in resolve_thinking("gemini-2.5-pro", "dynamic").describe()
+    assert (
+        resolve_thinking("deepseek-ai/DeepSeek-V4-Pro", "dynamic").describe()
+        == "(none sent)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry schema validation (bad registries must fail loudly at load).
+# ---------------------------------------------------------------------------
+
+
+def _minimal_registry():
+    return {
+        "families": {
+            "fam": {
+                "provider": "anthropic",
+                "thinking": {
+                    "mechanism": "anthropic-adaptive",
+                    "rungs": {"none": "omit", "high": "high"},
+                },
+            }
+        },
+        "models": {"claude-x": {"family": "fam", "pricing": {}}},
+    }
+
+
+def test_validate_registry_accepts_minimal():
+    assert _validate_registry(_minimal_registry())
+
+
+def test_validate_registry_rejects_unknown_provider():
+    bad = _minimal_registry()
+    bad["families"]["fam"]["provider"] = "closedai"
+    with pytest.raises(ValueError, match="unknown provider"):
+        _validate_registry(bad)
+
+
+def test_validate_registry_rejects_unknown_mechanism():
+    bad = _minimal_registry()
+    bad["families"]["fam"]["thinking"]["mechanism"] = "vibes"
+    with pytest.raises(ValueError, match="unknown mechanism"):
+        _validate_registry(bad)
+
+
+def test_validate_registry_rejects_non_ladder_rung():
+    bad = _minimal_registry()
+    bad["families"]["fam"]["thinking"]["rungs"]["turbo"] = "high"
+    with pytest.raises(ValueError, match="not a ladder level"):
+        _validate_registry(bad)
+
+
+def test_validate_registry_rejects_bad_rung_value_types():
+    bad = _minimal_registry()
+    bad["families"]["fam"]["thinking"]["rungs"]["high"] = 16384
+    with pytest.raises(ValueError, match="anthropic-adaptive values"):
+        _validate_registry(bad)
+
+
+def test_validate_registry_rejects_unknown_family_reference():
+    bad = _minimal_registry()
+    bad["models"]["claude-x"]["family"] = "ghost"
+    with pytest.raises(ValueError, match="unknown family"):
+        _validate_registry(bad)
+
+
+def test_validate_registry_rejects_unverified_not_in_rungs():
+    bad = _minimal_registry()
+    bad["families"]["fam"]["thinking"]["unverified"] = ["max"]
+    with pytest.raises(ValueError, match="unverified rung"):
+        _validate_registry(bad)
+
+
+def test_packaged_registry_is_valid():
+    # The shipped models.yaml must always pass its own validation.
+    from tutormoments.models import _load_registry
+
+    registry = _load_registry()
+    assert "families" in registry and "models" in registry

--- a/tests/tutormoments/test_models.py
+++ b/tests/tutormoments/test_models.py
@@ -45,9 +45,7 @@ WIRE_MATRIX = [
     # --- anthropic 4.6 adaptive tier ---
     ("claude-opus-4-6", "none", NOTHING),
     ("claude-opus-4-6", "low", _anth(ADAPTIVE, "low")),
-    ("claude-opus-4-6", "medium", _anth(ADAPTIVE, "medium")),
     ("claude-opus-4-6", "high", _anth(ADAPTIVE, "high")),
-    ("claude-opus-4-6", "max", _anth(ADAPTIVE, "max")),
     ("claude-opus-4-6", "dynamic", _anth(ADAPTIVE)),
     ("claude-sonnet-4-6", "high", _anth(ADAPTIVE, "high")),
     # --- anthropic 4.7+ adaptive tier ---
@@ -60,27 +58,14 @@ WIRE_MATRIX = [
     ("claude-sonnet-5", "dynamic", _anth(ADAPTIVE)),
     # --- anthropic legacy (enabled + budget) ---
     ("claude-haiku-4-5", "none", NOTHING),
-    ("claude-haiku-4-5", "minimal", _anth({"type": "enabled", "budget_tokens": 1024})),
     ("claude-haiku-4-5", "low", _anth({"type": "enabled", "budget_tokens": 4096})),
-    ("claude-haiku-4-5", "medium", _anth({"type": "enabled", "budget_tokens": 8192})),
     ("claude-haiku-4-5", "high", _anth({"type": "enabled", "budget_tokens": 16384})),
-    ("claude-haiku-4-5", "max", _anth({"type": "enabled", "budget_tokens": 32768})),
     ("claude-3-7-sonnet", "high", _anth({"type": "enabled", "budget_tokens": 16384})),
     # --- gemini 2.5 pro (always-thinking) ---
     (
         "gemini-2.5-pro",
-        "minimal",
-        _gem({"include_thoughts": True, "thinking_budget": 1024}),
-    ),
-    (
-        "gemini-2.5-pro",
         "high",
         _gem({"include_thoughts": True, "thinking_budget": 16384}),
-    ),
-    (
-        "gemini-2.5-pro",
-        "max",
-        _gem({"include_thoughts": True, "thinking_budget": 32768}),
     ),
     (
         "gemini-2.5-pro",
@@ -100,11 +85,6 @@ WIRE_MATRIX = [
     ),
     (
         "gemini-2.5-flash",
-        "max",
-        _gem({"include_thoughts": True, "thinking_budget": 24576}),
-    ),
-    (
-        "gemini-2.5-flash",
         "dynamic",
         _gem({"include_thoughts": True, "thinking_budget": -1}),
     ),
@@ -116,7 +96,6 @@ WIRE_MATRIX = [
     ),
     # --- openai gpt-5 line ---
     ("gpt-5.5", "low", _oai("low")),
-    ("gpt-5.5", "medium", _oai("medium")),
     ("gpt-5.5", "high", _oai("high")),
     ("gpt-5.4-mini", "high", _oai("high")),
     # --- openai o-series ---
@@ -173,11 +152,9 @@ def test_unsatisfiable_error_carries_family_reason():
 # ---------------------------------------------------------------------------
 
 UNVERIFIED = [
-    ("gemini-3.5-flash", "minimal"),
     ("gemini-3.5-flash", "low"),
     ("gemini-3.5-flash", "high"),
     ("gpt-5.5", "none"),
-    ("gpt-5.5", "minimal"),
     ("gpt-5.5", "xhigh"),
 ]
 
@@ -253,6 +230,14 @@ def test_coerce_rejects_unknown_strings():
         ThinkingLevel.coerce("adaptive")  # retired spelling; dynamic replaced it
     with pytest.raises(ThinkingConfigError, match="not a valid thinking level"):
         ThinkingLevel.coerce("enabled")
+
+
+@pytest.mark.parametrize("dropped", ["minimal", "medium", "max"])
+def test_coerce_rejects_dropped_rungs(dropped):
+    # The ladder is deliberately small: these rungs were removed as unused.
+    # Re-adding one is a reviewed registry line + a smoke verification.
+    with pytest.raises(ThinkingConfigError, match="not a valid thinking level"):
+        ThinkingLevel.coerce(dropped)
 
 
 def test_coerce_rejects_numbers():

--- a/tests/tutormoments/test_report.py
+++ b/tests/tutormoments/test_report.py
@@ -678,7 +678,7 @@ def test_leaderboard_dashes_ttft_for_a_cell_with_no_probe():
     md, _ = leaderboard([SUMMARY_A, SUMMARY_B], {})
     for line in md.splitlines():
         if line.startswith("| model-"):
-            assert "-" in line.split("|")[7]
+            assert "-" in line.split("|")[8]
 
 
 def test_leaderboard_ttft_join_is_per_mode():
@@ -694,7 +694,7 @@ def test_leaderboard_ttft_join_is_per_mode():
     probes = {("model-alpha", "scaffolding_rigor"): _probe_block(p50_all=9.446)}
     md, _ = leaderboard([SUMMARY_A, plain], probes)
     rows = {
-        line.split("|")[2].strip(): line
+        line.split("|")[3].strip(): line
         for line in md.splitlines()
         if line.startswith("| model-alpha")
     }
@@ -714,9 +714,9 @@ def test_leaderboard_splits_by_turn_for_a_provider_with_no_cache_reporting():
     md, _ = leaderboard([SUMMARY_A], probes)
     row = next(line for line in md.splitlines() if line.startswith("| model-alpha"))
     cells = [c.strip() for c in row.split("|")]
-    assert cells[7] == "14.080"  # ttft_p50
-    assert cells[8] == "14.700"  # ttft_first_p50
-    assert cells[9] == "13.700"  # ttft_later_p50
+    assert cells[8] == "14.080"  # ttft_p50
+    assert cells[9] == "14.700"  # ttft_first_p50
+    assert cells[10] == "13.700"  # ttft_later_p50
 
 
 def test_leaderboard_dashes_the_split_when_a_probe_carries_no_samples():
@@ -726,6 +726,6 @@ def test_leaderboard_dashes_the_split_when_a_probe_carries_no_samples():
     md, _ = leaderboard([SUMMARY_A], probes)
     row = next(line for line in md.splitlines() if line.startswith("| model-alpha"))
     cells = [c.strip() for c in row.split("|")]
-    assert cells[7] == "7.940"
-    assert cells[8] == "-"
+    assert cells[8] == "7.940"
     assert cells[9] == "-"
+    assert cells[10] == "-"

--- a/tests/tutormoments/test_smoke.py
+++ b/tests/tutormoments/test_smoke.py
@@ -64,14 +64,18 @@ def _factory(clients):
     return get
 
 
-def _sync_check(model="claude-opus-4-8", thinking="xhigh", label="arm:test"):
-    from tutormoments.models import ThinkingLevel, infer_provider
+ADAPTIVE_XHIGH = {"thinking": {"type": "adaptive"}, "effort": "xhigh"}
+ENABLED_16K = {"thinking": {"type": "enabled", "budget_tokens": 16384}}
+
+
+def _sync_check(model="claude-opus-4-8", thinking=None, label="arm:test"):
+    from tutormoments.models import infer_provider
 
     return SyncCheck(
         label=label,
         model=model,
         provider=infer_provider(model),
-        thinking=ThinkingLevel.coerce(thinking),
+        thinking=ADAPTIVE_XHIGH if thinking is None else thinking,
         json_mode=False,
     )
 
@@ -97,11 +101,11 @@ def smoke_config(tmp_path, monkeypatch):
 providers:
   anthropic: { env: ANTHROPIC_API_KEY }
   gemini:    { env: GEMINI_API_KEY }
-models:
-  sonnet-high: { model: claude-sonnet-4-6, thinking: high }
-  gemini-dyn:  { model: gemini-2.5-pro, thinking: dynamic }
-student: { model: claude-opus-4-6, mode: oracle, thinking: none }
-scorer:  { model: claude-opus-4-6, thinking: dynamic }
+benchmark_models:
+  sonnet-high: { model: claude-sonnet-4-6, thinking: { type: adaptive }, effort: high, condition: high }
+  gemini-dyn:  { model: gemini-2.5-pro, thinking_budget: -1, condition: dynamic }
+student: { model: claude-opus-4-6, mode: oracle, thinking: null }
+scorer:  { model: claude-opus-4-6, thinking: { type: adaptive } }
 defaults: { trials: 1, max_turns: 5 }
 retry:    { max_retries: 5, base_delay: 5 }
 batch:    { timeout: 86400 }
@@ -120,7 +124,7 @@ def test_build_plan_enumerates_arms_and_roles(smoke_config):
     arm = plan.sync_checks[0]
     assert arm.model == "claude-sonnet-4-6"
     assert arm.provider == "anthropic"
-    assert arm.thinking == "high"
+    assert arm.thinking == {"thinking": {"type": "adaptive"}, "effort": "high"}
     # One batch representative per batch-capable provider; the scorer's model
     # is preferred for its provider.
     by_provider = {b.provider: b for b in plan.batch_checks}
@@ -152,7 +156,7 @@ def test_build_plan_unknown_arm_raises(smoke_config):
 
 
 def test_sync_pass_with_thinking_evidence():
-    check = _sync_check("claude-haiku-4-5", "high")  # legacy enabled: required
+    check = _sync_check("claude-haiku-4-5", ENABLED_16K)  # enabled: required
     client = _FakeClient(
         "claude-haiku-4-5",
         response=SimpleNamespace(
@@ -166,7 +170,7 @@ def test_sync_pass_with_thinking_evidence():
     assert row.status == PASS
     assert row.thinking_evidence == "2"
     # The check must send the arm's real condition.
-    assert client.calls[0]["thinking"] == "high"
+    assert client.calls[0]["thinking"] == ENABLED_16K
 
 
 def test_sync_fail_on_empty_text():
@@ -196,7 +200,7 @@ def test_sync_fail_on_missing_usage():
 
 def test_required_thinking_without_evidence_fails():
     # Gemini fixed budget: thinking is required; zero reasoning tokens = FAIL.
-    check = _sync_check("gemini-2.5-pro", "high")
+    check = _sync_check("gemini-2.5-pro", {"thinking_budget": 16384})
     client = _FakeClient(
         "gemini-2.5-pro",
         response=SimpleNamespace(
@@ -211,7 +215,7 @@ def test_required_thinking_without_evidence_fails():
 
 
 def test_thinking_off_with_evidence_fails():
-    check = _sync_check("gemini-2.5-flash", "none")
+    check = _sync_check("gemini-2.5-flash", {"thinking_budget": 0})
     client = _FakeClient(
         "gemini-2.5-flash",
         response=SimpleNamespace(
@@ -226,7 +230,7 @@ def test_thinking_off_with_evidence_fails():
 
 
 def test_dynamic_without_evidence_warns_then_fails_strict():
-    check = _sync_check("gemini-2.5-pro", "dynamic")
+    check = _sync_check("gemini-2.5-pro", {"thinking_budget": -1})
     response = SimpleNamespace(
         text="answer", usage=_usage(provider="gemini", reasoning=0)
     )
@@ -247,7 +251,7 @@ def test_openai_reasoning_tokens_are_evidence():
     # surfaced by the client as the informational reasoning_tokens key (the
     # canonical `reasoning` bucket stays 0 there -- it is a subset of output,
     # not a separate cost). The smoke must read it as evidence.
-    check = _sync_check("gpt-5.5", "high")
+    check = _sync_check("gpt-5.5", {"reasoning": "high"})
     client = _FakeClient(
         "gpt-5.5",
         response=SimpleNamespace(
@@ -275,7 +279,7 @@ def test_openai_reasoning_tokens_are_evidence():
 
 
 def test_together_evidence_not_asserted():
-    check = _sync_check("deepseek-ai/DeepSeek-V4-Pro", "dynamic")
+    check = _sync_check("deepseek-ai/DeepSeek-V4-Pro", {})
     client = _FakeClient(
         "deepseek-ai/DeepSeek-V4-Pro",
         response=SimpleNamespace(
@@ -291,8 +295,12 @@ def test_together_evidence_not_asserted():
 
 
 def test_one_check_exception_does_not_abort_others():
-    bad = _sync_check("claude-opus-4-8", "xhigh", label="arm:bad")
-    good = _sync_check("claude-sonnet-4-6", "high", label="arm:good")
+    bad = _sync_check("claude-opus-4-8", label="arm:bad")
+    good = _sync_check(
+        "claude-sonnet-4-6",
+        {"thinking": {"type": "adaptive"}, "effort": "high"},
+        label="arm:good",
+    )
     clients = {
         "claude-opus-4-8": _FakeClient("claude-opus-4-8", error=RuntimeError("boom")),
         "claude-sonnet-4-6": _FakeClient(
@@ -315,13 +323,13 @@ def test_one_check_exception_does_not_abort_others():
 # ---------------------------------------------------------------------------
 
 
-def _batch_check(model="claude-opus-4-6", thinking="dynamic"):
-    from tutormoments.models import ThinkingLevel, infer_provider
+def _batch_check(model="claude-opus-4-6", thinking=None):
+    from tutormoments.models import infer_provider
 
     return BatchCheck(
         provider=infer_provider(model),
         model=model,
-        thinking=ThinkingLevel.coerce(thinking),
+        thinking={"thinking": {"type": "adaptive"}} if thinking is None else thinking,
     )
 
 
@@ -349,7 +357,7 @@ def test_batch_submit_and_cancel_pass():
     assert row.batch_id == "batch-123"
     assert cancelled["id"] == "batch-123"
     assert len(submitted["entries"]) == 2
-    assert submitted["thinking"] == "dynamic"
+    assert submitted["thinking"] == {"thinking": {"type": "adaptive"}}
 
 
 def test_batch_cancel_failure_warns_with_id():
@@ -393,7 +401,7 @@ def test_batch_submit_failure_fails():
 
 
 def test_report_renders_ascii_and_json():
-    check = _sync_check("claude-opus-4-8", "xhigh")
+    check = _sync_check("claude-opus-4-8", ADAPTIVE_XHIGH)
     client = _FakeClient(
         "claude-opus-4-8",
         response=SimpleNamespace(

--- a/tests/tutormoments/test_smoke.py
+++ b/tests/tutormoments/test_smoke.py
@@ -242,6 +242,34 @@ def test_dynamic_without_evidence_warns_then_fails_strict():
     assert report.results[0].status == FAIL
 
 
+def test_openai_reasoning_tokens_are_evidence():
+    # OpenAI reports thinking as usage.completion_tokens_details.reasoning_tokens,
+    # surfaced by the client as the informational reasoning_tokens key (the
+    # canonical `reasoning` bucket stays 0 there -- it is a subset of output,
+    # not a separate cost). The smoke must read it as evidence.
+    check = _sync_check("gpt-5.5", "high")
+    client = _FakeClient(
+        "gpt-5.5",
+        response=SimpleNamespace(
+            text="answer",
+            usage=_usage(provider="openai", reasoning=0, reasoning_tokens=1857),
+        ),
+    )
+    report = run_smoke(_plan(sync=[check]), client_factory=_factory({"gpt-5.5": client}))
+    assert report.results[0].status == PASS
+    assert report.results[0].thinking_evidence == "1857"
+
+    client = _FakeClient(
+        "gpt-5.5",
+        response=SimpleNamespace(
+            text="answer",
+            usage=_usage(provider="openai", reasoning=0, reasoning_tokens=0),
+        ),
+    )
+    report = run_smoke(_plan(sync=[check]), client_factory=_factory({"gpt-5.5": client}))
+    assert report.results[0].status == FAIL
+
+
 def test_together_evidence_not_asserted():
     check = _sync_check("deepseek-ai/DeepSeek-V4-Pro", "dynamic")
     client = _FakeClient(

--- a/tests/tutormoments/test_smoke.py
+++ b/tests/tutormoments/test_smoke.py
@@ -255,7 +255,9 @@ def test_openai_reasoning_tokens_are_evidence():
             usage=_usage(provider="openai", reasoning=0, reasoning_tokens=1857),
         ),
     )
-    report = run_smoke(_plan(sync=[check]), client_factory=_factory({"gpt-5.5": client}))
+    report = run_smoke(
+        _plan(sync=[check]), client_factory=_factory({"gpt-5.5": client})
+    )
     assert report.results[0].status == PASS
     assert report.results[0].thinking_evidence == "1857"
 
@@ -266,7 +268,9 @@ def test_openai_reasoning_tokens_are_evidence():
             usage=_usage(provider="openai", reasoning=0, reasoning_tokens=0),
         ),
     )
-    report = run_smoke(_plan(sync=[check]), client_factory=_factory({"gpt-5.5": client}))
+    report = run_smoke(
+        _plan(sync=[check]), client_factory=_factory({"gpt-5.5": client})
+    )
     assert report.results[0].status == FAIL
 
 

--- a/tests/tutormoments/test_smoke.py
+++ b/tests/tutormoments/test_smoke.py
@@ -1,0 +1,413 @@
+"""Offline tests for the live smoke layer (tutormoments smoke).
+
+The smoke command's own logic must be testable without any network: the
+client factory and batch submit/cancel callables are injectable, so canned
+responses drive every verdict path.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tutormoments.smoke import (
+    FAIL,
+    PASS,
+    WARN,
+    BatchCheck,
+    SmokePlan,
+    SyncCheck,
+    build_smoke_plan,
+    format_smoke_report,
+    run_smoke,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _usage(provider="anthropic", total=100, reasoning=0, **extra):
+    usage = {
+        "input_tokens": 80,
+        "output_tokens": 20,
+        "total_tokens": total,
+        "total": total,
+        "reasoning": reasoning,
+        "provider": provider,
+    }
+    usage.update(extra)
+    return usage
+
+
+class _FakeClient:
+    def __init__(self, model, response=None, error=None):
+        self.model = model
+        from tutormoments.models import infer_provider
+
+        self.provider = infer_provider(model)
+        self._response = response
+        self._error = error
+        self.calls = []
+
+    def generate(self, prompt, **kwargs):
+        self.calls.append({"prompt": prompt, **kwargs})
+        if self._error is not None:
+            raise self._error
+        return self._response
+
+
+def _factory(clients):
+    def get(model):
+        return clients[model]
+
+    return get
+
+
+def _sync_check(model="claude-opus-4-8", thinking="xhigh", label="arm:test"):
+    from tutormoments.models import ThinkingLevel, infer_provider
+
+    return SyncCheck(
+        label=label,
+        model=model,
+        provider=infer_provider(model),
+        thinking=ThinkingLevel.coerce(thinking),
+        json_mode=False,
+    )
+
+
+def _plan(sync=(), batch=(), skipped=()):
+    return SmokePlan(
+        sync_checks=list(sync), batch_checks=list(batch), skipped=list(skipped)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plan building (pure, from a config file)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def smoke_config(tmp_path, monkeypatch):
+    from tutormoments.config import _reset_config_cache
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+providers:
+  anthropic: { env: ANTHROPIC_API_KEY }
+  gemini:    { env: GEMINI_API_KEY }
+models:
+  sonnet-high: { model: claude-sonnet-4-6, thinking: high }
+  gemini-dyn:  { model: gemini-2.5-pro, thinking: dynamic }
+student: { model: claude-opus-4-6, mode: oracle, thinking: none }
+scorer:  { model: claude-opus-4-6, thinking: dynamic }
+defaults: { trials: 1, max_turns: 5 }
+retry:    { max_retries: 5, base_delay: 5 }
+batch:    { timeout: 86400 }
+""",
+        encoding="utf-8",
+    )
+    _reset_config_cache()
+    yield str(cfg)
+    _reset_config_cache()
+
+
+def test_build_plan_enumerates_arms_and_roles(smoke_config):
+    plan = build_smoke_plan(config_path=smoke_config)
+    labels = [c.label for c in plan.sync_checks]
+    assert labels == ["arm:sonnet-high", "arm:gemini-dyn", "student", "scorer"]
+    arm = plan.sync_checks[0]
+    assert arm.model == "claude-sonnet-4-6"
+    assert arm.provider == "anthropic"
+    assert arm.thinking == "high"
+    # One batch representative per batch-capable provider; the scorer's model
+    # is preferred for its provider.
+    by_provider = {b.provider: b for b in plan.batch_checks}
+    assert set(by_provider) == {"anthropic", "gemini"}
+    assert by_provider["anthropic"].model == "claude-opus-4-6"
+
+
+def test_build_plan_filters(smoke_config):
+    plan = build_smoke_plan(
+        config_path=smoke_config, arms=["gemini-dyn"], roles=["tutor"]
+    )
+    assert [c.label for c in plan.sync_checks] == ["arm:gemini-dyn"]
+
+    plan = build_smoke_plan(config_path=smoke_config, providers=["gemini"])
+    assert {c.provider for c in plan.sync_checks} == {"gemini"}
+
+    plan = build_smoke_plan(config_path=smoke_config, include_batch=False)
+    assert plan.batch_checks == []
+
+
+def test_build_plan_unknown_arm_raises(smoke_config):
+    with pytest.raises(ValueError, match="not in roster"):
+        build_smoke_plan(config_path=smoke_config, arms=["typo-arm"])
+
+
+# ---------------------------------------------------------------------------
+# Sync check verdicts
+# ---------------------------------------------------------------------------
+
+
+def test_sync_pass_with_thinking_evidence():
+    check = _sync_check("claude-haiku-4-5", "high")  # legacy enabled: required
+    client = _FakeClient(
+        "claude-haiku-4-5",
+        response=SimpleNamespace(
+            text="answer", usage=_usage(reasoning=0, thinking_blocks=2)
+        ),
+    )
+    report = run_smoke(
+        _plan(sync=[check]), client_factory=_factory({"claude-haiku-4-5": client})
+    )
+    (row,) = report.results
+    assert row.status == PASS
+    assert row.thinking_evidence == "2"
+    # The check must send the arm's real condition.
+    assert client.calls[0]["thinking"] == "high"
+
+
+def test_sync_fail_on_empty_text():
+    check = _sync_check()
+    client = _FakeClient(
+        "claude-opus-4-8", response=SimpleNamespace(text="  ", usage=_usage())
+    )
+    report = run_smoke(
+        _plan(sync=[check]), client_factory=_factory({"claude-opus-4-8": client})
+    )
+    assert report.results[0].status == FAIL
+    assert "empty response" in report.results[0].detail
+
+
+def test_sync_fail_on_missing_usage():
+    check = _sync_check()
+    client = _FakeClient(
+        "claude-opus-4-8",
+        response=SimpleNamespace(text="ok", usage={"total_tokens": 0, "total": 0}),
+    )
+    report = run_smoke(
+        _plan(sync=[check]), client_factory=_factory({"claude-opus-4-8": client})
+    )
+    assert report.results[0].status == FAIL
+    assert "usage" in report.results[0].detail
+
+
+def test_required_thinking_without_evidence_fails():
+    # Gemini fixed budget: thinking is required; zero reasoning tokens = FAIL.
+    check = _sync_check("gemini-2.5-pro", "high")
+    client = _FakeClient(
+        "gemini-2.5-pro",
+        response=SimpleNamespace(
+            text="answer", usage=_usage(provider="gemini", reasoning=0)
+        ),
+    )
+    report = run_smoke(
+        _plan(sync=[check]), client_factory=_factory({"gemini-2.5-pro": client})
+    )
+    assert report.results[0].status == FAIL
+    assert "no thinking observed" in report.results[0].detail
+
+
+def test_thinking_off_with_evidence_fails():
+    check = _sync_check("gemini-2.5-flash", "none")
+    client = _FakeClient(
+        "gemini-2.5-flash",
+        response=SimpleNamespace(
+            text="answer", usage=_usage(provider="gemini", reasoning=57)
+        ),
+    )
+    report = run_smoke(
+        _plan(sync=[check]), client_factory=_factory({"gemini-2.5-flash": client})
+    )
+    assert report.results[0].status == FAIL
+    assert "thinking-off" in report.results[0].detail
+
+
+def test_dynamic_without_evidence_warns_then_fails_strict():
+    check = _sync_check("gemini-2.5-pro", "dynamic")
+    response = SimpleNamespace(
+        text="answer", usage=_usage(provider="gemini", reasoning=0)
+    )
+    client = _FakeClient("gemini-2.5-pro", response=response)
+    factory = _factory({"gemini-2.5-pro": client})
+
+    report = run_smoke(_plan(sync=[check]), client_factory=factory)
+    assert report.results[0].status == WARN
+
+    report = run_smoke(
+        _plan(sync=[check]), client_factory=factory, strict_thinking=True
+    )
+    assert report.results[0].status == FAIL
+
+
+def test_together_evidence_not_asserted():
+    check = _sync_check("deepseek-ai/DeepSeek-V4-Pro", "dynamic")
+    client = _FakeClient(
+        "deepseek-ai/DeepSeek-V4-Pro",
+        response=SimpleNamespace(
+            text="answer", usage=_usage(provider="together", reasoning=0)
+        ),
+    )
+    report = run_smoke(
+        _plan(sync=[check]),
+        client_factory=_factory({"deepseek-ai/DeepSeek-V4-Pro": client}),
+    )
+    assert report.results[0].status == PASS
+    assert report.results[0].thinking_evidence == "n/a"
+
+
+def test_one_check_exception_does_not_abort_others():
+    bad = _sync_check("claude-opus-4-8", "xhigh", label="arm:bad")
+    good = _sync_check("claude-sonnet-4-6", "high", label="arm:good")
+    clients = {
+        "claude-opus-4-8": _FakeClient("claude-opus-4-8", error=RuntimeError("boom")),
+        "claude-sonnet-4-6": _FakeClient(
+            "claude-sonnet-4-6",
+            response=SimpleNamespace(
+                text="ok", usage=_usage(reasoning=0, thinking_blocks=1)
+            ),
+        ),
+    }
+    report = run_smoke(_plan(sync=[bad, good]), client_factory=_factory(clients))
+    by_label = {r.label: r for r in report.results}
+    assert by_label["arm:bad"].status == FAIL
+    assert "boom" in by_label["arm:bad"].detail
+    assert by_label["arm:good"].status == PASS
+    assert report.failed
+
+
+# ---------------------------------------------------------------------------
+# Batch checks
+# ---------------------------------------------------------------------------
+
+
+def _batch_check(model="claude-opus-4-6", thinking="dynamic"):
+    from tutormoments.models import ThinkingLevel, infer_provider
+
+    return BatchCheck(
+        provider=infer_provider(model),
+        model=model,
+        thinking=ThinkingLevel.coerce(thinking),
+    )
+
+
+def test_batch_submit_and_cancel_pass():
+    submitted = {}
+    cancelled = {}
+
+    def submit(client, entries, json_mode, display_name, thinking):
+        submitted["entries"] = entries
+        submitted["thinking"] = thinking
+        return "batch-123"
+
+    def cancel(client, batch_id):
+        cancelled["id"] = batch_id
+
+    client = _FakeClient("claude-opus-4-6")
+    report = run_smoke(
+        _plan(batch=[_batch_check()]),
+        client_factory=_factory({"claude-opus-4-6": client}),
+        submit_batch_fn=submit,
+        cancel_batch_fn=cancel,
+    )
+    (row,) = report.results
+    assert row.status == PASS
+    assert row.batch_id == "batch-123"
+    assert cancelled["id"] == "batch-123"
+    assert len(submitted["entries"]) == 2
+    assert submitted["thinking"] == "dynamic"
+
+
+def test_batch_cancel_failure_warns_with_id():
+    def submit(client, entries, json_mode, display_name, thinking):
+        return "batch-456"
+
+    def cancel(client, batch_id):
+        raise RuntimeError("cancel unsupported")
+
+    client = _FakeClient("claude-opus-4-6")
+    report = run_smoke(
+        _plan(batch=[_batch_check()]),
+        client_factory=_factory({"claude-opus-4-6": client}),
+        submit_batch_fn=submit,
+        cancel_batch_fn=cancel,
+    )
+    (row,) = report.results
+    assert row.status == WARN
+    assert "batch-456" == row.batch_id
+    assert "24h" in row.detail
+    assert not report.failed  # WARN alone is not a failure
+
+
+def test_batch_submit_failure_fails():
+    def submit(client, entries, json_mode, display_name, thinking):
+        raise RuntimeError("400 bad thinking_config")
+
+    report = run_smoke(
+        _plan(batch=[_batch_check()]),
+        client_factory=_factory({"claude-opus-4-6": _FakeClient("claude-opus-4-6")}),
+        submit_batch_fn=submit,
+        cancel_batch_fn=lambda c, b: None,
+    )
+    assert report.results[0].status == FAIL
+    assert "bad thinking_config" in report.results[0].detail
+
+
+# ---------------------------------------------------------------------------
+# Rendering + JSON report
+# ---------------------------------------------------------------------------
+
+
+def test_report_renders_ascii_and_json():
+    check = _sync_check("claude-opus-4-8", "xhigh")
+    client = _FakeClient(
+        "claude-opus-4-8",
+        response=SimpleNamespace(
+            text="ok", usage=_usage(reasoning=0, thinking_blocks=1)
+        ),
+    )
+    report = run_smoke(
+        _plan(sync=[check], skipped=[("batch:together", "provider has no batch API")]),
+        client_factory=_factory({"claude-opus-4-8": client}),
+        config_source="tutormoments:default_config.yaml",
+    )
+    text = format_smoke_report(report)
+    assert text.isascii()
+    assert "arm:test" in text
+    assert "effort=xhigh" in text
+    assert "SKIP" in text
+    assert "1 passed" in text
+
+    payload = json.loads(report.to_json())
+    assert payload["config_source"] == "tutormoments:default_config.yaml"
+    assert payload["results"][0]["status"] == PASS
+
+
+def test_cli_smoke_exit_codes(monkeypatch, capsys):
+    import tutormoments.cli as cli
+    from tutormoments.smoke import CheckResult, SmokeReport
+
+    def fake_run_smoke(plan, **kwargs):
+        report = SmokeReport()
+        report.results.append(
+            CheckResult(
+                label="arm:x", model="m", provider="anthropic", wire="", status=FAIL
+            )
+        )
+        return report
+
+    monkeypatch.setattr("tutormoments.smoke.run_smoke", fake_run_smoke)
+    monkeypatch.setattr("tutormoments.smoke.build_smoke_plan", lambda **kw: _plan())
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["smoke"])
+    assert exc_info.value.code == 1
+
+    monkeypatch.setattr(
+        "tutormoments.smoke.build_smoke_plan",
+        lambda **kw: (_ for _ in ()).throw(ValueError("Arm 'x' not in roster")),
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["smoke", "--arms", "x"])
+    assert exc_info.value.code == 2

--- a/tests/tutormoments/test_student.py
+++ b/tests/tutormoments/test_student.py
@@ -106,14 +106,13 @@ class TestResolveStudent:
     """Tests for resolve_student() -- hosted model resolution + registry."""
 
     def test_resolve_student_no_id_returns_hosted_claude_opus(self, monkeypatch):
-        """resolve_student() with no args returns hosted claude-opus-4-6 with thinking none."""
+        """resolve_student() with no args returns hosted claude-opus-4-6 with thinking off."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
 
         # Patch anthropic.Anthropic so no real HTTP call is made.
         import unittest.mock as mock
 
         from tutormoments.config import _reset_config_cache
-        from tutormoments.models import ThinkingLevel
 
         _reset_config_cache()
         with mock.patch("anthropic.Anthropic"):
@@ -123,9 +122,9 @@ class TestResolveStudent:
 
         assert result["kind"] == "hosted"
         assert result["client"] is not None
-        # The default config states the student's condition as a ladder level.
-        assert result["kwargs"]["thinking"] == ThinkingLevel.NONE
-        assert result["kwargs"]["thinking"] == "none"
+        # The default config states the student's thinking-off condition
+        # explicitly ({type: disabled}) so it survives model swaps.
+        assert result["kwargs"]["thinking"] == {"thinking": {"type": "disabled"}}
 
     def test_resolve_student_registered(self, monkeypatch):
         """A @register_student-decorated callable is returned by resolve_student(name)."""
@@ -167,12 +166,12 @@ providers:
   openai:    { env: OPENAI_API_KEY }
   gemini:    { env: GEMINI_API_KEY }
   together:  { env: TOGETHER_API_KEY }
-models:
-  claude-opus-4-8: { thinking: xhigh }
-# A registered (scripted) student model skips wire validation but still
-# states a thinking level on the canonical ladder.
-student: { model: dummy-from-config, mode: oracle, thinking: none }
-scorer:  { model: claude-opus-4-6, thinking: dynamic }
+benchmark_models:
+  claude-opus-4-8: { thinking: { type: adaptive }, effort: xhigh, condition: xhigh }
+# A registered (scripted) student model is a code callable: no wire form,
+# no thinking keys.
+student: { model: dummy-from-config, mode: oracle }
+scorer:  { model: claude-opus-4-6, thinking: { type: adaptive } }
 defaults: { trials: 1, max_turns: 5 }
 retry:    { max_retries: 5, base_delay: 5 }
 batch:    { timeout: 86400 }

--- a/tests/tutormoments/test_student.py
+++ b/tests/tutormoments/test_student.py
@@ -106,12 +106,16 @@ class TestResolveStudent:
     """Tests for resolve_student() -- hosted model resolution + registry."""
 
     def test_resolve_student_no_id_returns_hosted_claude_opus(self, monkeypatch):
-        """resolve_student() with no args returns hosted claude-opus-4-6 with thinking=False."""
+        """resolve_student() with no args returns hosted claude-opus-4-6 with thinking none."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
 
         # Patch anthropic.Anthropic so no real HTTP call is made.
         import unittest.mock as mock
 
+        from tutormoments.config import _reset_config_cache
+        from tutormoments.models import ThinkingLevel
+
+        _reset_config_cache()
         with mock.patch("anthropic.Anthropic"):
             from tutormoments.student import resolve_student
 
@@ -119,7 +123,9 @@ class TestResolveStudent:
 
         assert result["kind"] == "hosted"
         assert result["client"] is not None
-        assert result["kwargs"].get("thinking") is False
+        # The default config states the student's condition as a ladder level.
+        assert result["kwargs"]["thinking"] == ThinkingLevel.NONE
+        assert result["kwargs"]["thinking"] == "none"
 
     def test_resolve_student_registered(self, monkeypatch):
         """A @register_student-decorated callable is returned by resolve_student(name)."""
@@ -162,9 +168,11 @@ providers:
   gemini:    { env: GEMINI_API_KEY }
   together:  { env: TOGETHER_API_KEY }
 models:
-  claude-opus-4-8: {}
-student: { model: dummy-from-config, mode: oracle, thinking: false }
-scorer:  { model: claude-opus-4-6, thinking: adaptive }
+  claude-opus-4-8: { thinking: xhigh }
+# A registered (scripted) student model skips wire validation but still
+# states a thinking level on the canonical ladder.
+student: { model: dummy-from-config, mode: oracle, thinking: none }
+scorer:  { model: claude-opus-4-6, thinking: dynamic }
 defaults: { trials: 1, max_turns: 5 }
 retry:    { max_retries: 5, base_delay: 5 }
 batch:    { timeout: 86400 }

--- a/tests/tutormoments/test_taxonomy.py
+++ b/tests/tutormoments/test_taxonomy.py
@@ -499,12 +499,13 @@ def test_classify_run_writes_classified_and_counts(tmp_path):
 
 def test_taxonomy_spec_reads_config():
     from tutormoments import config as cfgmod
+    from tutormoments.models import ThinkingLevel
 
     cfgmod._reset_config_cache()
     spec = cfgmod.taxonomy_spec()
-    assert spec["model"] == "claude-opus-4-8"
-    assert spec["thinking"] is False
-    assert spec["batch_size"] == 50
+    assert spec.model == "claude-opus-4-8"
+    assert spec.thinking == ThinkingLevel.NONE
+    assert spec.batch_size == 50
 
 
 def test_read_paper_distribution_selects_series(tmp_path):

--- a/tests/tutormoments/test_taxonomy.py
+++ b/tests/tutormoments/test_taxonomy.py
@@ -384,6 +384,34 @@ def test_classifier_resume_skips_completed_batches(tmp_path):
     assert second.calls == []
 
 
+def test_classifier_requires_taxonomy_config(tmp_path, monkeypatch):
+    """A config without a taxonomy block raises; the classifier must never
+    silently substitute its own LM settings (there is no module fallback)."""
+    from tutormoments import config as cfgmod
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+providers:
+  anthropic: { env: ANTHROPIC_API_KEY }
+benchmark_models:
+  claude-opus-4-8: { thinking: { type: adaptive }, effort: xhigh, condition: xhigh }
+defaults: { trials: 1, max_turns: 5 }
+retry:    { max_retries: 5, base_delay: 5 }
+batch:    { timeout: 86400 }
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TUTORMOMENTS_CONFIG", str(config_path))
+    cfgmod._reset_config_cache()
+    try:
+        facets = [_mk_facet("The tutor asks a guiding question.")]
+        with pytest.raises(ValueError, match="no taxonomy block"):
+            tx.classify_pool(facets, tmp_path / "out", client=_FakeClient())
+    finally:
+        cfgmod._reset_config_cache()
+
+
 # ---------------------------------------------------------------------------
 # 7. CLI extras guard
 # ---------------------------------------------------------------------------
@@ -499,12 +527,11 @@ def test_classify_run_writes_classified_and_counts(tmp_path):
 
 def test_taxonomy_spec_reads_config():
     from tutormoments import config as cfgmod
-    from tutormoments.models import ThinkingLevel
 
     cfgmod._reset_config_cache()
     spec = cfgmod.taxonomy_spec()
     assert spec.model == "claude-opus-4-8"
-    assert spec.thinking == ThinkingLevel.NONE
+    assert spec.thinking == {"thinking": {"type": "disabled"}}
     assert spec.batch_size == 50
 
 

--- a/tests/tutormoments/test_tutor.py
+++ b/tests/tutormoments/test_tutor.py
@@ -143,5 +143,5 @@ def test_resolve_tutor_unknown_raises():
     _reset_config_cache()
 
     # Attempt to resolve an unknown tutor
-    with pytest.raises(ValueError, match="Model 'not-a-model' not in roster"):
+    with pytest.raises(ValueError, match="Arm 'not-a-model' not in roster"):
         resolve_tutor("not-a-model")

--- a/tutormoments_build/groundtruth.py
+++ b/tutormoments_build/groundtruth.py
@@ -105,19 +105,9 @@ def compute_iou(range_a, range_b):
     return intersection / union if union > 0 else 0
 
 
-def _phase_cfg() -> dict:
-    """Ground-truth phase config (model/poll_interval/thinking/...)."""
+def _phase_cfg():
+    """Ground-truth phase spec (model/poll_interval/thinking/labeller)."""
     return get_groundtruth_phase_config()
-
-
-def _use_thinking(cfg: dict) -> bool:
-    """Normalize the config `thinking` value to the bool run_batch expects.
-
-    Mirrors tutormoments.scoring.score: a string like "adaptive"/"enabled" (or True)
-    enables thinking; anything else (e.g. "disabled", False) disables it. Passing
-    the raw config string straight through would make ANY non-empty string truthy.
-    """
-    return cfg.get("thinking", False) in ("adaptive", "enabled", True)
 
 
 def load_from_jsonl(path, annotation_types=("scaffolding", "rapport")):
@@ -440,7 +430,7 @@ def decompose_batch(items):
     from tutormoments.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
-    client = ModelClient(cfg["model"])
+    client = ModelClient(cfg.model)
 
     action_template = _load_decompose_prompt("decompose_action.md")
     result_template = _load_decompose_prompt("decompose_result.md")
@@ -484,17 +474,15 @@ def decompose_batch(items):
 
     print(
         f"  Submitting {len(entries)} decomposition requests to batch API "
-        f"(model={cfg['model']})..."
+        f"(model={cfg.model})..."
     )
     raw = run_batch(
         client,
         entries,
         json_mode=True,
         display_name="decomposition",
-        poll_interval=cfg.get("poll_interval", 60),
-        thinking=_use_thinking(cfg),
-        thinking_budget=cfg.get("thinking_budget", 0),
-        reasoning_effort=cfg.get("reasoning_effort", ""),
+        poll_interval=cfg.poll_interval,
+        thinking=cfg.thinking,
     )
 
     for key, result in raw.items():
@@ -526,7 +514,7 @@ def action_direction_classify_batch(items):
     from tutormoments.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
-    client = ModelClient(cfg["model"])
+    client = ModelClient(cfg.model)
     template = _load_structure_prompt("classify_action.md")
 
     entries = [
@@ -542,17 +530,15 @@ def action_direction_classify_batch(items):
 
     print(
         f"  Submitting {len(entries)} action direction classifications to batch API "
-        f"(model={cfg['model']})..."
+        f"(model={cfg.model})..."
     )
     results = run_batch(
         client,
         entries,
         json_mode=True,
         display_name="action_direction_agg_classification",
-        poll_interval=cfg.get("poll_interval", 60),
-        thinking=_use_thinking(cfg),
-        thinking_budget=cfg.get("thinking_budget", 0),
-        reasoning_effort=cfg.get("reasoning_effort", ""),
+        poll_interval=cfg.poll_interval,
+        thinking=cfg.thinking,
     )
 
     labels = {}
@@ -585,7 +571,7 @@ def student_outcome_classify_batch(items):
     from tutormoments.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
-    client = ModelClient(cfg["model"])
+    client = ModelClient(cfg.model)
     template = _load_structure_prompt("classify_student_result.md")
 
     entries = [
@@ -601,17 +587,15 @@ def student_outcome_classify_batch(items):
 
     print(
         f"  Submitting {len(entries)} student outcome classifications to batch API "
-        f"(model={cfg['model']})..."
+        f"(model={cfg.model})..."
     )
     results = run_batch(
         client,
         entries,
         json_mode=False,
         display_name="student_outcome_agg_classification",
-        poll_interval=cfg.get("poll_interval", 60),
-        thinking=_use_thinking(cfg),
-        thinking_budget=cfg.get("thinking_budget", 0),
-        reasoning_effort=cfg.get("reasoning_effort", ""),
+        poll_interval=cfg.poll_interval,
+        thinking=cfg.thinking,
     )
 
     labels = {}
@@ -640,7 +624,7 @@ def situation_classify_batch(items):
     from tutormoments.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
-    client = ModelClient(cfg["model"])
+    client = ModelClient(cfg.model)
     prompt_template = load_situation_prompt()
 
     entries = []
@@ -660,17 +644,15 @@ def situation_classify_batch(items):
 
     print(
         f"  Submitting {len(entries)} situation classifications to batch API "
-        f"(model={cfg['model']})..."
+        f"(model={cfg.model})..."
     )
     results = run_batch(
         client,
         entries,
         json_mode=True,
         display_name="situation_classification",
-        poll_interval=cfg.get("poll_interval", 60),
-        thinking=_use_thinking(cfg),
-        thinking_budget=cfg.get("thinking_budget", 0),
-        reasoning_effort=cfg.get("reasoning_effort", ""),
+        poll_interval=cfg.poll_interval,
+        thinking=cfg.thinking,
     )
 
     for key, result in results.items():
@@ -701,7 +683,7 @@ def classify_batch(items, labeller="hybrid"):
     from tutormoments.client import ModelClient, build_batch_entry, run_batch
 
     cfg = _phase_cfg()
-    client = ModelClient(cfg["model"])
+    client = ModelClient(cfg.model)
 
     if labeller == "hybrid":
         templates = load_labeller_templates(get_labeller_config())
@@ -737,17 +719,15 @@ def classify_batch(items, labeller="hybrid"):
 
     print(
         f"  Submitting {len(entries)} classifications to Anthropic batch API "
-        f"(model={cfg['model']})..."
+        f"(model={cfg.model})..."
     )
     results = run_batch(
         client,
         entries,
         json_mode=False,
         display_name="effectiveness_classification_refresh",
-        poll_interval=cfg.get("poll_interval", 60),
-        thinking=_use_thinking(cfg),
-        thinking_budget=cfg.get("thinking_budget", 0),
-        reasoning_effort=cfg.get("reasoning_effort", ""),
+        poll_interval=cfg.poll_interval,
+        thinking=cfg.thinking,
     )
 
     for key, result in results.items():

--- a/tutormoments_build/moments_build.py
+++ b/tutormoments_build/moments_build.py
@@ -811,10 +811,11 @@ def _cli_build(args: argparse.Namespace) -> None:
     spec = student_spec()
     n_generated = generate_traits_for_moments(
         moments,
-        model_client=ModelClient(spec["model"]),
-        model_name=spec["model"],
+        model_client=ModelClient(spec.model),
+        model_name=spec.model,
+        thinking=spec.thinking,
     )
-    print(f"Generated {n_generated} student traits with {spec['model']}")
+    print(f"Generated {n_generated} student traits with {spec.model}")
 
     manifest = write_release(
         moments,

--- a/tutormoments_build/traits.py
+++ b/tutormoments_build/traits.py
@@ -126,8 +126,9 @@ class _ModelWrapperAdapter:
     This adapter translates that into client.generate(user_text, ..., cacheable_prefix=...).
     """
 
-    def __init__(self, client) -> None:
+    def __init__(self, client, thinking=None) -> None:
         self._client = client
+        self._thinking = thinking
 
     def call(
         self,
@@ -150,6 +151,7 @@ class _ModelWrapperAdapter:
             user_text,
             json_mode=False,
             max_tokens=max_tokens or 1024,
+            thinking=self._thinking,
             cacheable_prefix=system_prompt or None,
         )
         return resp.text or ""
@@ -330,11 +332,17 @@ def generate_trait(
     mode: str = DEFAULT_TRAIT_MODE,
     *,
     model_client,
+    thinking=None,
     temperature: float = 0.7,
     max_tokens: Optional[int] = None,
 ) -> str:
-    """Generate a student trait description from a transcript prefix."""
-    adapter = _ModelWrapperAdapter(model_client)
+    """Generate a student trait description from a transcript prefix.
+
+    thinking: canonical ladder level for the generator model (from the
+    student spec), forwarded to every generate call so trait generation runs
+    under the same stated condition as the student it feeds.
+    """
+    adapter = _ModelWrapperAdapter(model_client, thinking=thinking)
     generator = TraitGenerator(adapter)
     return generator.generate_trait(
         conversation_text=transcript_prefix,
@@ -360,6 +368,7 @@ def generate_traits_for_moments(
     *,
     model_client,
     model_name: str,
+    thinking=None,
     trait_mode: str = DEFAULT_TRAIT_MODE,
 ) -> int:
     """Attach a student.trait to every moment that lacks one.
@@ -375,7 +384,9 @@ def generate_traits_for_moments(
         if (moment.student.get("trait") or {}).get("persona"):
             continue
         prefix = _format_transcript_prefix(moment.context)
-        persona = generate_trait(prefix, trait_mode, model_client=model_client)
+        persona = generate_trait(
+            prefix, trait_mode, model_client=model_client, thinking=thinking
+        )
         moment.student["trait"] = {
             "persona": persona.strip(),
             "trait_mode": trait_mode,


### PR DESCRIPTION
## What

Fixes the root causes behind the PR #48 review findings: the `thinking` config key was re-interpreted by 7 different ad-hoc rules across callers, the raw provider knobs (`thinking_budget`/`reasoning_effort`/`effort`) leaked into config unvalidated, model facts were scattered across six prefix tables, and the fully-mocked suite could never prove a provider accepts our wire formats.

Supersedes #48 (its fixes are absorbed here: Gemini batch thinking_config injection + thought-part filtering + fail-fast validation). An earlier iteration of this branch introduced a canonical thinking ladder; it was collapsed before merge in favor of fully explicit provider-native config — see the design-pivot comment below for the narrative.

### 1. Explicit provider-native model configs
- The tutor roster is `benchmark_models:` — each key is an **arm** (a benchmark condition): `model` names the provider model id, provider-native keys state the exact request parameters (`thinking`/`effort`, `thinking_budget`/`thinking_level`/`include_thoughts`, `reasoning`), and a required `condition:` label groups results (written to `config.json`, `summary.json`, latency probes, and the leaderboard, which gains a condition column + filter). The same model can run under several arms.
- The student/scorer/taxonomy/groundtruth role blocks state their thinking parameters the same way. Reviewers never decode a hidden mapping to know what was run.
- Normalization happens once, inside `load_config`, into frozen specs — every block validates fail-closed at load, before any tokens are spent (`tutormoments.models.resolve_thinking`: key ownership per provider, Gemini budget/level exclusivity, Anthropic thinking-block structure). Value vocabularies (effort tiers, reasoning levels) are the provider's to extend and are proven live via smoke, not enumerated offline.
- **Wire-byte preservation**: `test_default_config_wire.py` pins that the shipped config produces exactly the fragments the pre-migration code sent. Three deliberate wire changes, all bug fixes or hardening: Gemini batch gains the thinking_config sync already sent; Gemini batch text extraction skips thought parts; and the thinking-off roles (student, taxonomy) send an explicit `thinking: {type: disabled}` instead of omitting the param (omission means off on Anthropic 4.x but adaptive on Sonnet 5+ — the explicit block keeps the condition stable under model swaps and smoke-assertable).

### 2. Model registry = per-model facts only (`models.yaml` + `models.py`)
One place for stable model facts: provider routing, pricing (cost-tracking workstream), and output caps. No reasoning configuration lives there. Model ids match exact-first then longest-prefix, case-insensitively. A brand-new model needs one facts entry before it can run priced — deliberate: the never-implicit-LM-config invariant, enforced by code.

### 3. `tutormoments smoke` — the live verification layer
One tiny real call per configured arm/role with its exact condition (cents) + submit-then-cancel batch per provider + a **thinking-evidence column** that catches silent no-op knobs in both directions (expectation derived from the wire fragment: enabled/budget must show reasoning tokens, disabled/budget-0 must not, adaptive warns). CI gains an always-green advisory reminder on PRs touching core API paths (no secrets in CI, ever).

It caught a real bug on its first run: OpenAI `reasoning_tokens` were never captured, so `reasoning_effort` could have been a silent no-op unnoticed.

### 4. Fail-fast cleanups from a caller audit
`taxonomy.classify_pool` no longer swallows config errors and silently substitutes module-default LM settings (the fallback constants are deleted); `run_sync_entries` resolves thinking before its loop, matching `run_batch`, instead of demoting a malformed mapping to N identical per-entry errors.

### Live verification (all providers, real APIs)

```
smoke: 14 passed, 0 warnings, 1 failed
```

Every Anthropic/Gemini/OpenAI arm and role PASSed under its exact configured knobs with matching thinking evidence (opus-4-6 accepts explicit `disabled`: evidence 0 on both off-roles; gemini-2.5-pro: 721 thought tokens; gpt-5.5: 46 reasoning tokens), all three batch submissions accepted + cancelled. The one FAIL is the `deepseek-v4-pro` arm: Together no longer serves the model serverless — pre-existing account/provisioning issue, no wire knobs involved (roster decision: #53; the retry-on-400 behavior it surfaced: #52).

### Notes for review
- `config_hash` changes for new runs (the config schema changed); metrics comparability is untouched, and for the shipped config arm names == model ids so run ids / summary keys are byte-identical. `summary.json` keeps `tutor_model` = arm name (all joins unchanged) and gains `model` and `condition`.
- Full suite: 706 passed / 13 skipped, offline as always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)