### PR TITLE
Propagate the canonical usage vector through aggregation to run summaries

### DIFF
--- a/src/tutormoments/cli.py
+++ b/src/tutormoments/cli.py
@@ -178,6 +178,7 @@ from tutormoments.moments import (
     load_manifest,
     load_moments,
 )
+from tutormoments.usage import add_usage, sum_usage
 
 
 def _dataset_label(cfg) -> str:
@@ -817,35 +818,32 @@ def run_cell(
         student_lat_samples: list = []
         tutor_timings: list = []
         student_timings: list = []
-        tutor_input = tutor_output = 0
-        student_input = student_output = 0
+        tutor_tokens = sum_usage()
+        student_tokens = sum_usage()
         for tx in all_trial_transcripts:
             tutor_lat_samples.extend(getattr(tx, "tutor_latencies", []) or [])
             student_lat_samples.extend(getattr(tx, "student_latencies", []) or [])
             tutor_timings.extend(getattr(tx, "tutor_timings", []) or [])
             student_timings.extend(getattr(tx, "student_timings", []) or [])
-            tu = getattr(tx, "tutor_usage", {}) or {}
-            su = getattr(tx, "student_usage", {}) or {}
-            tutor_input += tu.get("input_tokens", 0) or 0
-            tutor_output += tu.get("output_tokens", 0) or 0
-            student_input += su.get("input_tokens", 0) or 0
-            student_output += su.get("output_tokens", 0) or 0
+            add_usage(tutor_tokens, getattr(tx, "tutor_usage", {}) or {})
+            add_usage(student_tokens, getattr(tx, "student_usage", {}) or {})
 
-        tutor_tokens = {
-            "input_tokens": tutor_input,
-            "output_tokens": tutor_output,
-            "total_tokens": tutor_input + tutor_output,
-        }
-        student_tokens = {
-            "input_tokens": student_input,
-            "output_tokens": student_output,
-            "total_tokens": student_input + student_output,
-        }
-        total_tokens = {
-            "input_tokens": tutor_input + student_input,
-            "output_tokens": tutor_output + student_output,
-            "total_tokens": tutor_input + tutor_output + student_input + student_output,
-        }
+        # Scorer usage: the three pooled scoring passes per moment, accumulated
+        # onto each Annotation by score_batch. Endpoint provenance ("batch")
+        # rides along -- that is what the batch discount applies to in costing.
+        scorer_tokens = sum_usage()
+        for ann in all_trial_annotations:
+            ann_usage = (
+                ann.get("usage")
+                if isinstance(ann, dict)
+                else getattr(ann, "usage", None)
+            )
+            add_usage(scorer_tokens, ann_usage or {})
+
+        # Role sums keep every usage key: legacy provider counters (summed
+        # as-is, never recomputed -- the canonical `total` is the single
+        # consistent definition) plus the canonical cost vector + provenance.
+        total_tokens = sum_usage(tutor_tokens, student_tokens, scorer_tokens)
         # `tutor`/`student` keep their historical shape and meaning
         # (end-to-end wall-clock seconds per call) so report.py, the paper's
         # figure pipeline and the website refresh script keep working
@@ -863,6 +861,7 @@ def run_cell(
         token_block = {
             "tutor": tutor_tokens,
             "student": student_tokens,
+            "scorer": scorer_tokens,
             "total": total_tokens,
         }
 
@@ -908,9 +907,7 @@ def run_cell(
         tax_usage = (tax or {}).get("usage") or {}
         if tax_usage:
             metrics["tokens"]["taxonomy"] = tax_usage
-            total = metrics["tokens"]["total"]
-            for k in ("input_tokens", "output_tokens", "total_tokens"):
-                total[k] = total.get(k, 0) + int(tax_usage.get(k, 0) or 0)
+            add_usage(metrics["tokens"]["total"], tax_usage)
 
         results.write_summary(run_id, metrics, results_root=results_root)
         run_counts = metrics["run_counts"]

--- a/src/tutormoments/cli.py
+++ b/src/tutormoments/cli.py
@@ -602,18 +602,31 @@ def run_cell(
 
                         try:
                             ann = Annotation(**score_dict)
+                            # Reload the transcript alongside the score:
+                            # summary.json describes the whole run (run_counts
+                            # and the aggregate metrics already count resumed
+                            # moments), so the token/latency blocks must carry
+                            # their tutor/student usage too -- not just this
+                            # invocation's API spend. is_done guaranteed the
+                            # transcript file exists.
+                            transcript_dict = results.read_transcript(
+                                run_id, resume_sid, results_root=results_root
+                            )
                             completed_scenarios.append(scenario)
                             completed_annotations.append(ann)
+                            if transcript_dict is not None:
+                                completed_transcripts.append(
+                                    conversation.Transcript.from_dict(transcript_dict)
+                                )
                             counts["succeeded"] += 1
                             counts["resumed"] += 1
-                            # No transcript object on resume -- latencies not available
                         except Exception as e:
                             counts["failed"] += 1
                             failed_scenarios.append(
                                 {"id": sid, "error": str(e), "phase": "resume"}
                             )
                             logger.warning(
-                                "[trial %d][%d/%d] Could not reload score for %s: %s",
+                                "[trial %d][%d/%d] Could not reload score/transcript for %s: %s",
                                 trial_idx,
                                 i,
                                 n_total,

--- a/src/tutormoments/conversation.py
+++ b/src/tutormoments/conversation.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from tutormoments.moments import Moment
 from tutormoments.student import build_student_system_prompt, resolve_student
 from tutormoments.tutor import build_tutor_system_prompt, resolve_tutor
+from tutormoments.usage import EMPTY_USAGE, add_usage
 
 logger = logging.getLogger(__name__)
 
@@ -34,20 +35,8 @@ class Transcript:
     scenario_id: str
     tutor_model: str
     generated_turns: list[dict] = field(default_factory=list)
-    tutor_usage: dict = field(
-        default_factory=lambda: {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "total_tokens": 0,
-        }
-    )
-    student_usage: dict = field(
-        default_factory=lambda: {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "total_tokens": 0,
-        }
-    )
+    tutor_usage: dict = field(default_factory=lambda: dict(EMPTY_USAGE))
+    student_usage: dict = field(default_factory=lambda: dict(EMPTY_USAGE))
     # Per-call end-to-end wall-clock seconds. Meaning is unchanged by the
     # streaming work, so the paper's Figure 7 pipeline and the website
     # refresh script -- which read these directly -- stay comparable.
@@ -110,12 +99,6 @@ def _split_messages(text: str) -> list[str]:
     parts = normalized.split(NEXT_DELIMITER)
     messages = [p.strip() for p in parts]
     return [m for m in messages if m]
-
-
-def _add_usage(total: dict, new: dict) -> None:
-    """Accumulate token usage."""
-    for key in ("input_tokens", "output_tokens", "total_tokens"):
-        total[key] = total.get(key, 0) + new.get(key, 0)
 
 
 def _record_timing(timings: list[dict], response, turn_index: int) -> None:
@@ -368,7 +351,7 @@ def run_conversation(
                 text=raw_text, usage={}, latency_seconds=None, timing=None
             )
 
-        _add_usage(transcript.tutor_usage, response.usage)
+        add_usage(transcript.tutor_usage, response.usage)
         if response.latency_seconds is not None:
             transcript.tutor_latencies.append(response.latency_seconds)
         _record_timing(
@@ -425,7 +408,7 @@ def run_conversation(
                 text=raw_text, usage={}, latency_seconds=None, timing=None
             )
 
-        _add_usage(transcript.student_usage, response.usage)
+        add_usage(transcript.student_usage, response.usage)
         if response.latency_seconds is not None:
             transcript.student_latencies.append(response.latency_seconds)
         _record_timing(

--- a/src/tutormoments/scoring.py
+++ b/src/tutormoments/scoring.py
@@ -19,6 +19,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from tutormoments.resources import resource_text
+from tutormoments.usage import EMPTY_USAGE, add_usage, sum_usage
 
 logger = logging.getLogger(__name__)
 
@@ -261,10 +262,7 @@ def _parse_and_merge(
 
     for conv_id, conv_data in detections_by_conv.items():
         detections = conv_data.get("detections", [])
-        p1_usage = conv_data.get(
-            "usage", {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
-        )
-        total_usage = dict(p1_usage)
+        total_usage = sum_usage(conv_data.get("usage", {}))
 
         annotations = []
         for idx, det in enumerate(detections):
@@ -284,11 +282,7 @@ def _parse_and_merge(
                     }
                 )
 
-                p2_usage = a.get("_usage", {})
-                for field in ("input_tokens", "output_tokens", "total_tokens"):
-                    total_usage[field] = total_usage.get(field, 0) + p2_usage.get(
-                        field, 0
-                    )
+                add_usage(total_usage, a.get("_usage", {}))
             else:
                 annotations.append(
                     {
@@ -340,13 +334,7 @@ class Annotation:
     action_decomposed: list  # action decomposition phrases
     overscaffold_decomposed: list  # over-scaffolding decomposition phrases
     action_label: str  # "scaffolding" | "rigor" | "both" | "neither" | "unclear"
-    usage: dict = field(
-        default_factory=lambda: {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "total_tokens": 0,
-        }
-    )
+    usage: dict = field(default_factory=lambda: dict(EMPTY_USAGE))
 
     def to_dict(self) -> dict[str, Any]:
         """Return all fields as a plain dict."""
@@ -747,17 +735,6 @@ def _parse_result_label(text: str) -> tuple:
     return "unclear", True
 
 
-def _sum_usage(*usages: dict) -> dict:
-    """Sum input/output/total tokens across N usage dicts."""
-    out = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
-    for u in usages:
-        if not isinstance(u, dict):
-            continue
-        for k in out:
-            out[k] += int(u.get(k, 0) or 0)
-    return out
-
-
 def _build_structure_entries(
     results: dict,
     target: str = "scaffolding",
@@ -852,8 +829,6 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
 
     client = ModelClient(scorer_model)
 
-    _ZERO = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
-
     # -------------------------------------------------------------------------
     # Build synthetic conversations + detections, merged across all pairs
     # -------------------------------------------------------------------------
@@ -876,7 +851,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
                 action_decomposed=[],
                 overscaffold_decomposed=[],
                 action_label=DEFAULT_ACTION_LABEL,
-                usage=dict(_ZERO),
+                usage=dict(EMPTY_USAGE),
             )
             continue
         conversations.update(conv_dict)
@@ -885,7 +860,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
     if not detections:
         return annotations_out
 
-    usage_by_sid = {sid: dict(_ZERO) for sid in detections}
+    usage_by_sid = {sid: dict(EMPTY_USAGE) for sid in detections}
 
     # -------------------------------------------------------------------------
     # Pass 1: Annotate (one pooled batch)
@@ -908,9 +883,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
 
     for sid, conv_data in parsed.items():
         if sid in usage_by_sid:
-            usage_by_sid[sid] = _sum_usage(
-                usage_by_sid[sid], conv_data.get("usage", {})
-            )
+            usage_by_sid[sid] = sum_usage(usage_by_sid[sid], conv_data.get("usage", {}))
 
     # Build the results shape expected by _build_decompose_entries /
     # _build_structure_entries: {sid: {"annotations": [ann_dict, ...]}}
@@ -965,7 +938,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
             key = entry["key"]
             raw = decompose_raw.get(key, {})
             if conv_id in usage_by_sid:
-                usage_by_sid[conv_id] = _sum_usage(
+                usage_by_sid[conv_id] = sum_usage(
                     usage_by_sid[conv_id], raw.get("usage", {})
                 )
             text = raw.get("text", "")
@@ -1035,7 +1008,7 @@ def score_batch(pairs: "list[tuple[Any, Any]]") -> "dict[str, Annotation]":
             except ValueError:
                 continue
             if conv_id in usage_by_sid:
-                usage_by_sid[conv_id] = _sum_usage(
+                usage_by_sid[conv_id] = sum_usage(
                     usage_by_sid[conv_id], raw.get("usage", {})
                 )
             label, _ = parse_fn(raw.get("text", ""))

--- a/src/tutormoments/taxonomy.py
+++ b/src/tutormoments/taxonomy.py
@@ -48,6 +48,7 @@ from string import Template
 from typing import Any, Iterable, Iterator, Optional
 
 from tutormoments.resources import resource_text
+from tutormoments.usage import EMPTY_USAGE, add_usage
 
 logger = logging.getLogger(__name__)
 
@@ -1010,14 +1011,10 @@ def _make_classifier(client: Any, *, thinking=None):
             idx = a["id"] - 1
             if 0 <= idx < len(items):
                 out[items[idx]] = a["category"]
-        in_t = resp.usage.get("input_tokens", 0)
-        out_t = resp.usage.get("output_tokens", 0)
-        usage = {
-            "label": label,
-            "input_tokens": in_t,
-            "output_tokens": out_t,
-            "total_tokens": in_t + out_t,
-        }
+        # Log the full usage dict (legacy counters + canonical cost vector +
+        # provenance) so the sidecar carries everything costing needs; the
+        # per-batch label rides along as call-level detail.
+        usage = {"label": label, **resp.usage}
         return out, usage
 
     return ask
@@ -1564,7 +1561,9 @@ def classify_run(
         orientation[ORIENTATION_BY_LETTER.get(letter, "neutral")] += n
 
     # Sum per-batch usage from the sidecar for the run's token bookkeeping.
-    usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    # add_usage sums every integer key (canonical vector included) and keeps
+    # provenance; the per-batch "label" string is dropped by design.
+    usage = dict(EMPTY_USAGE)
     usage_path = out_dir / "usage_log.jsonl"
     if usage_path.exists():
         for line in usage_path.read_text(encoding="utf-8").splitlines():
@@ -1572,8 +1571,7 @@ def classify_run(
                 rec = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            for k in usage:
-                usage[k] += int(rec.get(k, 0) or 0)
+            add_usage(usage, rec)
 
     return {
         "scheme_version": SCHEME_VERSION,

--- a/src/tutormoments/usage.py
+++ b/src/tutormoments/usage.py
@@ -1,0 +1,88 @@
+"""Canonical usage-vector accumulation.
+
+Every LLM call is normalized at the client boundary
+(``client.normalize_usage``) into the canonical cost vector —
+``input_uncached / cache_read / cache_write / output / reasoning / total`` —
+plus provenance strings (``provider``, ``model``, ``endpoint``) and the
+legacy per-provider counters (``input_tokens`` / ``output_tokens`` /
+``total_tokens``). This module is where those vectors are summed without
+being destroyed: accumulators sum *every* integer-valued key rather than an
+allowlist, so a new field captured at the boundary survives to transcripts
+and run summaries without touching aggregation code again.
+
+Deliberately lightweight (stdlib only): conversation.py, scoring.py,
+taxonomy.py and cli.py aggregate usage without importing the
+provider-SDK-heavy client module.
+"""
+
+__all__ = ["EMPTY_USAGE", "add_usage", "sum_usage"]
+
+# Zero legacy counters plus the canonical cost vector. Accumulators start
+# from a copy so aggregated usage has a stable schema even when every
+# contribution is empty (e.g. registered/callable tutors, error rows).
+EMPTY_USAGE = {
+    "input_tokens": 0,
+    "output_tokens": 0,
+    "total_tokens": 0,
+    "input_uncached": 0,
+    "cache_read": 0,
+    "cache_write": 0,
+    "output": 0,
+    "reasoning": 0,
+    "total": 0,
+}
+
+# Provenance strings carried inside usage dicts (normalize_usage). These are
+# the only non-numeric keys an accumulator preserves; anything else
+# non-numeric (e.g. the taxonomy usage log's per-batch "label") is
+# call-level detail that has no aggregate meaning and is dropped.
+_PROVENANCE_KEYS = ("provider", "model", "endpoint")
+
+
+def _merge_provenance(prior: str, value: str) -> str:
+    """Combine two provenance values into a deterministic union.
+
+    Uniform values stay as-is; a genuine mix becomes a sorted "+"-join
+    (e.g. "stream+sync"), which keeps the one fact costing needs — whether
+    "batch" contributed — recoverable from an aggregate.
+    """
+    parts = set(prior.split("+")) | set(value.split("+"))
+    return "+".join(sorted(parts))
+
+
+def add_usage(total: dict, new: dict) -> dict:
+    """Accumulate one usage dict into ``total`` in place; returns ``total``.
+
+    Sums every integer-valued key (bools excluded) so the canonical vector,
+    the legacy counters, and any provider extras all survive. Provenance
+    strings are kept when uniform and "+"-merged when mixed.
+    """
+    for key, value in new.items():
+        if isinstance(value, bool) or not isinstance(value, int):
+            continue
+        base = total.get(key, 0)
+        if isinstance(base, bool) or not isinstance(base, int):
+            continue
+        total[key] = base + value
+    for key in _PROVENANCE_KEYS:
+        value = new.get(key)
+        if not isinstance(value, str) or not value:
+            continue
+        prior = total.get(key)
+        if isinstance(prior, str) and prior:
+            total[key] = _merge_provenance(prior, value)
+        else:
+            total[key] = value
+    return total
+
+
+def sum_usage(*usages: dict) -> dict:
+    """Sum N usage dicts into a fresh dict seeded with ``EMPTY_USAGE``.
+
+    Non-dict entries (None, error placeholders) are skipped.
+    """
+    total = dict(EMPTY_USAGE)
+    for usage in usages:
+        if isinstance(usage, dict):
+            add_usage(total, usage)
+    return total

--- a/tests/tutormoments/test_cli.py
+++ b/tests/tutormoments/test_cli.py
@@ -332,13 +332,29 @@ def test_run_cell_writes_latency_and_tokens(tmp_path):
 
     scenarios = list(FIXTURE_SCENARIOS)
 
-    # Two transcripts with known latencies and token counts
+    # Two transcripts with known latencies and token counts. The first tutor
+    # usage carries the full canonical vector + provenance (what Phase 1
+    # capture produces); the second is legacy-only, as an old resumed
+    # transcript would be.
     transcripts = [
         _make_transcript(
             "scenario_001",
             tutor_latencies=[1.0, 3.0],
             student_latencies=[0.5],
-            tutor_usage={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+            tutor_usage={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+                "input_uncached": 20,
+                "cache_read": 80,
+                "cache_write": 0,
+                "output": 50,
+                "reasoning": 0,
+                "total": 150,
+                "provider": "anthropic",
+                "model": "claude-opus-4-8",
+                "endpoint": "sync",
+            },
             student_usage={
                 "input_tokens": 80,
                 "output_tokens": 20,
@@ -399,15 +415,39 @@ def test_run_cell_writes_latency_and_tokens(tmp_path):
         f"p95 expected 3.0, got {lat['p95_seconds']}"
     )
 
-    # tokens.total block must be present
+    # tokens block must carry per-role components (tutor/student/scorer/total)
     assert "tokens" in summary, "summary must have 'tokens' key"
-    assert "total" in summary["tokens"], "summary['tokens'] must have 'total' key"
-    tok = summary["tokens"]["total"]
-    assert "total_tokens" in tok, "tokens.total must have total_tokens"
-    # tutor: 150+300=450, student: 100+200=300, total: 750
-    assert tok["total_tokens"] == 750, (
-        f"total_tokens expected 750, got {tok['total_tokens']}"
+    tokens = summary["tokens"]
+    for role in ("tutor", "student", "scorer", "total"):
+        assert role in tokens, f"summary['tokens'] must have '{role}' key"
+    # tutor: 150+300=450, student: 100+200=300 -- legacy totals summed as-is,
+    # never recomputed from input+output.
+    assert tokens["tutor"]["total_tokens"] == 450
+    assert tokens["student"]["total_tokens"] == 300
+    # scorer: the two mocked annotations carry 15 total_tokens each, and the
+    # run total includes them (they were omitted before the cost-tracking fix).
+    assert tokens["scorer"]["total_tokens"] == 30
+    tok = tokens["total"]
+    assert tok["total_tokens"] == 780, (
+        f"total_tokens expected 780 (450+300+30), got {tok['total_tokens']}"
     )
+    # The canonical cost vector's keys survive aggregation to disk.
+    for key in (
+        "input_uncached",
+        "cache_read",
+        "cache_write",
+        "output",
+        "reasoning",
+        "total",
+    ):
+        assert key in tok, f"tokens.total must carry canonical key '{key}'"
+    # ... with the captured values intact (scenario_001's tutor vector), and
+    # provenance preserved when uniform.
+    tutor_tok = tokens["tutor"]
+    assert tutor_tok["cache_read"] == 80
+    assert tutor_tok["input_uncached"] == 20
+    assert tutor_tok["provider"] == "anthropic"
+    assert tutor_tok["endpoint"] == "sync"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tutormoments/test_cli.py
+++ b/tests/tutormoments/test_cli.py
@@ -72,11 +72,6 @@ def _make_transcript(
     t.scenario_id = sid
     t.tutor_model = "claude-opus-4-8"
     t.generated_turns = [{"turn_number": 2, "role": "TUTOR", "text": "Hi"}]
-    t.to_dict.return_value = {
-        "scenario_id": sid,
-        "completed": True,
-        "generated_turns": [],
-    }
     t.tutor_latencies = tutor_latencies if tutor_latencies is not None else []
     t.student_latencies = student_latencies if student_latencies is not None else []
     t.tutor_usage = (
@@ -89,6 +84,18 @@ def _make_transcript(
         if student_usage is not None
         else {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
     )
+    # Mirror the real Transcript.to_dict shape so tests exercising the resume
+    # path get usage/latency data back from disk, like a real resumed run.
+    t.to_dict.return_value = {
+        "scenario_id": sid,
+        "tutor_model": t.tutor_model,
+        "completed": True,
+        "generated_turns": [],
+        "tutor_usage": t.tutor_usage,
+        "student_usage": t.student_usage,
+        "tutor_latencies": t.tutor_latencies,
+        "student_latencies": t.student_latencies,
+    }
     return t
 
 
@@ -457,11 +464,25 @@ def test_run_cell_writes_latency_and_tokens(tmp_path):
 
 def test_run_cell_resumes(tmp_path):
     """Second run_cell call finds both scenarios already done; 0 new conversation
-    calls are made (is_done returns True for both)."""
+    calls are made (is_done returns True for both), and the rewritten
+    summary.json still carries the full run's token usage (tutor/student
+    reloaded from the on-disk transcripts, scorer from the on-disk scores) --
+    not just the zero API spend of the resumed invocation."""
     from tutormoments.cli import run_cell
 
     scenarios = list(FIXTURE_SCENARIOS)
-    transcripts = [_make_transcript(s.id) for s in scenarios]
+    transcripts = [
+        _make_transcript(
+            s.id,
+            tutor_usage={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+            student_usage={
+                "input_tokens": 60,
+                "output_tokens": 40,
+                "total_tokens": 100,
+            },
+        )
+        for s in scenarios
+    ]
     annotations = [_make_annotation(s.id) for s in scenarios]
 
     cfg_mock = _make_run_config(sample=2)
@@ -505,6 +526,17 @@ def test_run_cell_resumes(tmp_path):
     # summary.json still written on resume
     run_dir = tmp_path / run_id
     assert (run_dir / "summary.json").exists()
+
+    # ... and its token block still covers the resumed moments: tutor/student
+    # usage reloaded from the transcripts on disk, scorer usage from the
+    # reloaded annotations (2 moments x 15 total_tokens each).
+    summary = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+    tokens = summary["tokens"]
+    assert tokens["tutor"]["total_tokens"] == 300
+    assert tokens["student"]["total_tokens"] == 200
+    assert tokens["scorer"]["total_tokens"] == 30
+    assert tokens["total"]["total_tokens"] == 530
+    assert summary["run_counts"]["resumed"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tutormoments/test_conversation.py
+++ b/tests/tutormoments/test_conversation.py
@@ -127,13 +127,16 @@ def test_imports():
 def test_transcript_defaults():
     """Transcript has sensible defaults."""
     from tutormoments.conversation import Transcript
+    from tutormoments.usage import EMPTY_USAGE
 
     t = Transcript(scenario_id="abc", tutor_model="m")
     assert t.scenario_id == "abc"
     assert t.tutor_model == "m"
     assert t.generated_turns == []
-    assert t.tutor_usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
-    assert t.student_usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    # Zero legacy counters plus the canonical cost vector, all zero.
+    assert t.tutor_usage == EMPTY_USAGE
+    assert t.student_usage == EMPTY_USAGE
+    assert t.tutor_usage is not t.student_usage
     assert t.tutor_latencies == []
     assert t.student_latencies == []
     assert t.completed is False
@@ -235,19 +238,19 @@ def test_split_messages_whitespace_only():
 
 
 def test_add_usage():
-    from tutormoments.conversation import _add_usage
+    from tutormoments.usage import add_usage
 
     total = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
-    _add_usage(total, {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5})
+    add_usage(total, {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5})
     assert total == {"input_tokens": 13, "output_tokens": 7, "total_tokens": 20}
 
 
 def test_add_usage_missing_keys():
     """Missing keys in new dict are treated as 0."""
-    from tutormoments.conversation import _add_usage
+    from tutormoments.usage import add_usage
 
     total = {"input_tokens": 10, "output_tokens": 0, "total_tokens": 10}
-    _add_usage(total, {})
+    add_usage(total, {})
     assert total["input_tokens"] == 10
 
 

--- a/tests/tutormoments/test_scoring.py
+++ b/tests/tutormoments/test_scoring.py
@@ -1316,6 +1316,8 @@ def test_score_accumulates_usage_across_passes(fixture_scenario, fixture_transcr
     annotate_key = f"{sid}__scaffolding__0"
 
     def make_resp(keys_vals, tokens_per_key):
+        # Legacy counters + canonical cost vector + provenance, as the
+        # post-capture batch paths emit them.
         return {
             k: {
                 "text": v if isinstance(v, str) else _json.dumps(v),
@@ -1323,6 +1325,15 @@ def test_score_accumulates_usage_across_passes(fixture_scenario, fixture_transcr
                     "input_tokens": tokens_per_key,
                     "output_tokens": tokens_per_key,
                     "total_tokens": tokens_per_key * 2,
+                    "input_uncached": tokens_per_key,
+                    "cache_read": 0,
+                    "cache_write": 0,
+                    "output": tokens_per_key,
+                    "reasoning": 0,
+                    "total": tokens_per_key * 2,
+                    "provider": "anthropic",
+                    "model": "claude-opus-4-6",
+                    "endpoint": "batch",
                 },
             }
             for k, v in keys_vals.items()
@@ -1364,6 +1375,12 @@ def test_score_accumulates_usage_across_passes(fixture_scenario, fixture_transcr
     usage = result.usage
     assert isinstance(usage, dict), "usage must be a dict"
     assert usage.get("total_tokens", 0) > 0, "total_tokens must be > 0"
+    # The canonical vector survives the 3-pass accumulation onto the
+    # Annotation, provenance included (scorer usage is always batch).
+    assert usage["total"] == usage["total_tokens"]
+    assert usage["input_uncached"] == usage["input_tokens"]
+    assert usage["endpoint"] == "batch"
+    assert usage["provider"] == "anthropic"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tutormoments/test_usage.py
+++ b/tests/tutormoments/test_usage.py
@@ -1,0 +1,103 @@
+"""Tests for tutormoments.usage: canonical usage-vector accumulation.
+
+Phase 2 of the cost-tracking plan: aggregation must stop destroying the
+canonical vector captured at the client boundary. These tests pin the
+accumulator's contract -- every integer key survives, provenance strings are
+kept when uniform and "+"-merged when mixed, and non-usage strings are
+dropped.
+"""
+
+from tutormoments.usage import EMPTY_USAGE, add_usage, sum_usage
+
+
+def _vector(**overrides) -> dict:
+    """A realistic post-Phase-1 usage dict (legacy + canonical + provenance)."""
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 40,
+        "total_tokens": 140,
+        "input_uncached": 20,
+        "cache_read": 80,
+        "cache_write": 0,
+        "output": 40,
+        "reasoning": 0,
+        "total": 140,
+        "provider": "anthropic",
+        "model": "claude-sonnet-5",
+        "endpoint": "sync",
+    }
+    usage.update(overrides)
+    return usage
+
+
+def test_add_usage_sums_every_integer_key():
+    """No allowlist: canonical keys and provider extras all accumulate."""
+    total = dict(EMPTY_USAGE)
+    add_usage(total, _vector())
+    add_usage(total, _vector(cache_write=50, cache_read_input_tokens=7924))
+
+    assert total["input_uncached"] == 40
+    assert total["cache_read"] == 160
+    assert total["cache_write"] == 50
+    assert total["output"] == 80
+    assert total["total"] == 280
+    assert total["input_tokens"] == 200
+    # A provider extra absent from EMPTY_USAGE still survives.
+    assert total["cache_read_input_tokens"] == 7924
+
+
+def test_add_usage_keeps_uniform_provenance():
+    total = dict(EMPTY_USAGE)
+    add_usage(total, _vector())
+    add_usage(total, _vector())
+    assert total["provider"] == "anthropic"
+    assert total["model"] == "claude-sonnet-5"
+    assert total["endpoint"] == "sync"
+
+
+def test_add_usage_merges_mixed_provenance_deterministically():
+    """Mixed provenance becomes a sorted "+"-join, so whether "batch"
+    contributed stays recoverable from an aggregate."""
+    total = dict(EMPTY_USAGE)
+    add_usage(total, _vector(endpoint="sync"))
+    add_usage(total, _vector(endpoint="stream"))
+    add_usage(total, _vector(endpoint="sync"))
+    assert total["endpoint"] == "stream+sync"
+
+    # Merging an already-merged aggregate keeps the union stable.
+    combined = sum_usage(total, _vector(endpoint="batch"))
+    assert combined["endpoint"] == "batch+stream+sync"
+
+
+def test_add_usage_ignores_bools_and_foreign_strings():
+    """Bools are not counters; non-provenance strings (e.g. the taxonomy
+    usage log's per-batch "label") have no aggregate meaning."""
+    total = dict(EMPTY_USAGE)
+    add_usage(total, {**_vector(), "label": "batch_003", "truncated": True})
+    assert "label" not in total
+    assert "truncated" not in total
+
+
+def test_add_usage_never_clobbers_non_numeric_totals():
+    """A numeric value under a provenance key in `new` must not overwrite
+    an accumulated string (and vice versa)."""
+    total = {"model": "claude-sonnet-5"}
+    add_usage(total, {"model": 3})
+    assert total["model"] == "claude-sonnet-5"
+
+
+def test_sum_usage_seeds_stable_schema_and_skips_non_dicts():
+    total = sum_usage(None, {}, _vector())
+    for key in EMPTY_USAGE:
+        assert key in total
+    assert total["total"] == 140
+    # Empty sum still has the full zero schema.
+    assert sum_usage() == EMPTY_USAGE
+
+
+def test_sum_usage_returns_fresh_dict():
+    a = _vector()
+    total = sum_usage(a)
+    total["output"] += 1
+    assert a["output"] == 40
+    assert EMPTY_USAGE["output"] == 0


### PR DESCRIPTION
## What

Phases 2+3 of the cost-tracking work (capture landed in #49, dead-path removal in #40). The client boundary already normalizes every LLM call into the canonical cost vector (`input_uncached` / `cache_read` / `cache_write` / `output` / `reasoning` / `total`, plus `provider` / `model` / `endpoint` provenance); this PR stops aggregation from destroying it and fixes what the run summary counts.

## How

**New `src/tutormoments/usage.py`** — stdlib-only, so conversation/scoring/taxonomy/cli keep aggregating without importing the provider-SDK-heavy client module:

- `add_usage` sums **every integer-valued key** (bools excluded) instead of a three-key allowlist, so a field captured at the boundary survives to transcripts and summaries without touching aggregation code again.
- Provenance strings are kept when uniform and `"+"`-merged when mixed (`"stream+sync"`), so whether `"batch"` contributed — the one fact the batch discount needs — stays recoverable from any aggregate. Other strings (e.g. the taxonomy log's per-batch `label`) are call-level detail and are dropped.
- `sum_usage` seeds a stable zero schema (legacy counters + canonical vector).

**Allowlists removed** in `conversation._add_usage`, `scoring._sum_usage`, `_parse_and_merge`'s inner p2-usage merge (a third allowlist not called out in the plan), and the taxonomy sidecar summing. The taxonomy `usage_log.jsonl` now records the full per-call usage dict.

**Run summary changes** (`cli.py`):

- Scorer usage — the three pooled scoring passes per moment, previously written per-scenario but **omitted from run totals** — now lands in `tokens.scorer` and is included in `tokens.total`.
- The `tokens` block carries per-role components (`tutor` / `student` / `scorer` / `taxonomy` / `total`), each the full vector with its endpoint provenance.
- Legacy `total_tokens` is summed as the providers reported it rather than recomputed as `input + output`, removing the two-conflicting-definitions discrepancy for models that bill thinking tokens (Gemini). The canonical `total` is the single consistent definition across providers.

## Compatibility

- Readers treat missing keys as 0, so old transcripts and summaries still load; old runs remain un-back-costable because the cache split was never recorded for them.
- `report.py`, the paper figure pipeline, and the website refresh script read `tokens.total.total_tokens` and the latency blocks, all of which keep their shape. Note the summary's `total_tokens` value now genuinely includes scorer usage and provider-reported totals — that is the fix, not a regression.

## Scope

Deferred, per the plan's sequencing: the pricing table and cost computation (Phases 4–5, rates to be confirmed before coding), summary/report `cost` blocks and `docs/cost.md` (Phase 6), and reconciliation follow-ups (Phase 7).

## Testing

- New `tests/tutormoments/test_usage.py` pins the accumulator contract (generic summing, provenance merge, bool/foreign-string exclusion, fresh-dict semantics).
- Existing tests extended to verify the vector survives to disk: `Transcript.tutor_usage` and the per-role summary blocks via the `run_cell` test, `Annotation.usage` (with `endpoint="batch"` provenance) via the 3-pass score test.
- Full suite passes (713 passed, 13 skipped); ruff clean. No smoke-gated wire-format files (`client.py`, `models.py`, `models.yaml`, `config.py`, `default_config.yaml`, `smoke.py`) are touched, so no live smoke is required for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)